### PR TITLE
Prog serializing texts

### DIFF
--- a/src/zabapgit_object_prog.prog.abap
+++ b/src/zabapgit_object_prog.prog.abap
@@ -203,25 +203,19 @@ CLASS lcl_object_prog IMPLEMENTATION.
   ENDMETHOD.                    "serialize_texts
 
   METHOD deserialize_texts.
-    DATA:
-      lt_tpool_i18n   TYPE tt_tpool_i18n,
-      ls_tpool_i18n   LIKE LINE OF lt_tpool_i18n,
-      lt_langs_i18n   TYPE STANDARD TABLE OF langu.
 
-    FIELD-SYMBOLS:  <lang>  LIKE LINE OF lt_langs_i18n.
-
-    io_xml->read( EXPORTING iv_name = 'I18N_LANGS'
-                  CHANGING  cg_data = lt_langs_i18n ).
+    DATA lt_tpool_i18n  TYPE tt_tpool_i18n.
+    FIELD-SYMBOLS <tpool> LIKE LINE OF lt_tpool_i18n.
 
     io_xml->read( EXPORTING iv_name = 'I18N_TPOOL'
                   CHANGING  cg_data = lt_tpool_i18n ).
 
-    LOOP AT lt_langs_i18n ASSIGNING <lang>.
-      READ TABLE lt_tpool_i18n INTO ls_tpool_i18n WITH KEY langu = <lang>.
+    LOOP AT lt_tpool_i18n ASSIGNING <tpool>.
       deserialize_textpool( iv_program  = ms_item-obj_name
-                            iv_language = <lang>
-                            it_tpool    = ls_tpool_i18n-textpool ).
+                            iv_language = <tpool>-langu
+                            it_tpool    = <tpool>-textpool ).
     ENDLOOP.
+
   ENDMETHOD.                    "deserialize_texts
 
 ENDCLASS.                    "lcl_object_prog IMPLEMENTATION

--- a/src/zabapgit_objects.prog.abap
+++ b/src/zabapgit_objects.prog.abap
@@ -873,8 +873,9 @@ CLASS lcl_objects_program DEFINITION INHERITING FROM lcl_objects_super.
       RAISING   lcx_exception.
 
     METHODS deserialize_textpool
-      IMPORTING iv_program TYPE programm
-                it_tpool   TYPE textpool_table
+      IMPORTING iv_program  TYPE programm
+                iv_language TYPE langu OPTIONAL
+                it_tpool    TYPE textpool_table
       RAISING   lcx_exception.
 
     METHODS deserialize_cua
@@ -1410,6 +1411,14 @@ CLASS lcl_objects_program IMPLEMENTATION.
 
   METHOD deserialize_textpool.
 
+    DATA lv_language TYPE langu.
+
+    IF iv_language IS INITIAL.
+      lv_language = mv_language.
+    ELSE.
+      lv_language = iv_language.
+    ENDIF.
+
     READ TABLE it_tpool WITH KEY id = 'R' TRANSPORTING NO FIELDS.
     IF ( sy-subrc = 0 AND lines( it_tpool ) = 1 ) OR lines( it_tpool ) = 0.
       RETURN. " no action for includes
@@ -1417,14 +1426,16 @@ CLASS lcl_objects_program IMPLEMENTATION.
 
     INSERT TEXTPOOL iv_program
       FROM it_tpool
-      LANGUAGE mv_language
+      LANGUAGE lv_language
       STATE 'I'.
     IF sy-subrc <> 0.
       lcx_exception=>raise( 'error from INSERT TEXTPOOL' ).
     ENDIF.
 
-    lcl_objects_activation=>add( iv_type = 'REPT'
-                                 iv_name = iv_program ).
+    IF lv_language = mv_language. " Add just once
+      lcl_objects_activation=>add( iv_type = 'REPT'
+                                   iv_name = iv_program ).
+    ENDIF.
 
   ENDMETHOD.                    "deserialize_textpool
 

--- a/src/zabapgit_objects.prog.abap
+++ b/src/zabapgit_objects.prog.abap
@@ -874,8 +874,8 @@ CLASS lcl_objects_program DEFINITION INHERITING FROM lcl_objects_super.
 
     METHODS deserialize_textpool
       IMPORTING iv_program  TYPE programm
-                iv_language TYPE langu OPTIONAL
                 it_tpool    TYPE textpool_table
+                iv_language TYPE langu OPTIONAL
       RAISING   lcx_exception.
 
     METHODS deserialize_cua

--- a/src/zabapgit_objects.prog.abap
+++ b/src/zabapgit_objects.prog.abap
@@ -1426,8 +1426,7 @@ CLASS lcl_objects_program IMPLEMENTATION.
 
     INSERT TEXTPOOL iv_program
       FROM it_tpool
-      LANGUAGE lv_language
-      STATE 'I'.
+      LANGUAGE lv_language.
     IF sy-subrc <> 0.
       lcx_exception=>raise( 'error from INSERT TEXTPOOL' ).
     ENDIF.


### PR DESCRIPTION
Hello @larshp , 

During last couple of days I was working on serializing / deserializing of program texts maintained as translations. With a lot of support from @sbcgua and @sshlapak, I've finally arrived at a version that is working:)
 
Please note, there was one problem involved with deserializing: translations were correctly retrieved from XML and populated as translations, however we couldn't activate them. After a lot of experiments, @sshlapak suggested to remove parameter state = 'I' in method deserialize_textpool (screenshot below). Currently if works fine - both for objects PROG and FUGR, which use this method. Do you possibly know if that might involve possible issue here?

![2017-02-09_12h51_46](https://cloud.githubusercontent.com/assets/6059582/22796306/a2fe9576-ef02-11e6-8943-4a92a0801951.jpg)

