### PR TITLE
lcl_html performance tuning

### DIFF
--- a/src/zabapgit_gui.prog.abap
+++ b/src/zabapgit_gui.prog.abap
@@ -251,9 +251,11 @@ CLASS lcl_gui IMPLEMENTATION.
 
   METHOD render.
 
-    DATA lv_url TYPE w3url.
+    DATA: lv_url  TYPE w3url,
+          lo_html TYPE REF TO lcl_html.
 
-    lv_url = cache_html( mi_cur_page->render( )->mv_html ).
+    lo_html = mi_cur_page->render( ).
+    lv_url  = cache_html( lo_html->render( iv_no_indent_jscss = abap_true ) ).
 
     mo_html_viewer->show_url( lv_url ).
 

--- a/src/zabapgit_page.prog.abap
+++ b/src/zabapgit_page.prog.abap
@@ -173,7 +173,7 @@ CLASS lcl_gui_page IMPLEMENTATION.
 
     lo_script = scripts( ).
 
-    IF lo_script IS BOUND AND lo_script->mv_html IS NOT INITIAL.
+    IF lo_script IS BOUND AND lo_script->is_empty( ) = abap_false.
       ro_html->add( '<script type="text/javascript">' ).
       ro_html->add( lo_script ).
       ro_html->add( 'debugOutput("js: OK");' ).

--- a/src/zabapgit_page_debug.prog.abap
+++ b/src/zabapgit_page_debug.prog.abap
@@ -85,7 +85,7 @@ CLASS lcl_gui_page_debuginfo IMPLEMENTATION.
       ENDIF.
     ENDLOOP.
 
-    rv_html = |</p>Supported objects: { lv_list }</p>|.
+    rv_html = |<p>Supported objects: { lv_list }</p>|.
 
   ENDMETHOD.  " render_supported_object_types
 

--- a/src/zabapgit_page_stage.prog.abap
+++ b/src/zabapgit_page_stage.prog.abap
@@ -151,12 +151,14 @@ CLASS lcl_gui_page_stage IMPLEMENTATION.
     LOOP AT ms_files-local ASSIGNING <ls_local>.
       AT FIRST.
         ro_html->add('<thead><tr>').
-        ro_html->add('<th></th><th colspan="2">LOCAL</th><th>' ).
+        ro_html->add('<th></th><th colspan="2">LOCAL</th>' ).
+        ro_html->add('<th>' ).
         IF lines( ms_files-local ) > 1.
           ro_html->add_a( iv_txt = |{ lines( ms_files-local ) } diffs|
                           iv_act = |{ gc_action-go_diff }?key={ mo_repo->get_key( ) }| ).
         ENDIF.
-        ro_html->add('</th></tr></thead>').
+        ro_html->add('</th>').
+        ro_html->add('</tr></thead>').
         ro_html->add('<tbody class="local">').
       ENDAT.
 

--- a/src/zabapgit_unit_test.prog.abap
+++ b/src/zabapgit_unit_test.prog.abap
@@ -1234,7 +1234,7 @@ CLASS ltcl_git_pack IMPLEMENTATION.
 
 ENDCLASS.                    "lcl_abap_unit IMPLEMENTATION
 
-CLASS ltcl_html_helper DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
+CLASS ltcl_html DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
 
   PRIVATE SECTION.
     DATA: mo_html TYPE REF TO lcl_html.
@@ -1251,9 +1251,9 @@ CLASS ltcl_html_helper DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT
       last_line
         RETURNING VALUE(rv_line) TYPE string.
 
-ENDCLASS.
+ENDCLASS. "ltcl_html
 
-CLASS ltcl_html_helper IMPLEMENTATION.
+CLASS ltcl_html IMPLEMENTATION.
 
   METHOD setup.
     CREATE OBJECT mo_html.
@@ -1261,49 +1261,73 @@ CLASS ltcl_html_helper IMPLEMENTATION.
 
   METHOD indent1.
 
+    DATA lv_exp TYPE string.
+
     mo_html->add( '<td>' ).
     mo_html->add( 'hello world' ).
     mo_html->add( '</td>' ).
 
+    lv_exp = '<td>' && gc_newline &&
+             '  hello world' && gc_newline &&
+             '</td>'.
+
     cl_abap_unit_assert=>assert_equals(
-      act = last_line( )
-      exp = '</td>' ).
+      act = mo_html->render( )
+      exp = lv_exp ).
 
   ENDMETHOD.
 
   METHOD indent2.
 
+    DATA lv_exp TYPE string.
+
     mo_html->add( '<td>' ).
     mo_html->add( '<input name="comment" type="text">' ).
     mo_html->add( '</td>' ).
 
+    lv_exp = '<td>' && gc_newline &&
+             '  <input name="comment" type="text">' && gc_newline &&
+             '</td>'.
+
     cl_abap_unit_assert=>assert_equals(
-      act = last_line( )
-      exp = '</td>' ).
+      act = mo_html->render( )
+      exp = lv_exp ).
 
   ENDMETHOD.
 
   METHOD indent3.
 
+    DATA lv_exp TYPE string.
+
     mo_html->add( '<td>' ).
     mo_html->add( '<textarea name="body" rows="10" cols="72"></textarea>' ).
     mo_html->add( '</td>' ).
 
