### PR TITLE
refactor lcl_log->add

### DIFF
--- a/src/zabapgit_file_status.prog.abap
+++ b/src/zabapgit_file_status.prog.abap
@@ -23,17 +23,17 @@ CLASS lcl_file_status DEFINITION FINAL
 
     CLASS-METHODS:
       calculate_status
-        IMPORTING iv_devclass        TYPE devclass
-                  it_local           TYPE ty_files_item_tt
-                  it_remote          TYPE ty_files_tt
-                  it_cur_state       TYPE ty_file_signatures_tt
-        RETURNING VALUE(rt_results)  TYPE ty_results_tt,
+        IMPORTING iv_devclass       TYPE devclass
+                  it_local          TYPE ty_files_item_tt
+                  it_remote         TYPE ty_files_tt
+                  it_cur_state      TYPE ty_file_signatures_tt
+        RETURNING VALUE(rt_results) TYPE ty_results_tt,
       run_checks
         IMPORTING io_log     TYPE REF TO lcl_log
                   it_results TYPE ty_results_tt
                   io_dot     TYPE REF TO lcl_dot_abapgit
                   iv_top     TYPE devclass
-        RAISING lcx_exception,
+        RAISING   lcx_exception,
       build_existing
         IMPORTING is_local         TYPE ty_file_item
                   is_remote        TYPE ty_file
@@ -49,9 +49,9 @@ CLASS lcl_file_status DEFINITION FINAL
                   it_state         TYPE ty_file_signatures_ts
         RETURNING VALUE(rs_result) TYPE ty_result,
       identify_object
-        IMPORTING iv_filename      TYPE string
-        EXPORTING es_item          TYPE ty_item
-                  ev_is_xml        TYPE abap_bool.
+        IMPORTING iv_filename TYPE string
+        EXPORTING es_item     TYPE ty_item
+                  ev_is_xml   TYPE abap_bool.
 
 ENDCLASS.                    "lcl_file_status DEFINITION
 
@@ -99,11 +99,9 @@ CLASS lcl_file_status IMPLEMENTATION.
         BINARY SEARCH. " Sorted above
 
       IF sy-subrc <> 0 OR <ls_res1>-path <> <ls_res2>-path. " All paths are same
-        io_log->add( iv_msgv1 = 'Files for object'
-                     iv_msgv2 = <ls_res1>-obj_type
-                     iv_msgv3 = <ls_res1>-obj_name
-                     iv_msgv4 = 'are not placed in the same folder'
-                     iv_msgty = 'W'
+        io_log->add( iv_msg = |Files for object { <ls_res1>-obj_type }{
+                       <ls_res1>-obj_name }are not placed in the same folder|
+                     iv_type = 'W'
                      iv_rc    = '1' ) ##no_text.
       ENDIF.
     ENDLOOP.
@@ -115,10 +113,9 @@ CLASS lcl_file_status IMPLEMENTATION.
                                                    io_dot     = io_dot
                                                    iv_package = <ls_res1>-package ).
       IF lv_path <> <ls_res1>-path.
