### PR TITLE
Adding Slack badge to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/larshp/abapGit.svg?branch=master)](https://travis-ci.org/larshp/abapGit)
 [![abaplint](http://abaplint.org/badges/larshp/abapGit)](http://abaplint.org/project/larshp/abapGit)
+[![Slack](https://abapgit-slackinviter.herokuapp.com/badge.svg)](https://abapgit-slackinviter.herokuapp.com/)
 
 # abapGit #
 


### PR DESCRIPTION
I deployed a small app on https://abapgit-slackinviter.herokuapp.com/ that allows for people to easily join the abapGit slack. It also has a small badge that we can use in the README.md file.