### PR TITLE
fix package popups #497

### DIFF
--- a/src/zabapgit_objects_impl.prog.abap
+++ b/src/zabapgit_objects_impl.prog.abap
@@ -672,8 +672,12 @@ CLASS lcl_objects IMPLEMENTATION.
                           iv_total   = lines( it_objects )
                           iv_text    = <ls_obj>-item-obj_name ) ##NO_TEXT.
 
+* magic, see function module RS_CORR_INSERT, FORM get_current_devclass
+      SET PARAMETER ID 'EUK' FIELD <ls_obj>-package.
       <ls_obj>-obj->deserialize( iv_package = <ls_obj>-package
                                  io_xml     = <ls_obj>-xml ).
+      SET PARAMETER ID 'EUK' FIELD ''.
+
       APPEND LINES OF <ls_obj>-obj->mo_files->get_accessed_files( ) TO ct_files.
     ENDLOOP.
 


### PR DESCRIPTION
I think this removes the package popups for a lot of objects, so far I've tested with SFBF SFBS SFWS and it works for these.

also see #497 

Does not work for these object types(and perhaps more):
ACID
AUTH
FUGR
SPLO
SSFO
SUSC
SUSO
WDYA
but I still think it is a good idea to add the code