### PR TITLE
Fix handling of extenstion objects

### DIFF
--- a/src/zabapgit_objects.prog.abap
+++ b/src/zabapgit_objects.prog.abap
@@ -1104,12 +1104,28 @@ CLASS lcl_objects_program IMPLEMENTATION.
     ELSE.
 * function module RPY_PROGRAM_INSERT cannot handle function group includes
 
-      INSERT REPORT is_progdir-name
-        FROM it_source
-        STATE 'I'
-        PROGRAM TYPE is_progdir-subc.
-      IF sy-subrc <> 0.
-        lcx_exception=>raise( 'error from INSERT REPORT' ).
+      IF strlen( is_progdir-name ) > 30.
+        " special treatment for extenstions
+        " if the program name exceeds 30 characters it is not a usual
+        " ABAP program but might be some extension, which requires the internal
+        " addition EXTENSION TYPE, see
+        " http://help.sap.com/abapdocu_751/en/abapinsert_report_internal.htm#!ABAP_ADDITION_1@1@
+        " This e.g. occurs in case of transportable Code Inspector variants (ending with ===VC)
+        INSERT REPORT is_progdir-name
+         FROM it_source
+         STATE 'I'
+         EXTENSION TYPE is_progdir-name+30.
+        IF sy-subrc <> 0.
+          lcx_exception=>raise( 'error from INSERT REPORT .. EXTENSION TYPE' ).
+        ENDIF.
+      ELSE.
+        INSERT REPORT is_progdir-name
+          FROM it_source
+          STATE 'I'
+          PROGRAM TYPE is_progdir-subc.
+        IF sy-subrc <> 0.
+          lcx_exception=>raise( 'error from INSERT REPORT' ).
+        ENDIF.
       ENDIF.
 
       IF NOT it_tpool[] IS INITIAL.


### PR DESCRIPTION
I just cloned a repository which contained also a transportable Code Inspector variant. These variants are some kind of extension objects, which are stored as 'program' (object type _PROG_ in _TADIR_), but which are named _...=====VC_ (where the 'VC' is at position 31 and 32 of the program name), e.g. 
![image](https://cloud.githubusercontent.com/assets/7314541/22367669/21a167da-e483-11e6-80d6-2bb686cef473.png)
![image](https://cloud.githubusercontent.com/assets/7314541/22367865/1b153ea4-e484-11e6-98bc-eddc7ab8fe60.png)


This caused an error ("error from INSERT REPORT") since _INSERT REPORT_ by default can not handle such extensions, e.g. programs with names longer than 30 characters. However, it works using the internal addition _EXTENSION TYPE_, see http://help.sap.com/abapdocu_751/en/abapinsert_report_internal.htm#!ABAP_ADDITION_1@1@. (There, type group SREXT is referenced for allowed extension types, but VC is not in it. Seems that the suffix of the program name corresponds to the required value for _exttype_ of the addition _EXTENSION TYPE_.

This pull request contains a fix for this issue, thus I was able to clone the repository, also the code inspector variant was successfully imported. 