### PR TITLE
migrations: skip repos that cannot be fetched

### DIFF
--- a/src/zabapgit_migrations.prog.abap
+++ b/src/zabapgit_migrations.prog.abap
@@ -35,7 +35,8 @@ CLASS lcl_migrations IMPLEMENTATION.
 
     DATA: lt_repos       TYPE lcl_repo_srv=>ty_repo_tt,
           lv_shown       TYPE abap_bool,
-          lo_dot_abapgit TYPE REF TO lcl_dot_abapgit.
+          lo_dot_abapgit TYPE REF TO lcl_dot_abapgit,
+          lx_exception   TYPE REF TO lcx_exception.
 
     FIELD-SYMBOLS: <lo_repo> LIKE LINE OF lt_repos.
 
@@ -56,7 +57,23 @@ CLASS lcl_migrations IMPLEMENTATION.
                 txt2  = 'Login to remote repositories if needed'.
             lv_shown = abap_true.
           ENDIF.
-          <lo_repo>->refresh( ).
+
+          " Skip repos that cannot be fetched.
+          " Particuarly useful on systems where users do not allow
+          " everybody to fetch their repos.
+          TRY.
+              <lo_repo>->refresh( ).
+            CATCH lcx_exception INTO lx_exception.
+              CALL FUNCTION 'POPUP_TO_INFORM'
+                EXPORTING
+                  titel = 'Migration has failed'
+                  txt1  = lx_exception->mv_text
+                  txt2  = 'Please do not use the ''' && <lo_repo>->get_name( ) && ''' repository until migrated.'
+                  txt3  = 'You will be prompted to migrate the repository every time you run abapGit.'
+                  txt4  = 'You can safely remove the repository in its ''Advanced -> Remove'' menu.'.
+              CONTINUE.
+          ENDTRY.
+
           lo_dot_abapgit = <lo_repo>->find_remote_dot_abapgit( ).
           IF lo_dot_abapgit IS INITIAL.
 * .abapgit.xml is not in the remote repo yet


### PR DESCRIPTION
On systems where users do not allow everybody to fetch their repo, you need to
be able skip certain repos.

Currently, if you cannot authorize yourself to read a migrated repo, abapGit
exits.

With this patch applied, failed authorization attempts are notified to the user
and the repo is skipped.

Signed-off-by: Jakub Filak <jakub.filak@sap.com>