### PR TITLE
skip initial xml(#478) and fix newline(#42)

### DIFF
--- a/src/zabapgit_objects.prog.abap
+++ b/src/zabapgit_objects.prog.abap
@@ -373,6 +373,9 @@ CLASS lcl_objects_files IMPLEMENTATION.
 
 
     CONCATENATE LINES OF it_abap INTO lv_source SEPARATED BY gc_newline.
+* when editing files via eg. GitHub web interface it adds a newline at end of file
+    lv_source = lv_source && gc_newline.
+
     ls_file-path = '/'.
     ls_file-filename = filename( iv_extra = iv_extra
                                  iv_ext   = 'abap' ).       "#EC NOTEXT

--- a/src/zabapgit_xml.prog.abap
+++ b/src/zabapgit_xml.prog.abap
@@ -222,6 +222,7 @@ CLASS lcl_xml_output IMPLEMENTATION.
     li_doc = cl_ixml=>create( )->create_document( ).
 
     CALL TRANSFORMATION id
+      OPTIONS initial_components = 'suppress'
       SOURCE (lt_stab)
       RESULT XML li_doc.
 


### PR DESCRIPTION
fix #478 
fix #42 

note that the change is/should be backwards compatible

before merging:
* create tag

after merging:
* increase minor version
* update changelog
* update XML and ABAP to new format in abapGit repo
* submit pull requests to other major abapGit repositories