### PR TITLE
Refactored jump to ADT to common method jump_adt

### DIFF
--- a/src/zabapgit_object_dcls.prog.abap
+++ b/src/zabapgit_object_dcls.prog.abap
@@ -50,43 +50,11 @@ CLASS lcl_object_dcls IMPLEMENTATION.
 
   METHOD lif_object~jump.
 
-    DATA: adt_link          TYPE string,
-          obj_name          TYPE e071-obj_name,
-          li_object         TYPE REF TO cl_wb_object,
-          li_adt            TYPE REF TO object,
-          li_adt_uri_mapper TYPE REF TO object,
-          li_adt_objref     TYPE REF TO object.
-
-    FIELD-SYMBOLS: <uri> TYPE string.
-
     TRY.
 
-        obj_name = ms_item-obj_name.
+        jump_adt( ).
 
-        li_object = cl_wb_object=>create_from_transport_key( p_object = ms_item-obj_type p_obj_name = obj_name ).
-
-        CALL METHOD ('CL_ADT_TOOLS_CORE_FACTORY')=>('GET_INSTANCE')
-          RECEIVING
-            result = li_adt.
-
-        CALL METHOD li_adt->('IF_ADT_TOOLS_CORE_FACTORY~GET_URI_MAPPER')
-          RECEIVING
-            result = li_adt_uri_mapper.
-
-        CALL METHOD li_adt_uri_mapper->('IF_ADT_URI_MAPPER~MAP_WB_OBJECT_TO_OBJREF')
-          EXPORTING
-            wb_object = li_object
-          RECEIVING
-            result    = li_adt_objref.
-
-        ASSIGN ('li_adt_objref->ref_data-uri') TO <uri>.
-
-        CONCATENATE 'adt://' sy-sysid <uri> INTO adt_link.
-
-        cl_gui_frontend_services=>execute( EXPORTING  document = adt_link
-                                           EXCEPTIONS OTHERS   = 1 ).
-
-      CATCH cx_root.
+      CATCH lcx_exception.
         lcx_exception=>raise( 'DCLS Jump Error' ).
     ENDTRY.
 

--- a/src/zabapgit_object_ddls.prog.abap
+++ b/src/zabapgit_object_ddls.prog.abap
@@ -212,7 +212,6 @@ CLASS lcl_object_ddls IMPLEMENTATION.
 
   METHOD open_adt_stob.
 
-    .
     DATA: lr_data                   TYPE REF TO data.
     DATA: li_ddl                    TYPE REF TO object.
     FIELD-SYMBOLS: <lt_ddnames>     TYPE STANDARD TABLE.

--- a/src/zabapgit_object_ddls.prog.abap
+++ b/src/zabapgit_object_ddls.prog.abap
@@ -212,12 +212,7 @@ CLASS lcl_object_ddls IMPLEMENTATION.
 
   METHOD open_adt_stob.
 
-    DATA: lv_adt_link               TYPE string.
-    DATA: lv_obj_name               TYPE e071-obj_name.
-    DATA: li_object                 TYPE REF TO cl_wb_object.
-    DATA: li_adt                    TYPE REF TO object.
-    DATA: li_adt_uri_mapper         TYPE REF TO object.
-    DATA: li_adt_objref             TYPE REF TO object.
+    .
     DATA: lr_data                   TYPE REF TO data.
     DATA: li_ddl                    TYPE REF TO object.
     FIELD-SYMBOLS: <lt_ddnames>     TYPE STANDARD TABLE.
@@ -226,8 +221,6 @@ CLASS lcl_object_ddls IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_entity_view> TYPE any.
     FIELD-SYMBOLS: <lv_ddname>      TYPE any.
     FIELD-SYMBOLS: <lv_ddlname>     TYPE any.
-    FIELD-SYMBOLS: <ls_uri>         TYPE string.
-
     TRY.
 
         CREATE DATA lr_data TYPE ('IF_DD_DDL_TYPES=>TY_T_DDOBJ').
@@ -247,8 +240,6 @@ CLASS lcl_object_ddls IMPLEMENTATION.
         <lv_ddname> = iv_ddls_name.
         INSERT <ls_ddnames> INTO TABLE <lt_ddnames>.
 
-
-
         CALL METHOD ('CL_DD_DDL_HANDLER_FACTORY')=>('CREATE')
           RECEIVING
             handler = li_ddl.
@@ -263,30 +254,8 @@ CLASS lcl_object_ddls IMPLEMENTATION.
         IF sy-subrc = 0.
           ASSIGN COMPONENT 'DDLNAME' OF STRUCTURE <ls_entity_view> TO <lv_ddlname>.
 
