### PR TITLE
UI diff page unified mode

### DIFF
--- a/src/zabapgit_css_common.w3mi.data.css
+++ b/src/zabapgit_css_common.w3mi.data.css
@@ -37,7 +37,7 @@ form input:focus, textarea:focus {
 .grey             { color: lightgrey  !important; }
 .darkgrey         { color: #808080    !important; }
 .attention        { color: red        !important; }
-.blue             { color: #5e8dc9;   !important; }
+.blue             { color: #5e8dc9    !important; }
 .red              { color: red        !important; }
 
 /* MODIFIERS */
@@ -415,8 +415,8 @@ span.diff_banner {
   padding-right: 0.3em;
 }
 .diff_ins {
-  border-color: #7bea7b;
-  background-color: #d3f8d3;
+  border-color: #abf2ab;
+  background-color: #e0ffe0;
 }
 .diff_del {
   border-color: #ff667d;
@@ -500,21 +500,37 @@ table.diff_tab thead.nav_line th {
   color: #bbb;
 }
 table.diff_tab td.num, th.num {
-  text-align: right;
+  width: 1%;
+  min-width: 2em;
+  padding-right: 8px;
+  padding-left:  8px;
+  text-align: right !important;
   color: #ccc;
   border-left: 1px solid #eee;
   border-right: 1px solid #eee;
+  -ms-user-select: none;
+  user-select: none;
+}
+table.diff_tab td.num::before {
+  content: attr(line-num);
 }
 table.diff_tab code {
   font-family: inherit;
   white-space: pre;
 }
+table.diff_tab td.code {
+  /* font-family: inherit; */
+  /* white-space: pre; */
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  overflow: visible;
+}
 
 table.diff_tab code span.keyword { color: #0a69ce; }
 table.diff_tab code span.text    { color: #48ce4f; }
 table.diff_tab code span.comment { color: #808080; font-style: italic; }
-table.diff_tab code span.xml_tag { color: #3370e0; }
-table.diff_tab code span.attr    { color: #f20707; }
+table.diff_tab code span.xml_tag { color: #457ce3; }
+table.diff_tab code span.attr    { color: #b777fb; }
 table.diff_tab code span.attr_val { color: #7a02f9; }
 
 table.diff_tab tbody tr:first-child td { padding-top: 0.5em; }

--- a/src/zabapgit_page_diff.prog.abap
+++ b/src/zabapgit_page_diff.prog.abap
@@ -7,32 +7,40 @@ CLASS lcl_gui_page_diff DEFINITION FINAL INHERITING FROM lcl_gui_page.
   PUBLIC SECTION.
 
     CONSTANTS:
-      BEGIN OF c_mod,
+      BEGIN OF c_fstate,
         local  TYPE char1 VALUE 'L',
         remote TYPE char1 VALUE 'R',
         both   TYPE char1 VALUE 'B',
-      END OF c_mod.
+      END OF c_fstate.
 
     TYPES: BEGIN OF ty_file_diff,
              filename TYPE string,
              lstate   TYPE char1,
              rstate   TYPE char1,
-             mod      TYPE char1, " Abstraction for shorter ifs
+             fstate   TYPE char1, " FILE state - Abstraction for shorter ifs
              o_diff   TYPE REF TO lcl_diff,
            END OF ty_file_diff,
            tt_file_diff TYPE STANDARD TABLE OF ty_file_diff.
 
-    METHODS: constructor
-      IMPORTING iv_key    TYPE lcl_persistence_repo=>ty_repo-key
-                is_file   TYPE ty_file OPTIONAL
-                is_object TYPE ty_item OPTIONAL
-      RAISING   lcx_exception.
+    METHODS:
+      constructor
+        IMPORTING iv_key    TYPE lcl_persistence_repo=>ty_repo-key
+                  is_file   TYPE ty_file OPTIONAL
+                  is_object TYPE ty_item OPTIONAL
+        RAISING   lcx_exception,
+      lif_gui_page~on_event REDEFINITION.
 
   PROTECTED SECTION.
     METHODS render_content REDEFINITION.
 
   PRIVATE SECTION.
-    DATA: mt_diff_files TYPE tt_file_diff.
+    CONSTANTS: BEGIN OF c_actions,
+                 toggle_unified TYPE string VALUE 'toggle_unified',
+               END OF c_actions.
+
+    DATA: mt_diff_files    TYPE tt_file_diff,
+          mt_delayed_lines TYPE lcl_diff=>ty_diffs_tt,
+          mv_unified       TYPE abap_bool VALUE abap_true.
 
     METHODS render_diff
       IMPORTING is_diff        TYPE ty_file_diff
@@ -49,16 +57,20 @@ CLASS lcl_gui_page_diff DEFINITION FINAL INHERITING FROM lcl_gui_page.
       IMPORTING is_diff_line   TYPE lcl_diff=>ty_diff
                 is_diff        TYPE ty_file_diff
       RETURNING VALUE(ro_html) TYPE REF TO lcl_html.
-    METHODS get_line_hl
-      IMPORTING iv_mod    TYPE char1
-                iv_result TYPE lcl_diff=>ty_diff-result
-      EXPORTING ev_lattr  TYPE string
-                ev_rattr  TYPE string.
+    METHODS render_line_split
+      IMPORTING is_diff_line   TYPE lcl_diff=>ty_diff
+                iv_fstate      TYPE char1
+      RETURNING VALUE(ro_html) TYPE REF TO lcl_html.
+    METHODS render_line_unified
+      IMPORTING is_diff_line   TYPE lcl_diff=>ty_diff OPTIONAL
+      RETURNING VALUE(ro_html) TYPE REF TO lcl_html.
     METHODS append_diff
       IMPORTING it_remote TYPE ty_files_tt
                 it_local  TYPE ty_files_item_tt
                 is_status TYPE ty_result
       RAISING   lcx_exception.
+    METHODS build_menu
+      RETURNING VALUE(ro_menu) TYPE REF TO lcl_html_toolbar.
 
 ENDCLASS. "lcl_gui_page_diff
 
@@ -75,6 +87,8 @@ CLASS lcl_gui_page_diff IMPLEMENTATION.
 
     super->constructor( ).
     ms_control-page_title = 'DIFF'.
+    ms_control-page_menu  = build_menu( ).
+    mv_unified            = lcl_app=>user( )->get_diff_unified( ).
 
     ASSERT is_file IS INITIAL OR is_object IS INITIAL. " just one passed
 
@@ -154,14 +168,14 @@ CLASS lcl_gui_page_diff IMPLEMENTATION.
     <ls_diff>-rstate   = is_status-rstate.
 
     IF <ls_diff>-lstate IS NOT INITIAL AND <ls_diff>-rstate IS NOT INITIAL.
-      <ls_diff>-mod = c_mod-both.
+      <ls_diff>-fstate = c_fstate-both.
     ELSEIF <ls_diff>-lstate IS NOT INITIAL.
-      <ls_diff>-mod = c_mod-local.
+      <ls_diff>-fstate = c_fstate-local.
     ELSE. "rstate IS NOT INITIAL, lstate = empty.
-      <ls_diff>-mod = c_mod-remote.
+      <ls_diff>-fstate = c_fstate-remote.
     ENDIF.
 
-    IF <ls_diff>-mod = c_mod-remote. " Remote file leading changes
+    IF <ls_diff>-fstate = c_fstate-remote. " Remote file leading changes
       CREATE OBJECT <ls_diff>-o_diff
         EXPORTING
           iv_new = <ls_remote>-data
@@ -175,45 +189,46 @@ CLASS lcl_gui_page_diff IMPLEMENTATION.
 
   ENDMETHOD.  "append_diff
 
-  METHOD render_diff_head.
-    DATA: lo_html  TYPE REF TO lcl_html,
-          ls_stats TYPE lcl_diff=>ty_count.
+  METHOD build_menu.
+    CREATE OBJECT ro_menu.
+    ro_menu->add( iv_txt = 'Split/Unified view'
+                  iv_act = c_actions-toggle_unified ) ##NO_TEXT.
+  ENDMETHOD.  " build_menu.
 
-    CREATE OBJECT lo_html.
+**********************************************************************
+* EVENT HANDLING
+**********************************************************************
 
-    ls_stats = is_diff-o_diff->stats( ).
+  METHOD lif_gui_page~on_event.
 
-    IF is_diff-mod = c_mod-both. " Merge stats into 'update' if both were changed
-      ls_stats-update = ls_stats-update + ls_stats-insert + ls_stats-delete.
-      CLEAR: ls_stats-insert, ls_stats-delete.
-    ENDIF.
+    CASE iv_action.
+      WHEN c_actions-toggle_unified. " Toggle file diplay
+        mv_unified = lcl_app=>user( )->toggle_diff_unified( ).
+        ev_state   = gc_event_state-re_render.
+    ENDCASE.
 
-    lo_html->add( '<div class="diff_head">' ).              "#EC NOTEXT
-    lo_html->add( |<span class="diff_banner diff_ins">+ { ls_stats-insert }</span>| ).
-    lo_html->add( |<span class="diff_banner diff_del">- { ls_stats-delete }</span>| ).
-    lo_html->add( |<span class="diff_banner diff_upd">~ { ls_stats-update }</span>| ).
-    lo_html->add( |<span class="diff_name">{ is_diff-filename }</span>| ). "#EC NOTEXT
-    lo_html->add( lcl_gui_chunk_lib=>render_item_state( iv1 = is_diff-lstate
-                                                        iv2 = is_diff-rstate ) ).
-    lo_html->add( '</div>' ).                               "#EC NOTEXT
+  ENDMETHOD. "lif_gui_page~on_event
 
-    ro_html = lo_html.
-  ENDMETHOD.
+**********************************************************************
+* RENDER LOGIC
+**********************************************************************
 
-  METHOD render_table_head.
+  METHOD render_content.
+
+    DATA ls_diff_file LIKE LINE OF mt_diff_files.
 
     CREATE OBJECT ro_html.
 
-    ro_html->add( '<thead class="header">' ).               "#EC NOTEXT
-    ro_html->add( '<tr>' ).                                 "#EC NOTEXT
-    ro_html->add( '<th class="num"></th>' ).                "#EC NOTEXT
-    ro_html->add( '<th>LOCAL</th>' ).                       "#EC NOTEXT
-    ro_html->add( '<th class="num"></th>' ).                "#EC NOTEXT
-    ro_html->add( '<th>REMOTE</th>' ).                      "#EC NOTEXT
-    ro_html->add( '</tr>' ).                                "#EC NOTEXT
-    ro_html->add( '</thead>' ).                             "#EC NOTEXT
+    LOOP AT mt_diff_files INTO ls_diff_file.
+      lcl_progress=>show( iv_key     = 'Diff'
+                          iv_current = sy-tabix
+                          iv_total   = lines( mt_diff_files )
+                          iv_text    = |Render Diff - { ls_diff_file-filename }| ).
 
-  ENDMETHOD.  " render_table_head.
+      ro_html->add( render_diff( ls_diff_file ) ).
+    ENDLOOP.
+
+  ENDMETHOD.  "render_content
 
   METHOD render_diff.
 
@@ -232,11 +247,70 @@ CLASS lcl_gui_page_diff IMPLEMENTATION.
 
     ro_html->add( '</div>' ).                               "#EC NOTEXT
 
+  ENDMETHOD.  " render_diff
+
+**********************************************************************
+* CHUNKS
+**********************************************************************
+
+  METHOD render_diff_head.
+
+    DATA: ls_stats TYPE lcl_diff=>ty_count.
+
+    CREATE OBJECT ro_html.
+    ls_stats = is_diff-o_diff->stats( ).
+
+    IF is_diff-fstate = c_fstate-both. " Merge stats into 'update' if both were changed
+      ls_stats-update = ls_stats-update + ls_stats-insert + ls_stats-delete.
+      CLEAR: ls_stats-insert, ls_stats-delete.
+    ENDIF.
+
+    ro_html->add( '<div class="diff_head">' ).              "#EC NOTEXT
+
+    ro_html->add( |<span class="diff_banner diff_ins">+ { ls_stats-insert }</span>| ).
+    ro_html->add( |<span class="diff_banner diff_del">- { ls_stats-delete }</span>| ).
+    ro_html->add( |<span class="diff_banner diff_upd">~ { ls_stats-update }</span>| ).
+    ro_html->add( |<span class="diff_name">{ is_diff-filename }</span>| ). "#EC NOTEXT
+    ro_html->add( lcl_gui_chunk_lib=>render_item_state( iv1 = is_diff-lstate
+                                                        iv2 = is_diff-rstate ) ).
+
+    IF is_diff-fstate = c_fstate-both AND mv_unified = abap_true.
+      ro_html->add( '<span class="attention pad-sides">Attention: Unified mode'
+                 && ' highlighting for MM assumes local file is newer ! </span>' ). "#EC NOTEXT
+    ENDIF.
+
+    ro_html->add( '</div>' ).                               "#EC NOTEXT
+
   ENDMETHOD.
+
+  METHOD render_table_head.
+
+    CREATE OBJECT ro_html.
+
+    IF mv_unified = abap_true.
+      ro_html->add( '<thead class="header">' ).               "#EC NOTEXT
+      ro_html->add( '<tr>' ).                                 "#EC NOTEXT
+      ro_html->add( '<th class="num">old</th>' ).             "#EC NOTEXT
+      ro_html->add( '<th class="num">new</th>' ).             "#EC NOTEXT
+      ro_html->add( '<th>code</th>' ).                        "#EC NOTEXT
+      ro_html->add( '</tr>' ).                                "#EC NOTEXT
+      ro_html->add( '</thead>' ).                             "#EC NOTEXT
+    ELSE.
+      ro_html->add( '<thead class="header">' ).               "#EC NOTEXT
+      ro_html->add( '<tr>' ).                                 "#EC NOTEXT
+      ro_html->add( '<th class="num"></th>' ).                "#EC NOTEXT
+      ro_html->add( '<th>LOCAL</th>' ).                       "#EC NOTEXT
+      ro_html->add( '<th class="num"></th>' ).                "#EC NOTEXT
+      ro_html->add( '<th>REMOTE</th>' ).                      "#EC NOTEXT
+      ro_html->add( '</tr>' ).                                "#EC NOTEXT
+      ro_html->add( '</thead>' ).                             "#EC NOTEXT
+    ENDIF.
+
+  ENDMETHOD.  " render_table_head.
 
   METHOD render_beacon.
 
-    DATA: lv_beacon TYPE string.
+    DATA: lv_beacon  TYPE string.
 
     CREATE OBJECT ro_html.
 
@@ -246,10 +320,19 @@ CLASS lcl_gui_page_diff IMPLEMENTATION.
       lv_beacon = '---'.
     ENDIF.
 
+
     ro_html->add( '<thead class="nav_line">' ).
     ro_html->add( '<tr>' ).
-    ro_html->add( '<th class="num"></th>' ).
-    ro_html->add( |<th colspan="3">@@ { is_diff_line-new_line } @@ { lv_beacon }</th>| ).
+
+    IF mv_unified = abap_true.
+      ro_html->add( '<th class="num"></th>' ).
+      ro_html->add( '<th class="num"></th>' ).
+      ro_html->add( |<th>@@ { is_diff_line-new_num } @@ { lv_beacon }</th>| ).
+    ELSE.
+      ro_html->add( '<th class="num"></th>' ).
+      ro_html->add( |<th colspan="3">@@ { is_diff_line-new_num } @@ { lv_beacon }</th>| ).
+    ENDIF.
+
     ro_html->add( '</tr>' ).
     ro_html->add( '</thead>' ).
 
@@ -259,10 +342,6 @@ CLASS lcl_gui_page_diff IMPLEMENTATION.
 
     DATA: lo_highlighter TYPE REF TO lcl_syntax_highlighter,
           lt_diffs       TYPE lcl_diff=>ty_diffs_tt,
-          lv_local       TYPE string,
-          lv_remote      TYPE string,
-          lv_lattr       TYPE string,
-          lv_rattr       TYPE string,
           lv_insert_nav  TYPE abap_bool.
 
     FIELD-SYMBOLS <ls_diff>  LIKE LINE OF lt_diffs.
@@ -283,83 +362,125 @@ CLASS lcl_gui_page_diff IMPLEMENTATION.
         lv_insert_nav = abap_false.
       ENDIF.
 
-      IF is_diff-mod = c_mod-remote. " Remote file leading changes
-        lv_local  = <ls_diff>-old.
-        lv_remote = <ls_diff>-new.
-      ELSE.             " Local leading changes or both were modified
-        lv_local  = <ls_diff>-new.
-        lv_remote = <ls_diff>-old.
-      ENDIF.
-
       IF lo_highlighter IS BOUND.
-        lv_local  = lo_highlighter->process_line( lv_local ).
-        lv_remote = lo_highlighter->process_line( lv_remote ).
+        <ls_diff>-new = lo_highlighter->process_line( <ls_diff>-new ).
+        <ls_diff>-old = lo_highlighter->process_line( <ls_diff>-old ).
       ELSE.
-        lv_local  = escape( val = lv_local format = cl_abap_format=>e_html_attr ).
-        lv_remote = escape( val = lv_remote format = cl_abap_format=>e_html_attr ).
+        <ls_diff>-new = escape( val = <ls_diff>-new format = cl_abap_format=>e_html_attr ).
+        <ls_diff>-old = escape( val = <ls_diff>-old format = cl_abap_format=>e_html_attr ).
       ENDIF.
 
-      get_line_hl( EXPORTING iv_mod    = is_diff-mod
-                             iv_result = <ls_diff>-result
-                   IMPORTING ev_lattr  = lv_lattr
-                             ev_rattr  = lv_rattr ).
+      CONDENSE <ls_diff>-new_num. "get rid of leading spaces
+      CONDENSE <ls_diff>-old_num.
 
-      ro_html->add( '<tr>' ).                               "#EC NOTEXT
-      ro_html->add( |<td class="num">{ <ls_diff>-new_line }</td>| ). "#EC NOTEXT
-      ro_html->add( |<td{ lv_lattr }><code>{ lv_local }</code></td>| ). "#EC NOTEXT
-      ro_html->add( |<td class="num">{ <ls_diff>-old_line }</td>| ). "#EC NOTEXT
-      ro_html->add( |<td{ lv_rattr }><code>{ lv_remote }</code></td>| ). "#EC NOTEXT
-      ro_html->add( '</tr>' ).                              "#EC NOTEXT
+      IF mv_unified = abap_true.
+        ro_html->add( render_line_unified( is_diff_line = <ls_diff> ) ).
+      ELSE.
+        ro_html->add( render_line_split( is_diff_line = <ls_diff>
+                                         iv_fstate    = is_diff-fstate ) ).
+      ENDIF.
 
     ENDLOOP.
 
-  ENDMETHOD.
-
-  METHOD get_line_hl.
-
-    CLEAR: ev_lattr, ev_rattr. " Class for changed lines
-
-    IF iv_result IS INITIAL.
-      RETURN.
+    IF mv_unified = abap_true.
+      ro_html->add( render_line_unified( ) ). " Release delayed lines
     ENDIF.
 
-    " Both file changed ? Or line updated ? - All yellow
-    IF iv_mod = c_mod-both OR iv_result = lcl_diff=>c_diff-update.
-      ev_lattr = ' class="diff_upd"'.                       "#EC NOTEXT
-      ev_rattr = ' class="diff_upd"'.                       "#EC NOTEXT
-    ELSEIF iv_mod = c_mod-local. " Changed locally
-      CASE iv_result.
-        WHEN lcl_diff=>c_diff-insert.
-          ev_lattr = ' class="diff_ins"'.                   "#EC NOTEXT
-        WHEN lcl_diff=>c_diff-delete.
-          ev_rattr = ' class="diff_del"'.                   "#EC NOTEXT
-      ENDCASE.
-    ELSEIF iv_mod = c_mod-remote. " Changed remotely - invert sides
-      CASE iv_result.
-        WHEN lcl_diff=>c_diff-insert.
-          ev_rattr = ' class="diff_ins"'.                   "#EC NOTEXT
-        WHEN lcl_diff=>c_diff-delete.
-          ev_lattr = ' class="diff_del"'.                   "#EC NOTEXT
-      ENDCASE.
-    ENDIF.
+  ENDMETHOD.  "render_lines
 
-  ENDMETHOD.  " get_line_hl.
+  METHOD render_line_split.
 
-  METHOD render_content.
-
-    DATA ls_diff_file LIKE LINE OF mt_diff_files.
+    DATA: lv_new  TYPE string,
+          lv_old  TYPE string,
+          lv_mark TYPE string,
+          lv_bg   TYPE string.
 
     CREATE OBJECT ro_html.
 
-    LOOP AT mt_diff_files INTO ls_diff_file.
-      lcl_progress=>show( iv_key     = 'Diff'
-                          iv_current = sy-tabix
-                          iv_total   = lines( mt_diff_files )
-                          iv_text    = |Render Diff - { ls_diff_file-filename }| ).
+    " New line
+    lv_mark = ` `.
+    IF iv_fstate = c_fstate-both OR is_diff_line-result = lcl_diff=>c_diff-update.
+      lv_bg = ' diff_upd'.
+      lv_mark = `~`.
+    ELSEIF is_diff_line-result = lcl_diff=>c_diff-insert.
+      lv_bg = ' diff_ins'.
+      lv_mark = `+`.
+    ENDIF.
+    lv_new = |<td class="num" line-num="{ is_diff_line-new_num }"></td>|
+          && |<td class="code{ lv_bg }">{ lv_mark }{ is_diff_line-new }</td>|.
 
-      ro_html->add( render_diff( ls_diff_file ) ).
-    ENDLOOP.
+    " Old line
+    CLEAR lv_bg.
+    lv_mark = ` `.
+    IF iv_fstate = c_fstate-both OR is_diff_line-result = lcl_diff=>c_diff-update.
+      lv_bg = ' diff_upd'.
+      lv_mark = `~`.
+    ELSEIF is_diff_line-result = lcl_diff=>c_diff-delete.
+      lv_bg = ' diff_del'.
+      lv_mark = `-`.
+    ENDIF.
+    lv_old = |<td class="num" line-num="{ is_diff_line-old_num }"></td>|
+          && |<td class="code{ lv_bg }">{ lv_mark }{ is_diff_line-old }</td>|.
 
-  ENDMETHOD.  "render_content
+    " render line, inverse sides if remote is newer
+    ro_html->add( '<tr>' ).                               "#EC NOTEXT
+    IF iv_fstate = c_fstate-remote. " Remote file leading changes
+      ro_html->add( lv_old ). " local
+      ro_html->add( lv_new ). " remote
+    ELSE.             " Local leading changes or both were modified
+      ro_html->add( lv_new ). " local
+      ro_html->add( lv_old ). " remote
+    ENDIF.
+    ro_html->add( '</tr>' ).                              "#EC NOTEXT
+
+  ENDMETHOD. "render_line_split
+
+  METHOD render_line_unified.
+
+    DATA lv_line TYPE string.
+
+    FIELD-SYMBOLS <diff_line> LIKE LINE OF mt_delayed_lines.
+
+    CREATE OBJECT ro_html.
+
+    " Release delayed subsequent update lines
+    IF is_diff_line-result <> lcl_diff=>c_diff-update.
+      LOOP AT mt_delayed_lines ASSIGNING <diff_line>.
+        ro_html->add( '<tr>' ).                               "#EC NOTEXT
+        ro_html->add( |<td class="num" line-num="{ <diff_line>-old_num }"></td>|
+                   && |<td class="num" line-num=""></td>|
+                   && |<td class="code diff_del">-{ <diff_line>-old }</td>| ).
+        ro_html->add( '</tr>' ).                              "#EC NOTEXT
+      ENDLOOP.
+      LOOP AT mt_delayed_lines ASSIGNING <diff_line>.
+        ro_html->add( '<tr>' ).                               "#EC NOTEXT
+        ro_html->add( |<td class="num" line-num=""></td>|
+                   && |<td class="num" line-num="{ <diff_line>-new_num }"></td>|
+                   && |<td class="code diff_ins">+{ <diff_line>-new }</td>| ).
+        ro_html->add( '</tr>' ).                              "#EC NOTEXT
+      ENDLOOP.
+      CLEAR mt_delayed_lines.
+    ENDIF.
+
+    ro_html->add( '<tr>' ).                               "#EC NOTEXT
+    CASE is_diff_line-result.
+      WHEN lcl_diff=>c_diff-update.
+        APPEND is_diff_line TO mt_delayed_lines. " Delay output of subsequent updates
+      WHEN lcl_diff=>c_diff-insert.
+        ro_html->add( |<td class="num" line-num=""></td>|
+                   && |<td class="num" line-num="{ is_diff_line-new_num }"></td>|
+                   && |<td class="code diff_ins">+{ is_diff_line-new }</td>| ).
+      WHEN lcl_diff=>c_diff-delete.
+        ro_html->add( |<td class="num" line-num="{ is_diff_line-old_num }"></td>|
+                   && |<td class="num" line-num=""></td>|
+                   && |<td class="code diff_del">-{ is_diff_line-old }</td>| ).
+      WHEN OTHERS. "none
+        ro_html->add( |<td class="num" line-num="{ is_diff_line-old_num }"></td>|
+                   && |<td class="num" line-num="{ is_diff_line-new_num }"></td>|
+                   && |<td class="code"> { is_diff_line-old }</td>| ).
+    ENDCASE.
+    ro_html->add( '</tr>' ).                              "#EC NOTEXT
+
+  ENDMETHOD. "render_line_unified
 
 ENDCLASS. "lcl_gui_page_diff

--- a/src/zabapgit_persistence.prog.abap
+++ b/src/zabapgit_persistence.prog.abap
@@ -422,6 +422,14 @@ CLASS lcl_persistence_user DEFINITION FINAL CREATE PRIVATE FRIENDS lcl_app.
       RETURNING VALUE(rv_changes_only) TYPE abap_bool
       RAISING   lcx_exception.
 
+    METHODS toggle_diff_unified
+      RETURNING VALUE(rv_diff_unified) TYPE abap_bool
+      RAISING   lcx_exception.
+
+    METHODS get_diff_unified
+      RETURNING VALUE(rv_diff_unified) TYPE abap_bool
+      RAISING   lcx_exception.
+
     METHODS get_favorites
       RETURNING VALUE(rt_favorites) TYPE tt_favorites
       RAISING   lcx_exception.
@@ -454,6 +462,7 @@ CLASS lcl_persistence_user DEFINITION FINAL CREATE PRIVATE FRIENDS lcl_app.
              repo_config  TYPE ty_repo_config_tt,
              hide_files   TYPE abap_bool,
              changes_only TYPE abap_bool,
+             diff_unified TYPE abap_bool,
              favorites    TYPE tt_favorites,
            END OF ty_user.
 
@@ -697,6 +706,24 @@ CLASS lcl_persistence_user IMPLEMENTATION.
     rv_changes_only = read( )-changes_only.
 
   ENDMETHOD. "get_changes_only
+
+  METHOD toggle_diff_unified.
+
+    DATA ls_user TYPE ty_user.
+
+    ls_user = read( ).
+    ls_user-diff_unified = boolc( ls_user-diff_unified = abap_false ).
+    update( ls_user ).
+
+    rv_diff_unified = ls_user-diff_unified.
+
+  ENDMETHOD. "toggle_diff_unified
+
+  METHOD get_diff_unified.
+
+    rv_diff_unified = read( )-diff_unified.
+
+  ENDMETHOD. "get_diff_unified
 
   METHOD get_favorites.
 

--- a/src/zabapgit_unit_test.prog.abap
+++ b/src/zabapgit_unit_test.prog.abap
@@ -242,11 +242,11 @@ CLASS ltcl_diff IMPLEMENTATION.
 
   DEFINE _expected.
     CLEAR ms_expected.
-    ms_expected-new_line = &1.
-    ms_expected-new      = &2.
-    ms_expected-result   = &3.
-    ms_expected-old_line = &4.
-    ms_expected-old      = &5.
+    ms_expected-new_num = &1.
+    ms_expected-new     = &2.
+    ms_expected-result  = &3.
+    ms_expected-old_num = &4.
+    ms_expected-old     = &5.
     APPEND ms_expected TO mt_expected.
   END-OF-DEFINITION.
 

--- a/src/zabapgit_util.prog.abap
+++ b/src/zabapgit_util.prog.abap
@@ -547,13 +547,13 @@ CLASS lcl_diff DEFINITION FINAL.
                END OF c_diff.
 
     TYPES: BEGIN OF ty_diff,
-             new_line TYPE c LENGTH 6,
-             new      TYPE string,
-             result   TYPE c LENGTH 1,
-             old_line TYPE c LENGTH 6,
-             old      TYPE string,
-             short    TYPE abap_bool,
-             beacon   TYPE i,
+             new_num TYPE c LENGTH 6,
+             new     TYPE string,
+             result  TYPE c LENGTH 1,
+             old_num TYPE c LENGTH 6,
+             old     TYPE string,
+             short   TYPE abap_bool,
+             beacon  TYPE i,
            END OF ty_diff.
     TYPES:  ty_diffs_tt TYPE STANDARD TABLE OF ty_diff WITH DEFAULT KEY.
 
@@ -697,16 +697,16 @@ CLASS lcl_diff IMPLEMENTATION.
 
 
     LOOP AT mt_diff ASSIGNING <ls_diff>.
-      <ls_diff>-new_line = lv_new.
-      <ls_diff>-old_line = lv_old.
+      <ls_diff>-new_num = lv_new.
+      <ls_diff>-old_num = lv_old.
 
       CASE <ls_diff>-result. " Line nums
         WHEN c_diff-delete.
           lv_old = lv_old + 1.
-          CLEAR <ls_diff>-new_line.
+          CLEAR <ls_diff>-new_num.
         WHEN c_diff-insert.
           lv_new = lv_new + 1.
-          CLEAR <ls_diff>-old_line.
+          CLEAR <ls_diff>-old_num.
         WHEN OTHERS.
           lv_new = lv_new + 1.
           lv_old = lv_old + 1.


### PR DESCRIPTION
to  #442

OK, finally got my hands on this feature. 

So:

![image](https://cloud.githubusercontent.com/assets/15635498/21826293/94a6b2fe-d78f-11e6-89ab-6c04c4fd414e.png)

- Actually implemented split mode. It is switched by menu button on diff page :)
- unified mode renders subsequent changed lines as one block
- added +/-/~ at the beginning of added/removed/changed lines - for easier reading - like in github (a bit arguable ... let's see the feedback ... maybe there is a better solution, e.g. showing marker on hover, or as a separate tab column)
- One **unsolved** issue: if a file was modified on both sides - then it is not possible to display unified mode properly (as it is not clear which content was earlier). So a warning displayed in the header and rendered like local is newer. Hopefully a rare case. And then it is always possible to swicth to split view.

![image](https://cloud.githubusercontent.com/assets/15635498/21826349/c9093ada-d78f-11e6-90e3-819e3dd9f66d.png)

CSS
- finetuned colors just a bit
- made adjustment to wrapping - now it always fit the page width, and wraps to the next line. (Maybe it is NOT good, let's see the feedback - like at github now however)
- Attempted to make line numbers unselectable with user-select CSS. However unsuccessfully - appeared that IE cannot do that (it is described even in it's official doc). IE renders it correctly (and I left it this way) but still numbers are selected together with code.

Seems like that's all :) Hopefully useful for someone else except me.