### PR TITLE
72 characters commit body

### DIFF
--- a/src/zabapgit_page_commit.prog.abap
+++ b/src/zabapgit_page_commit.prog.abap
@@ -193,7 +193,7 @@ CLASS lcl_gui_page_commit IMPLEMENTATION.
 
     ro_html->add( render_text_input( iv_name       = 'comment'
                                      iv_label      = 'comment'
-                                     iv_max_length = '50' ) ).
+                                     iv_max_length = '72' ) ).
 
     ro_html->add( '<div class="row">' ).
     ro_html->add( '<label for="c-body">body</label>' ).


### PR DESCRIPTION
Commit body should wrap at 72 characters as noted in: https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project

found bug while looking through code regarding https://github.com/larshp/abapGit/issues/648