### PR TITLE
Correct commit message formatting

### DIFF
--- a/src/zabapgit_services_git.prog.abap
+++ b/src/zabapgit_services_git.prog.abap
@@ -201,7 +201,7 @@ CLASS lcl_services_git IMPLEMENTATION.
     ls_comment-comment  = is_commit-comment.
 
     IF NOT is_commit-body IS INITIAL.
-      CONCATENATE ls_comment-comment is_commit-body
+      CONCATENATE ls_comment-comment '' is_commit-body
         INTO ls_comment-comment SEPARATED BY gc_newline.
     ENDIF.
 


### PR DESCRIPTION
Title message and full commit message must be delimited with an empty line,
otherwise CLI tools take full commit message as a part of title message.

Signed-off-by: Jakub Filak <jakub.filak@sap.com>