-        io_log->add( iv_msgv1 = 'Package and path does not match for object,'
-                     iv_msgv2 = <ls_res1>-obj_type
-                     iv_msgv3 = <ls_res1>-obj_name
-                     iv_msgty = 'W'
+        io_log->add( iv_msg = |Package and path does not match for object, {
+                       <ls_res1>-obj_type } { <ls_res1>-obj_name }|
+                     iv_type = 'W'
                      iv_rc    = '2' ) ##no_text.
       ENDIF.
     ENDLOOP.
@@ -128,18 +125,15 @@ CLASS lcl_file_status IMPLEMENTATION.
 
     LOOP AT lt_res_sort ASSIGNING <ls_res1>.
       IF <ls_res1>-filename IS NOT INITIAL AND <ls_res1>-filename = ls_file-filename.
-        io_log->add( iv_msgv1 = 'Multiple files with same filename,'
-                     iv_msgv2 = <ls_res1>-filename
-                     iv_msgty = 'W'
-                     iv_rc    = '3' ) ##no_text.
+        io_log->add( iv_msg  = |Multiple files with same filename, { <ls_res1>-filename }|
+                     iv_type = 'W'
+                     iv_rc   = '3' ) ##no_text.
       ENDIF.
 
       IF <ls_res1>-filename IS INITIAL.
-        io_log->add( iv_msgv1 = 'Filename is empty for object'
-                     iv_msgv2 = <ls_res1>-obj_type
-                     iv_msgv3 = <ls_res1>-obj_name
-                     iv_msgty = 'W'
-                     iv_rc    = '4' ) ##no_text.
+        io_log->add( iv_msg  = |Filename is empty for object { <ls_res1>-obj_type } { <ls_res1>-obj_name }|
+                     iv_type = 'W'
+                     iv_rc   = '4' ) ##no_text.
       ENDIF.
 
       MOVE-CORRESPONDING <ls_res1> TO ls_file.
@@ -258,9 +252,9 @@ CLASS lcl_file_status IMPLEMENTATION.
 
   METHOD identify_object.
 
-    DATA: lv_name   TYPE tadir-obj_name,
-          lv_type   TYPE string,
-          lv_ext    TYPE string.
+    DATA: lv_name TYPE tadir-obj_name,
+          lv_type TYPE string,
+          lv_ext  TYPE string.
 
     " Guess object type and name
     SPLIT to_upper( iv_filename ) AT '.' INTO lv_name lv_type lv_ext.

--- a/src/zabapgit_objects_impl.prog.abap
+++ b/src/zabapgit_objects_impl.prog.abap
@@ -481,11 +481,9 @@ CLASS lcl_objects IMPLEMENTATION.
 
     IF is_supported( is_item ) = abap_false.
       IF NOT io_log IS INITIAL.
-        io_log->add( iv_msgv1 = 'Object type ignored, not supported:'
-                     iv_msgv2 = is_item-obj_type
-                     iv_msgv3 = '-'
-                     iv_msgty = 'E'
-                     iv_msgv4 = is_item-obj_name ) ##no_text.
+        io_log->add( iv_msg = |Object type ignored, not supported: { is_item-obj_type
+                       }-{ is_item-obj_name }|
+                     iv_type = 'E' ).
       ENDIF.
       RETURN.
     ENDIF.

--- a/src/zabapgit_util.prog.abap
+++ b/src/zabapgit_util.prog.abap
@@ -444,7 +444,7 @@ CLASS lcl_path IMPLEMENTATION.
           lv_index TYPE i,
           lt_split TYPE TABLE OF string.
 
-" filename | c:\filename | /dir/filename | \\server\filename
+    " filename | c:\filename | /dir/filename | \\server\filename
     IF iv_path CA '/'.
       lv_split = '/'.
     ELSE.
@@ -1051,12 +1051,9 @@ CLASS lcl_log DEFINITION FINAL.
     METHODS:
       add
         IMPORTING
-          iv_msgv1 TYPE csequence
-          iv_msgv2 TYPE csequence OPTIONAL
-          iv_msgv3 TYPE csequence OPTIONAL
-          iv_msgv4 TYPE csequence OPTIONAL
-          iv_msgty TYPE symsgty   DEFAULT 'E'
-          iv_rc    TYPE balsort   OPTIONAL,
+          iv_msg  TYPE csequence
+          iv_type TYPE symsgty   DEFAULT 'E'
+          iv_rc   TYPE balsort   OPTIONAL,
       count
         RETURNING VALUE(rv_count) TYPE i,
       to_html
@@ -1068,7 +1065,13 @@ CLASS lcl_log DEFINITION FINAL.
       show.
 
   PRIVATE SECTION.
-    DATA: mt_log TYPE rs_t_msg.
+    TYPES: BEGIN OF ty_log,
+             msg  TYPE string,
+             type TYPE symsgty,
+             rc   TYPE balsort,
+           END OF ty_log.
+
+    DATA: mt_log TYPE STANDARD TABLE OF ty_log WITH DEFAULT KEY.
 
 ENDCLASS.
 
@@ -1076,9 +1079,8 @@ CLASS lcl_log IMPLEMENTATION.
 
   METHOD to_html.
 
-    DATA: lv_class  TYPE string,
-          lv_icon   TYPE string,
-          lv_string TYPE string.
+    DATA: lv_class TYPE string,
+          lv_icon  TYPE string.
 
     FIELD-SYMBOLS: <ls_log> LIKE LINE OF mt_log.
 
@@ -1089,7 +1091,7 @@ CLASS lcl_log IMPLEMENTATION.
     ENDIF.
 
     LOOP AT mt_log ASSIGNING <ls_log>.
-      CASE <ls_log>-msgty.
+      CASE <ls_log>-type.
         WHEN 'W'.
           lv_icon  = 'alert'.
           lv_class = 'warning'.
@@ -1101,12 +1103,9 @@ CLASS lcl_log IMPLEMENTATION.
           lv_class = 'error'.
       ENDCASE.
 
-      CONCATENATE <ls_log>-msgv1 <ls_log>-msgv2 <ls_log>-msgv3 <ls_log>-msgv4
-        INTO lv_string SEPARATED BY space.
-
       ro_html->add( |<span class="{ lv_class }">| ).
       ro_html->add_icon( iv_name = lv_icon ).
-      ro_html->add( lv_string ).
+      ro_html->add( <ls_log>-msg ).
       ro_html->add( '</span>' ).
     ENDLOOP.
 
@@ -1117,26 +1116,35 @@ CLASS lcl_log IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_log> LIKE LINE OF mt_log.
 
     APPEND INITIAL LINE TO mt_log ASSIGNING <ls_log>.
-    <ls_log>-msgty  = iv_msgty. " Error by default
-    <ls_log>-msgid  = '00'.
-    <ls_log>-msgno  = '001'.
-    <ls_log>-msgv1  = iv_msgv1.
-    <ls_log>-msgv2  = iv_msgv2.
-    <ls_log>-msgv3  = iv_msgv3.
-    <ls_log>-msgv4  = iv_msgv4.
-    <ls_log>-alsort = iv_rc. " Error code for unit test, not sure about better field
+    <ls_log>-msg  = iv_msg.
+    <ls_log>-type = iv_type.
+    <ls_log>-rc   = iv_rc.
 
   ENDMETHOD.
 
   METHOD show.
-    CALL FUNCTION 'RSDC_SHOW_MESSAGES_POPUP'
+* only supports showing 4 errors, but I guess this is okay
+* alternatively refactor to use method TO_HTML instead
+
+    DATA: ls_log1 LIKE LINE OF mt_log,
+          ls_log2 LIKE LINE OF mt_log,
+          ls_log3 LIKE LINE OF mt_log,
+          ls_log4 LIKE LINE OF mt_log.
+
+
+    READ TABLE mt_log INDEX 1 INTO ls_log1.
+    READ TABLE mt_log INDEX 1 INTO ls_log2.
+    READ TABLE mt_log INDEX 1 INTO ls_log3.
+    READ TABLE mt_log INDEX 1 INTO ls_log4.
+
+    CALL FUNCTION 'POPUP_TO_INFORM'
       EXPORTING
-        i_t_msg           = mt_log
-        i_txt             = 'Warning'
-        i_with_s_on_empty = abap_false
-        i_one_msg_direct  = abap_false
-        i_one_msg_type_s  = abap_false
-        ##no_text.
+        titel = 'Log'
+        txt1  = ls_log1-msg
+        txt2  = ls_log2-msg
+        txt3  = ls_log3-msg
+        txt4  = ls_log4-msg.
+
   ENDMETHOD.
 
   METHOD count.
@@ -1148,7 +1156,7 @@ CLASS lcl_log IMPLEMENTATION.
   ENDMETHOD.  " clear.
 
   METHOD has_rc.
-    READ TABLE mt_log WITH KEY alsort = iv_rc TRANSPORTING NO FIELDS.
+    READ TABLE mt_log WITH KEY rc = iv_rc TRANSPORTING NO FIELDS.
     rv_yes = boolc( sy-subrc = 0 ).
   ENDMETHOD. "has_rc
 


### PR DESCRIPTION
issue #653 

logging changed from 

```abap
       io_log->add( iv_msgv1 = 'Object type ignored, not supported:'
                     iv_msgv2 = is_item-obj_type
                     iv_msgv3 = '-'
                     iv_msgty = 'E'
                     iv_msgv4 = is_item-obj_name ) ##no_text.
```
to
```abap
        io_log->add( iv_msg = |Object type ignored, not supported: { is_item-obj_type
                       }-{ is_item-obj_name }|
                     iv_type = 'E' ).
```

next step could be to add a `add_error` method so the iv_type parameter is not needed, but anyhow, the logging functionality is not used very much