### PR TITLE
Fix #551 Delete blank lines from tadir objects

### DIFF
--- a/src/zabapgit_transport.prog.abap
+++ b/src/zabapgit_transport.prog.abap
@@ -172,7 +172,7 @@ CLASS lcl_transport IMPLEMENTATION.
 
     SORT rt_tadir BY object ASCENDING obj_name ASCENDING.
     DELETE ADJACENT DUPLICATES FROM rt_tadir COMPARING object obj_name.
-
+    DELETE rt_tadir WHERE table_line IS INITIAL.
   ENDMETHOD.
 
 ENDCLASS.


### PR DESCRIPTION
In "Transport to zip" option: Delete blank lines from tadir internal table before calculating the top package.
Fixes issue #551 .