### PR TITLE
local dot abapgit state #630

### DIFF
--- a/src/zabapgit.prog.abap
+++ b/src/zabapgit.prog.abap
@@ -45,8 +45,8 @@ INCLUDE zabapgit_xml.
 
 INCLUDE zabapgit_app.              " Some deferred definitions here
 INCLUDE zabapgit_persistence_old.
-INCLUDE zabapgit_persistence.
 INCLUDE zabapgit_dot_abapgit.
+INCLUDE zabapgit_persistence.
 INCLUDE zabapgit_sap_package.
 INCLUDE zabapgit_folder_logic.
 

--- a/src/zabapgit_dot_abapgit.prog.abap
+++ b/src/zabapgit_dot_abapgit.prog.abap
@@ -4,7 +4,7 @@
 
 CLASS ltcl_dot_abapgit DEFINITION DEFERRED.
 
-CLASS lcl_dot_abapgit DEFINITION CREATE PRIVATE FINAL FRIENDS ltcl_dot_abapgit.
+CLASS lcl_dot_abapgit DEFINITION FINAL FRIENDS ltcl_dot_abapgit.
 
   PUBLIC SECTION.
     CONSTANTS: BEGIN OF c_folder_logic,
@@ -12,9 +12,15 @@ CLASS lcl_dot_abapgit DEFINITION CREATE PRIVATE FINAL FRIENDS ltcl_dot_abapgit.
                  full   TYPE string VALUE 'FULL',
                END OF c_folder_logic.
 
+    TYPES: BEGIN OF ty_dot_abapgit,
+             master_language TYPE spras,
+             starting_folder TYPE string,
+             folder_logic    TYPE string,
+             ignore          TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
+           END OF ty_dot_abapgit.
+
     CLASS-METHODS:
       build_default
-        IMPORTING iv_master_language    TYPE spras
         RETURNING VALUE(ro_dot_abapgit) TYPE REF TO lcl_dot_abapgit,
       deserialize
         IMPORTING iv_xstr               TYPE xstring
@@ -22,9 +28,13 @@ CLASS lcl_dot_abapgit DEFINITION CREATE PRIVATE FINAL FRIENDS ltcl_dot_abapgit.
         RAISING   lcx_exception.
 
     METHODS:
+      constructor
+        IMPORTING is_data TYPE ty_dot_abapgit,
       serialize
         RETURNING VALUE(rv_xstr) TYPE xstring
         RAISING   lcx_exception,
+      get_data
+        RETURNING VALUE(rs_data) TYPE ty_dot_abapgit,
       add_ignore
         IMPORTING iv_path     TYPE string
                   iv_filename TYPE string,
@@ -46,24 +56,13 @@ CLASS lcl_dot_abapgit DEFINITION CREATE PRIVATE FINAL FRIENDS ltcl_dot_abapgit.
       get_master_language
         RETURNING VALUE(rv_language) TYPE spras,
 *      set_master_language
-*        IMPORTING iv_language TYPE spras.
+*        IMPORTING iv_language TYPE spras,
       get_signature
         RETURNING VALUE(rs_signature) TYPE ty_file_signature
         RAISING   lcx_exception.
 
   PRIVATE SECTION.
-    TYPES: BEGIN OF ty_dot_abapgit,
-             master_language TYPE spras,
-             starting_folder TYPE string,
-             folder_logic    TYPE string,
-             ignore          TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
-           END OF ty_dot_abapgit.
-
     DATA: ms_data TYPE ty_dot_abapgit.
-
-    METHODS:
-      constructor
-        IMPORTING is_data TYPE ty_dot_abapgit.
 
     CLASS-METHODS:
       to_xml
@@ -113,7 +112,7 @@ CLASS lcl_dot_abapgit IMPLEMENTATION.
     DATA: ls_data TYPE ty_dot_abapgit.
 
 
-    ls_data-master_language = iv_master_language.
+    ls_data-master_language = sy-langu.
     ls_data-starting_folder = '/'.
     ls_data-folder_logic    = c_folder_logic-prefix.
 
@@ -127,6 +126,10 @@ CLASS lcl_dot_abapgit IMPLEMENTATION.
       EXPORTING
         is_data = ls_data.
 
+  ENDMETHOD.
+
+  METHOD get_data.
+    rs_data = ms_data.
   ENDMETHOD.
 
   METHOD to_xml.

--- a/src/zabapgit_folder_logic.prog.abap
+++ b/src/zabapgit_folder_logic.prog.abap
@@ -37,6 +37,9 @@ CLASS lcl_folder_logic IMPLEMENTATION.
 
 
     lv_length  = strlen( io_dot->get_starting_folder( ) ).
