### PR TITLE
dot abapgit handling changed #440

### DIFF
--- a/src/zabapgit.prog.abap
+++ b/src/zabapgit.prog.abap
@@ -45,8 +45,8 @@ INCLUDE zabapgit_xml.
 
 INCLUDE zabapgit_app.              " Some deferred definitions here
 INCLUDE zabapgit_persistence_old.
-INCLUDE zabapgit_persistence.
 INCLUDE zabapgit_dot_abapgit.
+INCLUDE zabapgit_persistence.
 INCLUDE zabapgit_sap_package.
 
 INCLUDE zabapgit_stage.

--- a/src/zabapgit_dot_abapgit.prog.abap
+++ b/src/zabapgit_dot_abapgit.prog.abap
@@ -4,12 +4,17 @@
 
 CLASS ltcl_dot_abapgit DEFINITION DEFERRED.
 
-CLASS lcl_dot_abapgit DEFINITION CREATE PRIVATE FINAL FRIENDS ltcl_dot_abapgit.
+CLASS lcl_dot_abapgit DEFINITION FINAL FRIENDS ltcl_dot_abapgit.
 
   PUBLIC SECTION.
+    TYPES: BEGIN OF ty_dot_abapgit,
+             master_language TYPE spras,
+             starting_folder TYPE string,
+             ignore          TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
+           END OF ty_dot_abapgit.
+
     CLASS-METHODS:
       build_default
-        IMPORTING iv_master_language    TYPE spras
         RETURNING VALUE(ro_dot_abapgit) TYPE REF TO lcl_dot_abapgit,
       deserialize
         IMPORTING iv_xstr               TYPE xstring
@@ -17,9 +22,15 @@ CLASS lcl_dot_abapgit DEFINITION CREATE PRIVATE FINAL FRIENDS ltcl_dot_abapgit.
         RAISING   lcx_exception.
 
     METHODS:
+      constructor
+        IMPORTING is_data TYPE ty_dot_abapgit.
+
+    METHODS:
       serialize
         RETURNING VALUE(rv_xstr) TYPE xstring
         RAISING   lcx_exception,
+      get_data
+        RETURNING VALUE(rs_data) TYPE ty_dot_abapgit,
       add_ignore
         IMPORTING iv_path     TYPE string
                   iv_filename TYPE string,
@@ -32,28 +43,18 @@ CLASS lcl_dot_abapgit DEFINITION CREATE PRIVATE FINAL FRIENDS ltcl_dot_abapgit.
                   iv_filename TYPE string,
       get_starting_folder
         RETURNING VALUE(rv_path) TYPE string,
-*      set_starting_folder
-*        IMPORTING iv_path TYPE string,
+      set_starting_folder
+        IMPORTING iv_path TYPE string,
       get_master_language
         RETURNING VALUE(rv_language) TYPE spras,
-*      set_master_language
-*        IMPORTING iv_language TYPE spras.
+      set_master_language
+        IMPORTING iv_language TYPE spras,
       get_signature
         RETURNING VALUE(rs_signature) TYPE ty_file_signature
         RAISING   lcx_exception.
 
   PRIVATE SECTION.
-    TYPES: BEGIN OF ty_dot_abapgit,
-             master_language TYPE spras,
-             starting_folder TYPE string,
-             ignore          TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
-           END OF ty_dot_abapgit.
-
     DATA: ms_data TYPE ty_dot_abapgit.
-
-    METHODS:
-      constructor
-        IMPORTING is_data TYPE ty_dot_abapgit.
 
     CLASS-METHODS:
       to_xml
@@ -88,6 +89,10 @@ CLASS lcl_dot_abapgit IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD get_data.
+    rs_data = ms_data.
+  ENDMETHOD.
+
   METHOD serialize.
 
     DATA: lv_xml TYPE string.
@@ -103,7 +108,7 @@ CLASS lcl_dot_abapgit IMPLEMENTATION.
     DATA: ls_data TYPE ty_dot_abapgit.
 
 
-    ls_data-master_language = iv_master_language.
+    ls_data-master_language = sy-langu.
     ls_data-starting_folder = '/'.
     APPEND '/.gitignore' TO ls_data-ignore.
     APPEND '/LICENSE' TO ls_data-ignore.
