### PR TITLE
HEAD in select branch dialog & highlighting css bug fix 

### DIFF
--- a/src/zabapgit_css_common.w3mi.data.css
+++ b/src/zabapgit_css_common.w3mi.data.css
@@ -519,19 +519,17 @@ table.diff_tab code {
   white-space: pre;
 }
 table.diff_tab td.code {
-  /* font-family: inherit; */
-  /* white-space: pre; */
   word-wrap: break-word;
   white-space: pre-wrap;
   overflow: visible;
 }
 
-table.diff_tab code span.keyword { color: #0a69ce; }
-table.diff_tab code span.text    { color: #48ce4f; }
-table.diff_tab code span.comment { color: #808080; font-style: italic; }
-table.diff_tab code span.xml_tag { color: #457ce3; }
-table.diff_tab code span.attr    { color: #b777fb; }
-table.diff_tab code span.attr_val { color: #7a02f9; }
+table.diff_tab .code span.keyword { color: #0a69ce; }
+table.diff_tab .code span.text    { color: #48ce4f; }
+table.diff_tab .code span.comment { color: #808080; font-style: italic; }
+table.diff_tab .code span.xml_tag { color: #457ce3; }
+table.diff_tab .code span.attr    { color: #b777fb; }
+table.diff_tab .code span.attr_val { color: #7a02f9; }
 
 table.diff_tab tbody tr:first-child td { padding-top: 0.5em; }
 table.diff_tab tbody tr:last-child td { padding-bottom: 0.5em; }

--- a/src/zabapgit_css_common.w3mi.data.css
+++ b/src/zabapgit_css_common.w3mi.data.css
@@ -111,9 +111,22 @@ div.menu .menu_end { border-right: 0px !important; }
 div.menu a {
   padding-left: 0.5em;
   padding-right: 0.5em;
-  border-right: 1px solid lightgrey;
   font-size: 12pt;
 }
+
+div.menu > a {
+  border-right: 1px solid lightgrey;
+}
+div.menu > div.dropdown > a {
+  border-right: 1px solid lightgrey;
+}
+div.menu > a:last-child {
+  border-right: 0px !important;
+}
+div.menu > div.dropdown:last-child > a {
+  border-right: 0px !important;
+}
+
 div.menu_vertical   { display: inline; }
 div.menu_vertical a {
   display: block;

--- a/src/zabapgit_css_common.w3mi.xml
+++ b/src/zabapgit_css_common.w3mi.xml
@@ -3,7 +3,7 @@
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <NAME>ZABAPGIT_CSS_COMMON</NAME>
-   <TEXT>AbapGit common styles</TEXT>
+   <TEXT/>
    <PARAMS>
     <WWWPARAMS>
      <RELID>MI</RELID>

--- a/src/zabapgit_git_helpers.prog.abap
+++ b/src/zabapgit_git_helpers.prog.abap
@@ -111,7 +111,7 @@ CLASS lcl_git_branch_list DEFINITION FINAL.
                  tag    TYPE ty_git_branch_type VALUE 'TG',
                  other  TYPE ty_git_branch_type VALUE 'ZZ',
                END OF c_type.
-    CONSTANTS head_name   TYPE string VALUE 'HEAD'.
+    CONSTANTS c_head_name   TYPE string VALUE 'HEAD'.
 
     METHODS constructor
       IMPORTING iv_data TYPE string
@@ -125,6 +125,9 @@ CLASS lcl_git_branch_list DEFINITION FINAL.
     METHODS get_head " For potential future use
       RETURNING VALUE(rs_branch) TYPE ty_git_branch
       RAISING   lcx_exception.
+
+    METHODS get_head_symref
+      RETURNING VALUE(rv_head_symref) TYPE string.
 
     METHODS get_branches_only
       RETURNING VALUE(rt_branches) TYPE ty_git_branch_list_tt
@@ -147,6 +150,10 @@ CLASS lcl_git_branch_list DEFINITION FINAL.
       RETURNING VALUE(rv_type) TYPE ty_git_branch_type.
 
     CLASS-METHODS complete_heads_branch_name
+      IMPORTING iv_branch_name TYPE clike
+      RETURNING VALUE(rv_name) TYPE string.
+
+    CLASS-METHODS normalize_branch_name
       IMPORTING iv_branch_name TYPE clike
       RETURNING VALUE(rv_name) TYPE string.
 
@@ -178,6 +185,10 @@ CLASS lcl_git_branch_list IMPLEMENTATION.
                 ev_head_symref = me->mv_head_symref ).
   ENDMETHOD.  "create
 
+  METHOD get_head_symref.
+    rv_head_symref = mv_head_symref.
+  ENDMETHOD.  " get_head_symref.
+
   METHOD find_by_name.
 
     IF iv_branch_name IS INITIAL.
@@ -197,7 +208,7 @@ CLASS lcl_git_branch_list IMPLEMENTATION.
     IF mv_head_symref IS NOT INITIAL.
       rs_branch = find_by_name( mv_head_symref ).
     ELSE.
-      rs_branch = find_by_name( head_name ).
+      rs_branch = find_by_name( c_head_name ).
     ENDIF.
 
   ENDMETHOD.  "get_head
@@ -246,7 +257,7 @@ CLASS lcl_git_branch_list IMPLEMENTATION.
       <ls_branch>-name         = lv_name.
       <ls_branch>-display_name = get_display_name( lv_name ).
       <ls_branch>-type         = get_type( lv_name ).
-      IF <ls_branch>-name = head_name OR <ls_branch>-name = ev_head_symref.
+      IF <ls_branch>-name = c_head_name OR <ls_branch>-name = ev_head_symref.
         <ls_branch>-is_head    = abap_true.
       ENDIF.
     ENDLOOP.
@@ -295,7 +306,7 @@ CLASS lcl_git_branch_list IMPLEMENTATION.
   METHOD get_type.
     rv_type = c_type-other.
 
-    IF iv_branch_name CP 'refs/heads/*' OR iv_branch_name = head_name.
+    IF iv_branch_name CP 'refs/heads/*' OR iv_branch_name = c_head_name.
       rv_type = c_type-branch.
       RETURN.
     ENDIF.
@@ -333,5 +344,12 @@ CLASS lcl_git_branch_list IMPLEMENTATION.
       ENDIF.
     ENDLOOP.
   ENDMETHOD.  "get_tags_only
+
+  METHOD normalize_branch_name.
+
+    rv_name = iv_branch_name. " Force convert to string
+    REPLACE ALL OCCURRENCES OF ` ` IN rv_name WITH '-'. " Disallow space in branch name
+
+  ENDMETHOD.  " normalize_branch_name.
 
 ENDCLASS. "lcl_git_branch_list

--- a/src/zabapgit_html.prog.abap
+++ b/src/zabapgit_html.prog.abap
@@ -426,7 +426,8 @@ CLASS lcl_html_toolbar IMPLEMENTATION.
     ENDIF.
 
     IF lv_is_drop = abap_true. " Dropdown
-      ro_html->add( '</div></div>' ).
+      ro_html->add( '</div>' ).
+      ro_html->add( '</div>' ).
     ENDIF.
 
     ro_html->add( '</div>' ).

--- a/src/zabapgit_html.prog.abap
+++ b/src/zabapgit_html.prog.abap
@@ -332,8 +332,7 @@ CLASS lcl_html_toolbar IMPLEMENTATION.
   METHOD render. "TODO refactor
 
     DATA: lv_class   TYPE string,
-          lv_is_drop TYPE abap_bool,
-          lv_last    TYPE abap_bool.
+          lv_is_drop TYPE abap_bool.
 
     FIELD-SYMBOLS <ls_item> LIKE LINE OF mt_items.
 
@@ -359,13 +358,8 @@ CLASS lcl_html_toolbar IMPLEMENTATION.
       IF iv_as_angle = abap_true.
         ro_html->add( '<div class="dropbtn_angle"></div>' ).
       ELSE.
-        lv_class = 'dropbtn'.
-        IF iv_no_separator = abap_true.
-          lv_class = lv_class && ' menu_end' ##NO_TEXT.
-        ENDIF.
-
         ro_html->add_a( iv_txt   = iv_as_droplist_with_label
-                        iv_class = lv_class
+                        iv_class = 'dropbtn'
                         iv_act   = '' ).
       ENDIF.
 
@@ -386,15 +380,8 @@ CLASS lcl_html_toolbar IMPLEMENTATION.
     ENDIF.
 
     LOOP AT mt_items ASSIGNING <ls_item>.
-      lv_last = boolc( sy-tabix = lines( mt_items ) ).
 
       IF <ls_item>-sub IS INITIAL.
-        CLEAR lv_class.
-        IF iv_no_separator = abap_true
-            OR lv_last = abap_true
-            AND iv_as_droplist_with_label IS INITIAL.
-          lv_class = 'menu_end'.
-        ENDIF.
 
         IF iv_with_icons = abap_true.
           ro_html->add( '<tr>' ).
@@ -405,8 +392,7 @@ CLASS lcl_html_toolbar IMPLEMENTATION.
         ro_html->add_a( iv_txt   = <ls_item>-txt
                         iv_act   = <ls_item>-act
                         iv_opt   = <ls_item>-opt
-                        iv_typ   = <ls_item>-typ
-                        iv_class = lv_class ).
+                        iv_typ   = <ls_item>-typ ).
 
         IF iv_with_icons = abap_true.
           ro_html->add( '</td>' ).
@@ -414,9 +400,7 @@ CLASS lcl_html_toolbar IMPLEMENTATION.
         ENDIF.
 
       ELSE.
-        ro_html->add( <ls_item>-sub->render(
-          iv_as_droplist_with_label = <ls_item>-txt
-          iv_no_separator           = lv_last ) ).
+        ro_html->add( <ls_item>-sub->render( iv_as_droplist_with_label = <ls_item>-txt ) ).
       ENDIF.
 
     ENDLOOP.

--- a/src/zabapgit_html_chunks.prog.abap
+++ b/src/zabapgit_html_chunks.prog.abap
@@ -162,7 +162,8 @@ CLASS lcl_gui_chunk_lib IMPLEMENTATION.
 
     lv_text = lcl_git_branch_list=>get_display_name( iv_branch ).
 
-    IF iv_branch = io_repo->get_head_branch_name( ) OR iv_branch = lcl_git_branch_list=>head_name.
+    IF iv_branch    = io_repo->get_head_branch_name( )
+       OR iv_branch = lcl_git_branch_list=>c_head_name.
       lv_class = 'branch branch_head'.
     ELSEIF lcl_git_branch_list=>get_type( iv_branch ) = lcl_git_branch_list=>c_type-branch.
       lv_class = 'branch branch_branch'.


### PR DESCRIPTION
to #531 + a small bug fix after previous `page_diff` commits.

![2017-01-12_16h51_13](https://cloud.githubusercontent.com/assets/15635498/21894378/a8753db0-d8e7-11e6-8abc-82a753b3e5f3.png)

Removed `refs/heads` prefix. Seems like look better. But will need changes if we will support switching to tags once. Also in general `branch_list_popup` is a bit clunky now :( Not sure how to improve it immediately. But it works :)

plus added normalize_branch_name call in new_branch_popup to substitute space to '-' (space are not supported in branch names if I understand well, guthub also does similarly)