+    IF lv_length > strlen( lv_path ).
+      lcx_exception=>raise( 'unexpected folder structure' ).
+    ENDIF.
     lv_path    = iv_path+lv_length.
     lv_parent  = iv_top.
     rv_package = iv_top.
@@ -153,7 +156,7 @@ CLASS ltcl_folder_logic_helper IMPLEMENTATION.
           lo_dot     TYPE REF TO lcl_dot_abapgit.
 
 
-    lo_dot = lcl_dot_abapgit=>build_default( sy-langu ).
+    lo_dot = lcl_dot_abapgit=>build_default( ).
     lo_dot->set_starting_folder( iv_starting ).
     lo_dot->set_folder_logic( iv_logic ).
 

--- a/src/zabapgit_folder_logic.prog.abap
+++ b/src/zabapgit_folder_logic.prog.abap
@@ -37,7 +37,7 @@ CLASS lcl_folder_logic IMPLEMENTATION.
 
 
     lv_length  = strlen( io_dot->get_starting_folder( ) ).
-    IF lv_length > strlen( lv_path ).
+    IF lv_length > strlen( iv_path ).
       lcx_exception=>raise( 'unexpected folder structure' ).
     ENDIF.
     lv_path    = iv_path+lv_length.

--- a/src/zabapgit_objects.prog.abap
+++ b/src/zabapgit_objects.prog.abap
@@ -1111,7 +1111,7 @@ CLASS lcl_objects_program IMPLEMENTATION.
 * function module RPY_PROGRAM_INSERT cannot handle function group includes
 
       IF strlen( is_progdir-name ) > 30.
-        " special treatment for extenstions
+        " special treatment for extensions
         " if the program name exceeds 30 characters it is not a usual
         " ABAP program but might be some extension, which requires the internal
         " addition EXTENSION TYPE, see

--- a/src/zabapgit_repo.prog.abap
+++ b/src/zabapgit_repo.prog.abap
@@ -40,6 +40,9 @@ CLASS lcl_repo DEFINITION ABSTRACT FRIENDS lcl_repo_srv.
         RAISING lcx_exception,
       get_dot_abapgit
         RETURNING VALUE(ro_dot_abapgit) TYPE REF TO lcl_dot_abapgit,
+      set_dot_abapgit
+        IMPORTING io_dot_abapgit TYPE REF TO lcl_dot_abapgit
+        RAISING lcx_exception,
       deserialize
         RAISING lcx_exception,
       refresh
@@ -47,26 +50,25 @@ CLASS lcl_repo DEFINITION ABSTRACT FRIENDS lcl_repo_srv.
         RAISING lcx_exception,
       refresh_local, " For testing purposes, maybe removed later
       update_local_checksums
-        IMPORTING it_files            TYPE ty_file_signatures_tt
+        IMPORTING it_files TYPE ty_file_signatures_tt
         RAISING   lcx_exception,
       rebuild_local_checksums
         RAISING   lcx_exception,
+      find_remote_dot_abapgit
+        RETURNING VALUE(ro_dot) TYPE REF TO lcl_dot_abapgit
+        RAISING lcx_exception,
       is_offline
         RETURNING VALUE(rv_offline) TYPE abap_bool
         RAISING   lcx_exception.
 
   PROTECTED SECTION.
-
     DATA: mt_local              TYPE ty_files_item_tt,
           mt_remote             TYPE ty_files_tt,
-          mo_dot_abapgit        TYPE REF TO lcl_dot_abapgit,
           mv_do_local_refresh   TYPE abap_bool,
           mv_last_serialization TYPE timestamp,
           ms_data               TYPE lcl_persistence_repo=>ty_repo.
 
     METHODS:
-      find_dot_abapgit
-        RAISING lcx_exception,
       set
         IMPORTING iv_sha1        TYPE ty_sha1 OPTIONAL
                   it_checksums   TYPE lcl_persistence_repo=>ty_local_checksum_tt OPTIONAL
@@ -74,6 +76,7 @@ CLASS lcl_repo DEFINITION ABSTRACT FRIENDS lcl_repo_srv.
                   iv_branch_name TYPE lcl_persistence_repo=>ty_repo-branch_name OPTIONAL
                   iv_head_branch TYPE lcl_persistence_repo=>ty_repo-head_branch OPTIONAL
                   iv_offline     TYPE lcl_persistence_repo=>ty_repo-offline OPTIONAL
+                  is_dot_abapgit TYPE lcl_persistence_repo=>ty_repo-dot_abapgit OPTIONAL
         RAISING   lcx_exception.
 
 ENDCLASS.                    "lcl_repo DEFINITION

