### PR TITLE
separate login, author and committer

### DIFF
--- a/src/zabapgit_background.prog.abap
+++ b/src/zabapgit_background.prog.abap
@@ -75,9 +75,9 @@ CLASS lcl_background IMPLEMENTATION.
                      iv_data     = <ls_local>-file-data ).
     ENDLOOP.
 
-    ls_comment-username = is_settings-aname.
-    ls_comment-email    = is_settings-amail.
-    ls_comment-comment  = build_comment( ls_files ).
+    ls_comment-committer-name  = is_settings-aname.
+    ls_comment-committer-email = is_settings-amail.
+    ls_comment-comment         = build_comment( ls_files ).
 
     io_repo->push( is_comment = ls_comment
                    io_stage   = lo_stage ).
@@ -131,8 +131,8 @@ CLASS lcl_background IMPLEMENTATION.
       ENDIF.
 
       CLEAR ls_comment.
-      ls_comment-username = lcl_objects=>changed_by( <ls_local>-item ).
-      ls_comment-email    = |{ ls_comment-username }@localhost|.
+      ls_comment-committer-name  = lcl_objects=>changed_by( <ls_local>-item ).
+      ls_comment-committer-email = |{ ls_comment-committer-name }@localhost|.
 
       CREATE OBJECT lo_stage
         EXPORTING
@@ -142,9 +142,9 @@ CLASS lcl_background IMPLEMENTATION.
       CLEAR ls_user_files.
 
       LOOP AT ls_files-local ASSIGNING <ls_local>.
-        IF lcl_objects=>changed_by( <ls_local>-item ) = ls_comment-username.
+        IF lcl_objects=>changed_by( <ls_local>-item ) = ls_comment-committer-name.
           WRITE: / 'stage' ##NO_TEXT,
-            ls_comment-username,
+            ls_comment-committer-name,
             <ls_local>-file-path,
             <ls_local>-file-filename.
 

--- a/src/zabapgit_css_common.w3mi.data.css
+++ b/src/zabapgit_css_common.w3mi.data.css
@@ -408,16 +408,34 @@ input.stage-filter { width: 18em; }
 }
 
 /* COMMIT */
