### PR TITLE
Fix missing software component for subpackages

### DIFF
--- a/src/zabapgit_sap_package.prog.abap
+++ b/src/zabapgit_sap_package.prog.abap
@@ -215,9 +215,10 @@ CLASS lcl_sap_package IMPLEMENTATION.
     ENDIF.
 
     ls_child-devclass  = iv_child.
+    ls_child-dlvunit   = li_parent->software_component.
     ls_child-ctext     = iv_child.
     ls_child-parentcl  = iv_parent.
-    ls_child-component = li_parent->transport_layer.
+    ls_child-pdevclass = li_parent->transport_layer.
     ls_child-as4user   = sy-uname.
 
     create( ls_child ).
@@ -246,6 +247,12 @@ CLASS lcl_sap_package IMPLEMENTATION.
     ENDIF.
 
     ls_package = is_package.
+
+    " Set software component to 'HOME' if none is set at this point.
+    " Otherwise SOFTWARE_COMPONENT_INVALID will be raised.
+    IF ls_package-dlvunit IS INITIAL.
+      ls_package-dlvunit = 'HOME'.
+    ENDIF.
 
     cl_package_factory=>create_new_package(
       EXPORTING
@@ -348,7 +355,7 @@ CLASS lcl_sap_package IMPLEMENTATION.
     ls_package-devclass  = iv_package.
     ls_package-ctext     = iv_package.
     ls_package-parentcl  = '$TMP'.
-    ls_package-component = 'LOCAL'.
+    ls_package-dlvunit   = 'LOCAL'.
     ls_package-as4user   = sy-uname.
 
     create( ls_package ).


### PR DESCRIPTION
I had a problem when migrating a package hierarchy from one SAP system to another using abapGit with exporting/importing from zip archives. I got the message "Package ... could not be created" from `LCL_SAP_PACKAGE=>CREATE` because `CL_PACKAGE_FACTORY=>CREATE_NEW_PACKAGE` threw `SOFTWARE_COMPONENT_INVALID`. Looking into it with the debugger I noticed that the field `dlvunit` was not filled, so I filled it and it worked.

I assume there has been some accidental swapping of Application Component and Software Component. This commit addresses these.

### Steps to reproduce
1. Create a package with several subpackages, in each of them there is at least one object.
2. Use abapGit to create a new repository for the parent package.
3. Export to zip.
4. Delete the packages or move to another system.
5. Create a new repository and import from zip.


Lines 251 to 256 can be removed again, if you prefer not having a fallback value.
