### PR TITLE
toc css fix (conflicts between line height and sup tag)

### DIFF
--- a/src/zabapgit_css_common.w3mi.data.css
+++ b/src/zabapgit_css_common.w3mi.data.css
@@ -24,7 +24,7 @@ img               { border: 0px; vertical-align: middle; }
 table             { border-collapse: collapse; }
 pre               { display: inline; }
 sup {
-  vertical-align: baseline;
+  vertical-align: top;
   position: relative;
   top: -0.5em;
   font-size: 75%;


### PR DESCRIPTION
Seems that BG issue in toc was not completely resolved. Now it works better (at least in my case). Although the issue is a bit misterious for me ...

Before fix:
![2017-04-08_09h35_51](https://cloud.githubusercontent.com/assets/15635498/24826467/99980e8a-1c3f-11e7-9e14-7a223cfc3612.png)