--- a/src/zabapgit_repo_browser_util.prog.abap
+++ b/src/zabapgit_repo_browser_util.prog.abap
@@ -184,7 +184,7 @@ CLASS lcl_repo_content_browser IMPLEMENTATION.
 * todo, offline projects should have an dot abapgit too
     lt_tadir = lcl_tadir=>read(
       iv_package = mo_repo->get_package( )
-      io_dot     = lcl_dot_abapgit=>build_default( sy-langu ) ).
+      io_dot     = lcl_dot_abapgit=>build_default( ) ).
 
     LOOP AT lt_tadir ASSIGNING <ls_tadir>.
       APPEND INITIAL LINE TO rt_repo_items ASSIGNING <ls_repo_item>.

--- a/src/zabapgit_stage.prog.abap
+++ b/src/zabapgit_stage.prog.abap
@@ -56,10 +56,10 @@ CLASS lcl_stage DEFINITION FINAL.
         IMPORTING iv_path     TYPE ty_file-path
                   iv_filename TYPE ty_file-filename
         RAISING   lcx_exception,
-*      lookup
-*        IMPORTING iv_path          TYPE ty_file-path
-*                  iv_filename      TYPE ty_file-filename
-*        RETURNING VALUE(rv_method) TYPE ty_method,
+      lookup
+        IMPORTING iv_path          TYPE ty_file-path
+                  iv_filename      TYPE ty_file-filename
+        RETURNING VALUE(rv_method) TYPE ty_method,
       get_merge_source
         RETURNING VALUE(rv_source) TYPE ty_sha1,
       count
@@ -103,19 +103,19 @@ CLASS lcl_stage IMPLEMENTATION.
     rv_branch = mv_branch_sha1.
   ENDMETHOD.
 
-*  METHOD lookup.
-*
-*    DATA ls_stage LIKE LINE OF mt_stage.
-*
-*
-*    READ TABLE mt_stage INTO ls_stage
-*      WITH KEY file-path     = iv_path
-*               file-filename = iv_filename.
-*    IF sy-subrc = 0.
-*      rv_method = ls_stage-method.
-*    ENDIF.
-*
-*  ENDMETHOD.        "lookup
+  METHOD lookup.
+
+    DATA ls_stage LIKE LINE OF mt_stage.
+
+
+    READ TABLE mt_stage INTO ls_stage
+      WITH KEY file-path     = iv_path
+               file-filename = iv_filename.
+    IF sy-subrc = 0.
+      rv_method = ls_stage-method.
+    ENDIF.
+
+  ENDMETHOD.        "lookup
 
   METHOD get_all.
     rt_stage = mt_stage.

--- a/src/zabapgit_transport.prog.abap
+++ b/src/zabapgit_transport.prog.abap
@@ -30,12 +30,13 @@ CLASS lcl_transport IMPLEMENTATION.
 
   METHOD zip.
 
-    DATA: lt_requests   TYPE trwbo_requests,
-          lt_tadir      TYPE scts_tadir,
-          lv_package    TYPE devclass,
-          ls_data       TYPE lcl_persistence_repo=>ty_repo,
-          lo_repo       TYPE REF TO lcl_repo_offline,
-          lt_trkorr TYPE trwbo_request_headers.
+    DATA: lt_requests TYPE trwbo_requests,
+          lt_tadir    TYPE scts_tadir,
+          lv_package  TYPE devclass,
+          ls_data     TYPE lcl_persistence_repo=>ty_repo,
+          lo_repo     TYPE REF TO lcl_repo_offline,
+          lt_trkorr   TYPE trwbo_request_headers.
+
 
     lt_trkorr = popup( ).
     IF lines( lt_trkorr ) = 0.
@@ -53,15 +54,15 @@ CLASS lcl_transport IMPLEMENTATION.
       lcx_exception=>raise( 'error finding super package' ).
     ENDIF.
 
-    ls_data-key             = 'TZIP'.
-    ls_data-package         = lv_package.
-    ls_data-master_language = sy-langu.
+    ls_data-key         = 'TZIP'.
+    ls_data-package     = lv_package.
+    ls_data-dot_abapgit = lcl_dot_abapgit=>build_default( )->get_data( ).
 
     CREATE OBJECT lo_repo
       EXPORTING
         is_data = ls_data.
 