-          lv_obj_name = <lv_ddlname>.
-
-          li_object = cl_wb_object=>create_from_transport_key( p_object = 'DDLS' p_obj_name = lv_obj_name ).
-
-          CALL METHOD ('CL_ADT_TOOLS_CORE_FACTORY')=>('GET_INSTANCE')
-            RECEIVING
-              result = li_adt.
-
-          CALL METHOD LI_ADT->('IF_ADT_TOOLS_CORE_FACTORY~GET_URI_MAPPER')
-            RECEIVING
-              result = li_adt_uri_mapper.
-
-          CALL METHOD li_adt_uri_mapper->('IF_ADT_URI_MAPPER~MAP_WB_OBJECT_TO_OBJREF')
-            EXPORTING
-              wb_object = li_object
-            RECEIVING
-              result    = li_adt_objref.
-
-          ASSIGN ('li_adt_objref->ref_data-uri') TO <ls_uri>.
-
-          CONCATENATE 'adt://' sy-sysid <ls_uri> INTO lv_adt_link.
-
-          cl_gui_frontend_services=>execute( EXPORTING  document = lv_adt_link
-                                             EXCEPTIONS OTHERS   = 1 ).
+          jump_adt( i_obj_name = <lv_ddlname>
+                    i_obj_type = 'DDLS' ).
 
         ENDIF.
 

--- a/src/zabapgit_objects.prog.abap
+++ b/src/zabapgit_objects.prog.abap
@@ -1642,8 +1642,7 @@ CLASS lcl_objects_super IMPLEMENTATION.
     ENDIF.
 
     TRY.
-        li_object = cl_wb_object=>create_from_transport_key( p_object 	= obj_type
-                                                             p_obj_name = obj_name ).
+        li_object = cl_wb_object=>create_from_transport_key( p_object = obj_type p_obj_name = obj_name ).
 
         CALL METHOD ('CL_ADT_TOOLS_CORE_FACTORY')=>('GET_INSTANCE')
           RECEIVING

--- a/src/zabapgit_objects.prog.abap
+++ b/src/zabapgit_objects.prog.abap
@@ -576,6 +576,10 @@ CLASS lcl_objects_super DEFINITION ABSTRACT.
       jump_se11
         IMPORTING iv_radio TYPE string
                   iv_field TYPE string
+        RAISING   lcx_exception,
+      jump_adt
+        IMPORTING i_obj_name like ms_item-obj_name OPTIONAL
+                  i_obj_type like ms_item-obj_type OPTIONAL
         RAISING   lcx_exception.
 
 ENDCLASS.                    "lcl_objects_super DEFINITION
@@ -1612,6 +1616,66 @@ CLASS lcl_objects_super IMPLEMENTATION.
         ##fm_subrc_ok.                                                   "#EC CI_SUBRC
 
   ENDMETHOD.                                                "jump_se11
+
+  METHOD jump_adt.
+
+    DATA: adt_link          TYPE string,
+          obj_type          TYPE trobjtype,
+          obj_name          TYPE trobj_name,
+          li_object         TYPE REF TO cl_wb_object,
+          li_adt            TYPE REF TO object,
+          li_adt_uri_mapper TYPE REF TO object,
+          li_adt_objref     TYPE REF TO object.
+
+    FIELD-SYMBOLS: <uri> TYPE string.
+
+    IF i_obj_name IS SUPPLIED.
+      obj_name = i_obj_name.
+    ELSE.
+      obj_name = ms_item-obj_name.
+    ENDIF.
+
+    IF i_obj_type IS SUPPLIED.
+      obj_type = i_obj_type.
+    ELSE.
+      obj_type = ms_item-obj_type.
+    ENDIF.
+
+    TRY.
+        li_object = cl_wb_object=>create_from_transport_key( p_object 	= obj_type
+                                                             p_obj_name = obj_name ).
+
+        CALL METHOD ('CL_ADT_TOOLS_CORE_FACTORY')=>('GET_INSTANCE')
+          RECEIVING
+            result = li_adt.
+
+        CALL METHOD li_adt->('IF_ADT_TOOLS_CORE_FACTORY~GET_URI_MAPPER')
+          RECEIVING
+            result = li_adt_uri_mapper.
+
+        CALL METHOD li_adt_uri_mapper->('IF_ADT_URI_MAPPER~MAP_WB_OBJECT_TO_OBJREF')
+          EXPORTING
+            wb_object = li_object
+          RECEIVING
+            result    = li_adt_objref.
+
+        ASSIGN ('li_adt_objref->ref_data-uri') TO <uri>.
+
+        CONCATENATE 'adt://' sy-sysid <uri> INTO adt_link.
+
+        cl_gui_frontend_services=>execute( EXPORTING  document = adt_link
+                                           EXCEPTIONS OTHERS   = 1 ).
+
+        IF sy-subrc <> 0.
+          lcx_exception=>raise( 'ADT Jump Error' ).
+        ENDIF.
+
+      CATCH cx_root.
+        lcx_exception=>raise( 'ADT Jump Error' ).
+    ENDTRY.
+
+  ENDMETHOD.
+
 
   METHOD get_metadata.
     rs_metadata-class =


### PR DESCRIPTION
The jump to ADT functionality for DDLS and DCLS are quite similar. Therefore I refactored them to the common superclass lcl_objects_super. The new method jump_adt can now also be used by other object types.