### PR TITLE
Disable popup delete table

### DIFF
--- a/src/zabapgit_object_tabl.prog.abap
+++ b/src/zabapgit_object_tabl.prog.abap
@@ -106,7 +106,7 @@ CLASS lcl_object_tabl IMPLEMENTATION.
 
     CALL FUNCTION 'RS_DD_DELETE_OBJ'
       EXPORTING
-        no_ask               = abap_false
+        no_ask               = abap_true
         objname              = lv_objname
         objtype              = 'T'
       EXCEPTIONS


### PR DESCRIPTION
Now correct small update for issue #548 . Only valid for tables.