-    lcl_zip=>export( io_repo = lo_repo
+    lcl_zip=>export( io_repo   = lo_repo
                      it_filter = lt_tadir ).
 
   ENDMETHOD.

--- a/src/zabapgit_unit_test.prog.abap
+++ b/src/zabapgit_unit_test.prog.abap
@@ -397,7 +397,7 @@ CLASS ltcl_dot_abapgit IMPLEMENTATION.
           ls_after  TYPE lcl_dot_abapgit=>ty_dot_abapgit.
 
 
-    lo_dot = lcl_dot_abapgit=>build_default( gc_english ).
+    lo_dot = lcl_dot_abapgit=>build_default( ).
     ls_before = lo_dot->ms_data.
 
     lo_dot = lcl_dot_abapgit=>deserialize( lo_dot->serialize( ) ).
@@ -418,7 +418,7 @@ CLASS ltcl_dot_abapgit IMPLEMENTATION.
           lo_dot     TYPE REF TO lcl_dot_abapgit.
 
 
-    lo_dot = lcl_dot_abapgit=>build_default( gc_english ).
+    lo_dot = lcl_dot_abapgit=>build_default( ).
 
     lv_ignored = lo_dot->is_ignored( iv_path = lc_path iv_filename = lc_filename ).
     cl_abap_unit_assert=>assert_equals(
@@ -1986,7 +1986,7 @@ CLASS ltcl_file_status2 IMPLEMENTATION.
 
     lcl_file_status=>run_checks( io_log     = lo_log
                                  it_results = lt_results
-                                 io_dot     = lcl_dot_abapgit=>build_default( sy-langu )
+                                 io_dot     = lcl_dot_abapgit=>build_default( )
                                  iv_top     = '$Z$' ).
 
     assert_equals( act = lo_log->count( ) exp = 0 ).
@@ -2004,7 +2004,7 @@ CLASS ltcl_file_status2 IMPLEMENTATION.
 
     lcl_file_status=>run_checks( io_log     = lo_log
                                  it_results = lt_results
-                                 io_dot     = lcl_dot_abapgit=>build_default( sy-langu )
+                                 io_dot     = lcl_dot_abapgit=>build_default( )
                                  iv_top     = '$Z$' ).
 
     " This one is not pure - incorrect path also triggers path vs package check
@@ -2024,7 +2024,7 @@ CLASS ltcl_file_status2 IMPLEMENTATION.
 
     lcl_file_status=>run_checks( io_log     = lo_log
                                  it_results = lt_results
-                                 io_dot     = lcl_dot_abapgit=>build_default( sy-langu )
+                                 io_dot     = lcl_dot_abapgit=>build_default( )
                                  iv_top     = '$Z$' ).
 
     assert_equals( act = lo_log->count( ) exp = 1 ).
@@ -2043,7 +2043,7 @@ CLASS ltcl_file_status2 IMPLEMENTATION.
 
     lcl_file_status=>run_checks( io_log     = lo_log
                                  it_results = lt_results
-                                 io_dot     = lcl_dot_abapgit=>build_default( sy-langu )
+                                 io_dot     = lcl_dot_abapgit=>build_default( )
                                  iv_top     = '$Z$' ).
 
     assert_equals( act = lo_log->count( ) exp = 1 ).
@@ -2061,7 +2061,7 @@ CLASS ltcl_file_status2 IMPLEMENTATION.
 
     lcl_file_status=>run_checks( io_log     = lo_log
                                  it_results = lt_results
-                                 io_dot     = lcl_dot_abapgit=>build_default( sy-langu )
+                                 io_dot     = lcl_dot_abapgit=>build_default( )
                                  iv_top     = '$Z$' ).
 
     assert_equals( act = lo_log->count( )

--- a/src/zabapgit_zip.prog.abap
+++ b/src/zabapgit_zip.prog.abap
@@ -432,13 +432,14 @@ CLASS lcl_zip IMPLEMENTATION.
     DATA: lo_repo TYPE REF TO lcl_repo_offline,
           ls_data TYPE lcl_persistence_repo=>ty_repo.
 
+
     ls_data-package = lcl_popups=>popup_package_export( ).
     IF ls_data-package IS INITIAL.
       RAISE EXCEPTION TYPE lcx_cancel.
     ENDIF.
 
-    ls_data-key             = 'DUMMY'.
-    ls_data-master_language = sy-langu.
+    ls_data-key = 'DUMMY'.
+    ls_data-dot_abapgit = lcl_dot_abapgit=>build_default( )->get_data( ).
 
     CREATE OBJECT lo_repo
       EXPORTING


### PR DESCRIPTION
fixes https://github.com/larshp/abapGit/issues/630 local .abapgit.xml state, including migration so all repositories are migrated automatically

Tested following ok:
* create new offline
* clone online
* create new empty online
* export package to zip
* export files to zip
* online project staging, add ignore file
* migration of online project
* migration of offline project
* offline import zip -> set dot abapgit
* update local abapgit on pull

after this is merged then https://github.com/larshp/abapGit/issues/227 can be started