-div.form_div {
+div.form-container {
   margin: 0.5em 0em;
   background-color: #F8F8F8;
   padding: 1em 1em;
 }
 
-div.form_div td.field_name {
+form.aligned-form {
+  display: table;
+  border-spacing: 2px;
+}
+
+form.aligned-form label {
   color: #BBB;
   padding-right: 1em;
+  vertical-align: middle;
 }
+
+form.aligned-form span.sub-title {
+  color: #BBB;
+  font-size: smaller;
+  padding-top: 8px;
+}
+
+form.aligned-form div.row { display: table-row; }
+form.aligned-form label { display: table-cell; }
+form.aligned-form input { display: table-cell; }
+form.aligned-form input[type="text"] { width: 25em; }
+form.aligned-form span.cell { display: table-cell; }
 
 /* SETTINGS STYLES */
 div.settings_container {

--- a/src/zabapgit_definitions.prog.abap
+++ b/src/zabapgit_definitions.prog.abap
@@ -28,11 +28,18 @@ TYPES: ty_files_tt TYPE STANDARD TABLE OF ty_file WITH DEFAULT KEY.
 
 TYPES: ty_string_tt TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
 
-TYPES: BEGIN OF ty_comment,
-         username TYPE string,
-         email    TYPE string,
-         comment  TYPE string,
-       END OF ty_comment.
+TYPES:
+  BEGIN OF ty_git_user,
+    name TYPE string,
+    email TYPE string,
+  END OF ty_git_user.
+
+TYPES:
+  BEGIN OF ty_comment,
+    committer TYPE ty_git_user,
+    author    TYPE ty_git_user,
+    comment   TYPE string,
+  END OF ty_comment.
 
 TYPES: BEGIN OF ty_item,
          obj_type TYPE tadir-object,

--- a/src/zabapgit_git.prog.abap
+++ b/src/zabapgit_git.prog.abap
@@ -1176,12 +1176,18 @@ CLASS lcl_git_porcelain IMPLEMENTATION.
     ASSERT sy-subrc = 0.
 
 * new commit
+    ls_commit-committer = |{ is_comment-committer-name
+      } <{ is_comment-committer-email }> { lv_time }|.
+    IF is_comment-author-name IS NOT INITIAL.
+      ls_commit-author = |{ is_comment-author-name
+        } <{ is_comment-author-email }> { lv_time }|.
+    ELSE.
+      ls_commit-author = ls_commit-committer.
+    ENDIF.
+
     ls_commit-tree      = <ls_tree>-sha1.
     ls_commit-parent    = io_stage->get_branch_sha1( ).
     ls_commit-parent2   = io_stage->get_merge_source( ).
-    CONCATENATE is_comment-username space '<' is_comment-email '>' space lv_time
-      INTO ls_commit-author RESPECTING BLANKS.
-    ls_commit-committer = ls_commit-author.
     ls_commit-body      = is_comment-comment.
     lv_commit = lcl_git_pack=>encode_commit( ls_commit ).
 

--- a/src/zabapgit_html_action_utils.prog.abap
+++ b/src/zabapgit_html_action_utils.prog.abap
@@ -293,11 +293,12 @@ CLASS lcl_html_action_utils IMPLEMENTATION.
     lt_fields = cl_http_utility=>if_http_utility~string_to_fields( lv_string ).
     field_keys_to_upper( CHANGING ct_fields = lt_fields ).
 
-    get_field( EXPORTING name = 'REPO_KEY' it = lt_fields CHANGING cv = es_fields ).
-    get_field( EXPORTING name = 'USERNAME' it = lt_fields CHANGING cv = es_fields ).
-    get_field( EXPORTING name = 'EMAIL'    it = lt_fields CHANGING cv = es_fields ).
-    get_field( EXPORTING name = 'COMMENT'  it = lt_fields CHANGING cv = es_fields ).
-    get_field( EXPORTING name = 'BODY'     it = lt_fields CHANGING cv = es_fields ).
+    get_field( EXPORTING name = 'COMMITTER_NAME'  it = lt_fields CHANGING cv = es_fields ).
+    get_field( EXPORTING name = 'COMMITTER_EMAIL' it = lt_fields CHANGING cv = es_fields ).
+    get_field( EXPORTING name = 'AUTHOR_NAME'     it = lt_fields CHANGING cv = es_fields ).
+    get_field( EXPORTING name = 'AUTHOR_EMAIL'    it = lt_fields CHANGING cv = es_fields ).
+    get_field( EXPORTING name = 'COMMENT'         it = lt_fields CHANGING cv = es_fields ).
+    get_field( EXPORTING name = 'BODY'            it = lt_fields CHANGING cv = es_fields ).
 
     ASSIGN COMPONENT 'BODY' OF STRUCTURE es_fields TO <body>.
     ASSERT <body> IS ASSIGNED.

--- a/src/zabapgit_http.prog.abap
+++ b/src/zabapgit_http.prog.abap
@@ -475,7 +475,7 @@ CLASS lcl_http IMPLEMENTATION.
           lo_digest        TYPE REF TO lcl_http_digest.
 
 
-    lv_default_user = lcl_app=>user( )->get_repo_username( iv_url ).
+    lv_default_user = lcl_app=>user( )->get_repo_login( iv_url ).
     lv_user         = lv_default_user.
 
     lcl_password_dialog=>popup(
@@ -490,8 +490,8 @@ CLASS lcl_http IMPLEMENTATION.
     ENDIF.
 
     IF lv_user <> lv_default_user.
-      lcl_app=>user( )->set_repo_username( iv_url      = iv_url
-                                           iv_username = lv_user ).
+      lcl_app=>user( )->set_repo_login( iv_url   = iv_url
+                                        iv_login = lv_user ).
     ENDIF.
 
     " Offer two factor authentication if it is available and required

--- a/src/zabapgit_persistence.prog.abap
+++ b/src/zabapgit_persistence.prog.abap
@@ -364,19 +364,19 @@ CLASS lcl_persistence_user DEFINITION FINAL CREATE PRIVATE FRIENDS lcl_app.
 
     TYPES: tt_favorites TYPE lcl_persistence_repo=>tt_repo_keys.
 
-    METHODS set_username
+    METHODS set_default_git_user_name
       IMPORTING iv_username TYPE string
       RAISING   lcx_exception.
 
-    METHODS get_username
+    METHODS get_default_git_user_name
       RETURNING VALUE(rv_username) TYPE string
       RAISING   lcx_exception.
 
-    METHODS set_email
+    METHODS set_default_git_user_email
       IMPORTING iv_email TYPE string
       RAISING   lcx_exception.
 
-    METHODS get_email
+    METHODS get_default_git_user_email
       RETURNING VALUE(rv_email) TYPE string
       RAISING   lcx_exception.
 
@@ -388,22 +388,32 @@ CLASS lcl_persistence_user DEFINITION FINAL CREATE PRIVATE FRIENDS lcl_app.
       RETURNING VALUE(rv_key) TYPE lcl_persistence_repo=>ty_repo-key
       RAISING   lcx_exception.
 
-    METHODS set_repo_username
+    METHODS set_repo_git_user_name
       IMPORTING iv_url      TYPE lcl_persistence_repo=>ty_repo-url
                 iv_username TYPE string
       RAISING   lcx_exception.
 
-    METHODS get_repo_username
+    METHODS get_repo_git_user_name
       IMPORTING iv_url             TYPE lcl_persistence_repo=>ty_repo-url
       RETURNING VALUE(rv_username) TYPE string
       RAISING   lcx_exception.
 
-    METHODS set_repo_email
+    METHODS set_repo_login
+      IMPORTING iv_url   TYPE lcl_persistence_repo=>ty_repo-url
+                iv_login TYPE string
+      RAISING   lcx_exception.
+
+    METHODS get_repo_login
+      IMPORTING iv_url          TYPE lcl_persistence_repo=>ty_repo-url
+      RETURNING VALUE(rv_login) TYPE string
+      RAISING   lcx_exception.
+
+    METHODS set_repo_git_user_email
       IMPORTING iv_url   TYPE lcl_persistence_repo=>ty_repo-url
                 iv_email TYPE string
       RAISING   lcx_exception.
 
-    METHODS get_repo_email
+    METHODS get_repo_git_user_email
       IMPORTING iv_url          TYPE lcl_persistence_repo=>ty_repo-url
       RETURNING VALUE(rv_email) TYPE string
       RAISING   lcx_exception.
@@ -450,23 +460,25 @@ CLASS lcl_persistence_user DEFINITION FINAL CREATE PRIVATE FRIENDS lcl_app.
 
     DATA: mv_user TYPE xubname.
 
-    TYPES: BEGIN OF ty_repo_config,
-             url      TYPE lcl_persistence_repo=>ty_repo-url,
-             username TYPE string,
-             email    TYPE string,
-           END OF ty_repo_config.
+    TYPES:
+      BEGIN OF ty_repo_config,
+        url      TYPE lcl_persistence_repo=>ty_repo-url,
+        login    TYPE string,
+        git_user TYPE ty_git_user,
+      END OF ty_repo_config.
+
     TYPES: ty_repo_config_tt TYPE STANDARD TABLE OF ty_repo_config WITH DEFAULT KEY.
 
-    TYPES: BEGIN OF ty_user,
-             username     TYPE string,
-             email        TYPE string,
-             repo_show    TYPE lcl_persistence_repo=>ty_repo-key,
-             repo_config  TYPE ty_repo_config_tt,
-             hide_files   TYPE abap_bool,
-             changes_only TYPE abap_bool,
-             diff_unified TYPE abap_bool,
-             favorites    TYPE tt_favorites,
-           END OF ty_user.
+    TYPES:
+      BEGIN OF ty_user,
+        default_git_user TYPE ty_git_user,
+        repo_show        TYPE lcl_persistence_repo=>ty_repo-key,
+        repo_config      TYPE ty_repo_config_tt,
+        hide_files       TYPE abap_bool,
+        changes_only     TYPE abap_bool,
+        diff_unified     TYPE abap_bool,
+        favorites        TYPE tt_favorites,
+      END OF ty_user.
 
     METHODS constructor
       IMPORTING iv_user TYPE xubname DEFAULT sy-uname.
@@ -576,39 +588,39 @@ CLASS lcl_persistence_user IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD set_username.
+  METHOD set_default_git_user_name.
 
     DATA: ls_user TYPE ty_user.
 
 
     ls_user = read( ).
 
-    ls_user-username = iv_username.
+    ls_user-default_git_user-name = iv_username.
 
     update( ls_user ).
 
   ENDMETHOD.
 
-  METHOD get_username.
+  METHOD get_default_git_user_name.
 
-    rv_username = read( )-username.
+    rv_username = read( )-default_git_user-name.
 
   ENDMETHOD.
 
-  METHOD set_email.
+  METHOD set_default_git_user_email.
 
     DATA: ls_user TYPE ty_user.
 
 
     ls_user = read( ).
-    ls_user-email = iv_email.
+    ls_user-default_git_user-email = iv_email.
     update( ls_user ).
 
   ENDMETHOD.
 
-  METHOD get_email.
+  METHOD get_default_git_user_email.
 
-    rv_email = read( )-email.
+    rv_email = read( )-default_git_user-email.
 
   ENDMETHOD.
 
@@ -641,35 +653,51 @@ CLASS lcl_persistence_user IMPLEMENTATION.
 
   ENDMETHOD.  "update_repo_config
 
-  METHOD set_repo_username.
+  METHOD set_repo_git_user_name.
 
     DATA: ls_repo_config TYPE ty_repo_config.
 
-    ls_repo_config          = read_repo_config( iv_url ).
-    ls_repo_config-username = iv_username.
+    ls_repo_config               = read_repo_config( iv_url ).
+    ls_repo_config-git_user-name = iv_username.
     update_repo_config( iv_url = iv_url is_repo_config = ls_repo_config ).
 
   ENDMETHOD.  "set_repo_username
 
-  METHOD get_repo_username.
+  METHOD get_repo_git_user_name.
 
-    rv_username = read_repo_config( iv_url )-username.
+    rv_username = read_repo_config( iv_url )-git_user-name.
 
   ENDMETHOD.  "get_repo_username
 
-  METHOD set_repo_email.
+  METHOD set_repo_login.
 
     DATA: ls_repo_config TYPE ty_repo_config.
 
     ls_repo_config       = read_repo_config( iv_url ).
-    ls_repo_config-email = iv_email.
+    ls_repo_config-login = iv_login.
+    update_repo_config( iv_url = iv_url is_repo_config = ls_repo_config ).
+
+  ENDMETHOD.  "set_repo_login
+
+  METHOD get_repo_login.
+
+    rv_login = read_repo_config( iv_url )-login.
+
+  ENDMETHOD.  "get_repo_login
+
+  METHOD set_repo_git_user_email.
+
+    DATA: ls_repo_config TYPE ty_repo_config.
+
+    ls_repo_config                = read_repo_config( iv_url ).
+    ls_repo_config-git_user-email = iv_email.
     update_repo_config( iv_url = iv_url is_repo_config = ls_repo_config ).
 
   ENDMETHOD.  "set_repo_email
 
-  METHOD get_repo_email.
+  METHOD get_repo_git_user_email.
 
-    rv_email = read_repo_config( iv_url )-email.
+    rv_email = read_repo_config( iv_url )-git_user-email.
 
   ENDMETHOD.  "get_repo_email
 
@@ -1238,8 +1266,8 @@ CLASS lcl_persistence_migrate IMPLEMENTATION.
     lt_users = lcl_user=>list( ).
     LOOP AT lt_users ASSIGNING <ls_user>.
       lo_user = lcl_app=>user( <ls_user>-user ).
-      lo_user->set_username( <ls_user>-username ).
-      lo_user->set_email( <ls_user>-email ).
+      lo_user->set_default_git_user_name( <ls_user>-username ).
+      lo_user->set_default_git_user_email( <ls_user>-email ).
     ENDLOOP.
 
   ENDMETHOD.

--- a/src/zabapgit_services_git.prog.abap
+++ b/src/zabapgit_services_git.prog.abap
@@ -6,11 +6,13 @@ CLASS lcl_services_git DEFINITION FINAL.
   PUBLIC SECTION.
 
     TYPES: BEGIN OF ty_commit_fields,
-             repo_key TYPE lcl_persistence_repo=>ty_repo-key,
-             username TYPE string,
-             email    TYPE string,
-             comment  TYPE string,
-             body     TYPE string,
+             repo_key        TYPE lcl_persistence_repo=>ty_repo-key,
+             committer_name  TYPE string,
+             committer_email TYPE string,
+             author_name     TYPE string,
+             author_email    TYPE string,
+             comment         TYPE string,
+             body            TYPE string,
            END OF ty_commit_fields.
 
     CLASS-METHODS pull
@@ -183,22 +185,26 @@ CLASS lcl_services_git IMPLEMENTATION.
           lo_user    TYPE REF TO lcl_persistence_user.
 
     lo_user = lcl_app=>user( ).
-    lo_user->set_repo_username( iv_url      = io_repo->get_url( )
-                                iv_username = is_commit-username ).
-    lo_user->set_repo_email(    iv_url      = io_repo->get_url( )
-                                iv_email    = is_commit-email ).
+    lo_user->set_repo_git_user_name( iv_url      = io_repo->get_url( )
+                                     iv_username = is_commit-committer_name ).
+    lo_user->set_repo_git_user_email( iv_url     = io_repo->get_url( )
+                                      iv_email   = is_commit-committer_email ).
 
-    IF is_commit-username IS INITIAL.
-      lcx_exception=>raise( 'Commit: empty username' ).
-    ELSEIF is_commit-email IS INITIAL.
-      lcx_exception=>raise( 'Commit: empty email' ).
+    IF is_commit-committer_name IS INITIAL.
+      lcx_exception=>raise( 'Commit: Committer name empty' ).
+    ELSEIF is_commit-committer_email IS INITIAL.
+      lcx_exception=>raise( 'Commit: Committer email empty' ).
+    ELSEIF is_commit-author_email IS NOT INITIAL AND is_commit-author_name IS INITIAL.
+      lcx_exception=>raise( 'Commit: Author email empty' ). " Opposite should be OK ?
     ELSEIF is_commit-comment IS INITIAL.
       lcx_exception=>raise( 'Commit: empty comment' ).
     ENDIF.
 
-    ls_comment-username = is_commit-username.
-    ls_comment-email    = is_commit-email.
-    ls_comment-comment  = is_commit-comment.
+    ls_comment-committer-name  = is_commit-committer_name.
+    ls_comment-committer-email = is_commit-committer_email.
+    ls_comment-author-name     = is_commit-author_name.
+    ls_comment-author-email    = is_commit-author_email.
+    ls_comment-comment         = is_commit-comment.
 
     IF NOT is_commit-body IS INITIAL.
       CONCATENATE ls_comment-comment '' is_commit-body


### PR DESCRIPTION
to #535

Some tech comments: I've done some refactoring on how the information is stored. In particular there is new type ty_git_user with name and email inside which kind of represent [user] section in `.git/config`. username / email fields in lcl_user_persistence and XMLs are replaced with this new structure. Which will cause the loss of stored logins/usernames/emails ... in my opinion it should be ok as easily returned back ... hope not too big price for internal clarity. login user is now called login.