+    lv_exp = '<td>' && gc_newline &&
+             '  <textarea name="body" rows="10" cols="72"></textarea>' && gc_newline &&
+             '</td>'.
+
     cl_abap_unit_assert=>assert_equals(
-      act = last_line( )
-      exp = '</td>' ).
+      act = mo_html->render( )
+      exp = lv_exp ).
 
   ENDMETHOD.
 
   METHOD indent4.
 
+    DATA lv_exp TYPE string.
+
     mo_html->add( '<td>' ).
     mo_html->add( 'foo<br>bar' ).
     mo_html->add( '</td>' ).
 
+    lv_exp = '<td>' && gc_newline &&
+             '  foo<br>bar' && gc_newline &&
+             '</td>'.
+
     cl_abap_unit_assert=>assert_equals(
-      act = last_line( )
-      exp = '</td>' ).
+      act = mo_html->render( )
+      exp = lv_exp ).
 
   ENDMETHOD.
 
@@ -1311,33 +1335,37 @@ CLASS ltcl_html_helper IMPLEMENTATION.
 
     DATA: lt_strings TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
 
-    SPLIT mo_html->mv_html AT gc_newline INTO TABLE lt_strings.
-
+    SPLIT mo_html->render( ) AT gc_newline INTO TABLE lt_strings.
     READ TABLE lt_strings INDEX lines( lt_strings ) INTO rv_line.
 
   ENDMETHOD.
 
   METHOD style1.
 
+    DATA lv_exp TYPE string.
+
     mo_html->add( '<style type="text/css">' ).
     mo_html->add( '.class1 { color: red }' ).
     mo_html->add( '.class2 {' ).
     mo_html->add( 'color: red' ).
-
-    cl_abap_unit_assert=>assert_equals( act = last_line( ) exp = '    color: red' ).
-
     mo_html->add( '}' ).
-
-    cl_abap_unit_assert=>assert_equals( act = last_line( ) exp = '  }' ).
-
     mo_html->add( '</style>' ).
 
-    cl_abap_unit_assert=>assert_equals( act = last_line( ) exp = '</style>' ).
+    lv_exp = '<style type="text/css">' && gc_newline &&
+             '  .class1 { color: red }' && gc_newline &&
+             '  .class2 {' && gc_newline &&
+             '    color: red' && gc_newline &&
+             '  }' && gc_newline &&
+             '</style>'.
+
+    cl_abap_unit_assert=>assert_equals(
+      act = mo_html->render( )
+      exp = lv_exp ).
 
   ENDMETHOD.
 
 
-ENDCLASS.
+ENDCLASS. "ltcl_html
 
 *----------------------------------------------------------------------*
 *       CLASS ltcl_serialize DEFINITION

--- a/src/zabapgit_view_repo.prog.abap
+++ b/src/zabapgit_view_repo.prog.abap
@@ -503,31 +503,26 @@ CLASS lcl_gui_view_repo_content IMPLEMENTATION.
   METHOD build_dir_jump_link.
 
     DATA: lv_path   TYPE string,
-          lv_encode TYPE string,
-          lo_html   TYPE REF TO lcl_html.
+          lv_encode TYPE string.
 
     lv_path = iv_path.
     REPLACE FIRST OCCURRENCE OF mv_cur_dir IN lv_path WITH ''.
     lv_encode = lcl_html_action_utils=>dir_encode( lv_path ).
 
-    CREATE OBJECT lo_html.
-    lo_html->add_a( iv_txt = lv_path iv_act = |{ c_actions-change_dir }?{ lv_encode }| ).
-    rv_html = lo_html->mv_html.
+    rv_html = lcl_html=>a( iv_txt = lv_path
+                           iv_act = |{ c_actions-change_dir }?{ lv_encode }| ).
 
   ENDMETHOD.  "build_dir_jump_link
 
   METHOD build_obj_jump_link.
 
-    DATA: lv_encode TYPE string,
-          lo_html   TYPE REF TO lcl_html.
+    DATA: lv_encode TYPE string.
 
     lv_encode = lcl_html_action_utils=>jump_encode( iv_obj_type = is_item-obj_type
                                                     iv_obj_name = is_item-obj_name ).
 
-    CREATE OBJECT lo_html.
-    lo_html->add_a( iv_txt = |{ is_item-obj_name }|
-                    iv_act = |{ gc_action-jump }?{ lv_encode }| ).
-    rv_html = lo_html->mv_html.
+    rv_html = lcl_html=>a( iv_txt = |{ is_item-obj_name }|
+                           iv_act = |{ gc_action-jump }?{ lv_encode }| ).
 
   ENDMETHOD.  "build_obj_jump_link
 


### PR DESCRIPTION
To #537

tricky optimization arrives. Took a lot of time surprisingly. `lcl_html` actually redesigned completely. 
Briefly: string concatenation is slow, RTTI is slow, FIND is slow, internal tables are fast :) One the biggest impact surprisingly was after switch from `rv_html = rv_html + ...` to `concatenate lines of ...` in `render`. The design change gave ~2x, the `concat lines` gave the rest. At least on test case.

![2017-01-22_18h00_21](https://cloud.githubusercontent.com/assets/15635498/22184460/7c59a734-e0da-11e6-8fe4-9457c8548d98.png)

