### PR TITLE
lock icon (#386)

### DIFF
--- a/src/zabapgit_page.prog.abap
+++ b/src/zabapgit_page.prog.abap
@@ -98,6 +98,10 @@ CLASS lcl_gui_page_super IMPLEMENTATION.
 
     ro_html->add( '<td class="repo_attr right">' ).
 
+    IF io_repo->is_write_protected( ) = abap_true.
+      ro_html->add( '<img src="img/lock">' ).
+    ENDIF.
+
     IF io_repo->is_offline( ) = abap_false.
       lo_repo_online ?= io_repo.
       IF iv_show_branch = abap_true.

--- a/src/zabapgit_page_main.prog.abap
+++ b/src/zabapgit_page_main.prog.abap
@@ -845,6 +845,15 @@ CLASS lcl_gui_page_main IMPLEMENTATION.
       && '1gQQfzKDhgCSPFw9Kg2yZ9WqAgBWJBENLk6V3AAAAABJRU5ErkJggg=='.
     APPEND ls_image TO rt_assets.
 
+    ls_image-url     = 'img/lock' ##NO_TEXT.
+    ls_image-content =
+         'iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAOVBMVEUAAACIiIiIiIiI'
+      && 'iIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIjNaTNB'
+      && 'AAAAEnRSTlMABgdBVXt8iYuRsNXZ3uDi6Pmu6tfUAAAASUlEQVQYV63KSxJAQBAE0TQ0'
+      && 'Znym1f0PayE0QdjJ5asCgGTu1hClqjppvaRXB60swBeA2QNUAIq+ICvKx367nqAn/P8Y'
+      && 't2jg3Q5rgASaF3KNRwAAAABJRU5ErkJggg=='.
+    APPEND ls_image TO rt_assets.
+
   ENDMETHOD.  "get_assets
 
 ENDCLASS.


### PR DESCRIPTION
to #386 

P.S. I guess you can try to squash this one if needed. There are 3 technical merges. Somehow repos ahead/behind marker went out of sync again, don't know why. But if I merge from upstream it syncs again. So there is a workaround for me. 