@@ -198,17 +203,17 @@ CLASS lcl_dot_abapgit IMPLEMENTATION.
     rv_path = ms_data-starting_folder.
   ENDMETHOD.
 
-*  METHOD set_starting_folder.
-*    ms_data-starting_folder = iv_path.
-*  ENDMETHOD.
+  METHOD set_starting_folder.
+    ms_data-starting_folder = iv_path.
+  ENDMETHOD.
 
   METHOD get_master_language.
     rv_language = ms_data-master_language.
   ENDMETHOD.
 
-*  METHOD set_master_language.
-*    ms_data-master_language = iv_language.
-*  ENDMETHOD.
+  METHOD set_master_language.
+    ms_data-master_language = iv_language.
+  ENDMETHOD.
 
   METHOD get_signature.
 

--- a/src/zabapgit_file_status.prog.abap
+++ b/src/zabapgit_file_status.prog.abap
@@ -63,7 +63,6 @@ CLASS lcl_file_status IMPLEMENTATION.
 
 
     rt_results = calculate_status(
-
       iv_devclass  = io_repo->get_package( )
       it_local     = io_repo->get_files_local( io_log = io_log )
       it_remote    = io_repo->get_files_remote( )

--- a/src/zabapgit_objects_impl.prog.abap
+++ b/src/zabapgit_objects_impl.prog.abap
@@ -232,6 +232,9 @@ CLASS lcl_objects IMPLEMENTATION.
 
 
     lv_length = strlen( iv_start ).
+    IF lv_length > strlen( iv_path ).
+      lcx_exception=>raise( 'Error: folder structure' ).
+    ENDIF.
     lv_path = iv_path+lv_length.
     lv_parent = iv_top.
     rv_package = iv_top.
@@ -644,7 +647,7 @@ CLASS lcl_objects IMPLEMENTATION.
       lo_xml = lo_files->read_xml( ).
 
       li_obj = create_object( is_item     = ls_item
-                              iv_language = io_repo->get_master_language( )
+                              iv_language = io_repo->get_dot_abapgit( )->get_master_language( )
                               is_metadata = lo_xml->get_metadata( ) ).
 
       compare_remote_to_local(

--- a/src/zabapgit_persistence.prog.abap
+++ b/src/zabapgit_persistence.prog.abap
@@ -104,7 +104,7 @@ CLASS lcl_persistence_repo DEFINITION FINAL.
              package            TYPE devclass,
              offline            TYPE sap_bool,
              local_checksums    TYPE ty_local_checksum_tt,
-             master_language    TYPE spras,
+             dot_abapgit        TYPE lcl_dot_abapgit=>ty_dot_abapgit,
              head_branch        TYPE string,   " HEAD symref of the repo, master branch
              write_protect      TYPE sap_bool, " Deny destructive ops: pull, switch branch ...
              ignore_subpackages TYPE sap_bool,
@@ -126,6 +126,11 @@ CLASS lcl_persistence_repo DEFINITION FINAL.
     METHODS update_sha1
       IMPORTING iv_key         TYPE ty_repo-key
                 iv_branch_sha1 TYPE ty_repo_xml-sha1
+      RAISING   lcx_exception.
+
+    METHODS update_dot_abapgit
+      IMPORTING iv_key         TYPE ty_repo-key
+                is_dot_abapgit TYPE lcl_dot_abapgit=>ty_dot_abapgit
       RAISING   lcx_exception.
 
     METHODS update_local_checksums
@@ -159,6 +164,7 @@ CLASS lcl_persistence_repo DEFINITION FINAL.
                 iv_branch      TYPE ty_sha1 OPTIONAL
                 iv_package     TYPE devclass
                 iv_offline     TYPE sap_bool DEFAULT abap_false
+                is_dot_abapgit TYPE lcl_dot_abapgit=>ty_dot_abapgit OPTIONAL
       RETURNING VALUE(rv_key)  TYPE ty_repo-key
       RAISING   lcx_exception.
 
@@ -905,7 +911,8 @@ CLASS lcl_persistence_repo IMPLEMENTATION.
     ls_repo-sha1         = iv_branch.
     ls_repo-package      = iv_package.
     ls_repo-offline      = iv_offline.
-    ls_repo-master_language = sy-langu.
+    ASSERT NOT is_dot_abapgit IS INITIAL.
+    ls_repo-dot_abapgit  = is_dot_abapgit.
 
     lv_repo_as_xml = to_xml( ls_repo ).
 
@@ -1052,6 +1059,30 @@ CLASS lcl_persistence_repo IMPLEMENTATION.
 
   ENDMETHOD.  "update_offline
 
+  METHOD update_dot_abapgit.
+
+    DATA: lt_content TYPE lcl_persistence_db=>tt_content,
+          ls_content LIKE LINE OF lt_content,
+          ls_repo    TYPE ty_repo.
+
+
+    ASSERT NOT iv_key IS INITIAL.
+
+    TRY.
+        ls_repo = read( iv_key ).
+      CATCH lcx_not_found.
+        lcx_exception=>raise( 'key not found' ).
+    ENDTRY.
+
+    ls_repo-dot_abapgit = is_dot_abapgit.
+    ls_content-data_str = to_xml( ls_repo ).
+
+    mo_db->update( iv_type  = c_type_repo
+                   iv_value = iv_key
+                   iv_data  = ls_content-data_str ).
+
+  ENDMETHOD.
+
   METHOD update_sha1.
 
     DATA: lt_content TYPE lcl_persistence_db=>tt_content,
@@ -1152,10 +1183,6 @@ CLASS lcl_persistence_repo IMPLEMENTATION.
       lcx_exception=>raise( 'Inconsistent repo metadata' ).
     ENDIF.
 
-* field master_language is new, so default it for old repositories
-    IF rs_repo-master_language IS INITIAL.
-      rs_repo-master_language = sy-langu.
-    ENDIF.
   ENDMETHOD.
 
   METHOD to_xml.

--- a/src/zabapgit_repo.prog.abap
+++ b/src/zabapgit_repo.prog.abap
@@ -30,8 +30,6 @@ CLASS lcl_repo DEFINITION ABSTRACT FRIENDS lcl_repo_srv.
         RAISING   lcx_exception,
       get_package
         RETURNING VALUE(rv_package) TYPE lcl_persistence_repo=>ty_repo-package,
-      get_master_language
-        RETURNING VALUE(rv_language) TYPE spras,
       is_write_protected
         RETURNING VALUE(rv_yes) TYPE sap_bool,
       ignore_subpackages
@@ -66,6 +64,7 @@ CLASS lcl_repo DEFINITION ABSTRACT FRIENDS lcl_repo_srv.
 
     METHODS:
       find_dot_abapgit
+        RETURNING VALUE(ro_dot) TYPE REF TO lcl_dot_abapgit
         RAISING lcx_exception,
       set
         IMPORTING iv_sha1        TYPE ty_sha1 OPTIONAL
@@ -74,6 +73,7 @@ CLASS lcl_repo DEFINITION ABSTRACT FRIENDS lcl_repo_srv.
                   iv_branch_name TYPE lcl_persistence_repo=>ty_repo-branch_name OPTIONAL
                   iv_head_branch TYPE lcl_persistence_repo=>ty_repo-head_branch OPTIONAL
                   iv_offline     TYPE lcl_persistence_repo=>ty_repo-offline OPTIONAL
+                  is_dot_abapgit TYPE lcl_persistence_repo=>ty_repo-dot_abapgit OPTIONAL
         RAISING   lcx_exception.
 
 ENDCLASS.                    "lcl_repo DEFINITION

--- a/src/zabapgit_stage.prog.abap
+++ b/src/zabapgit_stage.prog.abap
@@ -56,10 +56,10 @@ CLASS lcl_stage DEFINITION FINAL.
         IMPORTING iv_path     TYPE ty_file-path
                   iv_filename TYPE ty_file-filename
         RAISING   lcx_exception,
-*      lookup
-*        IMPORTING iv_path          TYPE ty_file-path
-*                  iv_filename      TYPE ty_file-filename
-*        RETURNING VALUE(rv_method) TYPE ty_method,
+      lookup
+        IMPORTING iv_path          TYPE ty_file-path
+                  iv_filename      TYPE ty_file-filename
+        RETURNING VALUE(rv_method) TYPE ty_method,
       get_merge_source
         RETURNING VALUE(rv_source) TYPE ty_sha1,
       count
@@ -103,19 +103,19 @@ CLASS lcl_stage IMPLEMENTATION.
     rv_branch = mv_branch_sha1.
   ENDMETHOD.
 
-*  METHOD lookup.
-*
-*    DATA ls_stage LIKE LINE OF mt_stage.
-*
-*
-*    READ TABLE mt_stage INTO ls_stage
-*      WITH KEY file-path     = iv_path
-*               file-filename = iv_filename.
-*    IF sy-subrc = 0.
-*      rv_method = ls_stage-method.
-*    ENDIF.
-*
-*  ENDMETHOD.        "lookup
+  METHOD lookup.
+
+    DATA ls_stage LIKE LINE OF mt_stage.
+
+
+    READ TABLE mt_stage INTO ls_stage
+      WITH KEY file-path     = iv_path
+               file-filename = iv_filename.
+    IF sy-subrc = 0.
+      rv_method = ls_stage-method.
+    ENDIF.
+
+  ENDMETHOD.        "lookup
 
   METHOD get_all.
     rt_stage = mt_stage.

--- a/src/zabapgit_transport.prog.abap
+++ b/src/zabapgit_transport.prog.abap
@@ -55,7 +55,6 @@ CLASS lcl_transport IMPLEMENTATION.
 
     ls_data-key             = 'TZIP'.
     ls_data-package         = lv_package.
-    ls_data-master_language = sy-langu.
 
     CREATE OBJECT lo_repo
       EXPORTING

--- a/src/zabapgit_unit_test.prog.abap
+++ b/src/zabapgit_unit_test.prog.abap
@@ -397,7 +397,7 @@ CLASS ltcl_dot_abapgit IMPLEMENTATION.
           ls_after  TYPE lcl_dot_abapgit=>ty_dot_abapgit.
 
 
-    lo_dot = lcl_dot_abapgit=>build_default( gc_english ).
+    lo_dot = lcl_dot_abapgit=>build_default( ).
     ls_before = lo_dot->ms_data.
 
     lo_dot = lcl_dot_abapgit=>deserialize( lo_dot->serialize( ) ).
@@ -418,7 +418,7 @@ CLASS ltcl_dot_abapgit IMPLEMENTATION.
           lo_dot     TYPE REF TO lcl_dot_abapgit.
 
 
-    lo_dot = lcl_dot_abapgit=>build_default( gc_english ).
+    lo_dot = lcl_dot_abapgit=>build_default( ).
 
     lv_ignored = lo_dot->is_ignored( iv_path = lc_path iv_filename = lc_filename ).
     cl_abap_unit_assert=>assert_equals(

--- a/src/zabapgit_zip.prog.abap
+++ b/src/zabapgit_zip.prog.abap
@@ -437,8 +437,7 @@ CLASS lcl_zip IMPLEMENTATION.
       RAISE EXCEPTION TYPE lcx_cancel.
     ENDIF.
 
-    ls_data-key             = 'DUMMY'.
-    ls_data-master_language = sy-langu.
+    ls_data-key = 'DUMMY'.
 
     CREATE OBJECT lo_repo
       EXPORTING


### PR DESCRIPTION
Changes, fixing #440:
* dot abapgit type added to repo persistency type(i.e. content of .abapgit.xml is now saved to database)
* add project: set default dot abapgit
* load: read from database
* push(METHOD push): save local content of dot abapgit to database(files might have been added to the ignore list)
* pull(METHOD deserialize): save remote content of dot abapgit to database

This also adds the possibility for using STARTING_FOLDER in offline projects

NOTE: Pull must be done for existing online repositires to update the local state

@sbcgua do you have time to test this before it is merged?

Future enhancements:
* split ZABAPGIT_REPO_IMPL file
* page for editing repository settings, as the .abapgit.xml file is now saved in database we can create a settings page for editing it