### PR TITLE
New Parameter for Commit Message Length - #648

### DIFF
--- a/src/zabapgit_definitions.prog.abap
+++ b/src/zabapgit_definitions.prog.abap
@@ -21,7 +21,7 @@ TYPES: ty_file_signatures_ts TYPE SORTED TABLE OF
          ty_file_signature WITH UNIQUE KEY path filename.
 
 TYPES: BEGIN OF ty_file.
-    INCLUDE TYPE ty_file_signature.
+        INCLUDE TYPE ty_file_signature.
 TYPES: data TYPE xstring,
        END OF ty_file.
 TYPES: ty_files_tt TYPE STANDARD TABLE OF ty_file WITH DEFAULT KEY.
@@ -127,7 +127,7 @@ TYPES: ty_sval_tt TYPE STANDARD TABLE OF sval WITH DEFAULT KEY.
 TYPES: ty_seocompotx_tt TYPE STANDARD TABLE OF seocompotx WITH DEFAULT KEY.
 
 TYPES: BEGIN OF ty_tpool.
-    INCLUDE TYPE textpool.
+        INCLUDE TYPE textpool.
 TYPES:   split TYPE c LENGTH 8.
 TYPES: END OF ty_tpool.
 
@@ -185,6 +185,7 @@ CONSTANTS: BEGIN OF gc_action_type,
              dummy     TYPE c VALUE '_',
            END OF gc_action_type.
 
+CONSTANTS: gc_crlf    TYPE abap_cr_lf VALUE cl_abap_char_utilities=>cr_lf.
 CONSTANTS: gc_newline TYPE abap_char1 VALUE cl_abap_char_utilities=>newline.
 
 CONSTANTS: gc_english TYPE spras VALUE 'E'.

--- a/src/zabapgit_html_action_utils.prog.abap
+++ b/src/zabapgit_html_action_utils.prog.abap
@@ -302,6 +302,7 @@ CLASS lcl_html_action_utils IMPLEMENTATION.
     CLEAR es_fields.
 
     CONCATENATE LINES OF it_postdata INTO lv_string.
+    REPLACE ALL OCCURRENCES OF gc_crlf    IN lv_string WITH lc_replace.
     REPLACE ALL OCCURRENCES OF gc_newline IN lv_string WITH lc_replace.
     lt_fields = parse_fields( lv_string ).
 

--- a/src/zabapgit_page_commit.prog.abap
+++ b/src/zabapgit_page_commit.prog.abap
@@ -202,7 +202,8 @@ CLASS lcl_gui_page_commit IMPLEMENTATION.
     ro_html->add( '<div class="row">' ).
     ro_html->add( '<label for="c-body">body</label>' ).
 
-    ro_html->add( |<textarea id="c-body" name="body" rows="10" cols="{ lo_settings->get_commitmsg_body_size( ) }" wrap="hard"></textarea>| ).
+    ro_html->add( |<textarea id="c-body" name="body" rows="10" cols="| &&
+                  |{ lo_settings->get_commitmsg_body_size( ) }" wrap="hard"></textarea>| ).
     ro_html->add( '<input type="submit" class="hidden-submit">' ).
     ro_html->add( '</div>' ).
 

--- a/src/zabapgit_page_commit.prog.abap
+++ b/src/zabapgit_page_commit.prog.abap
@@ -37,10 +37,10 @@ CLASS lcl_gui_page_commit DEFINITION FINAL INHERITING FROM lcl_gui_page.
         RETURNING VALUE(ro_html) TYPE REF TO lcl_html
         RAISING   lcx_exception,
       render_text_input
-        IMPORTING iv_name       TYPE string
-                  iv_label      TYPE string
-                  iv_value      TYPE string OPTIONAL
-                  iv_max_length TYPE string OPTIONAL
+        IMPORTING iv_name        TYPE string
+                  iv_label       TYPE string
+                  iv_value       TYPE string OPTIONAL
+                  iv_max_length  TYPE string OPTIONAL
         RETURNING VALUE(ro_html) TYPE REF TO lcl_html.
 
 ENDCLASS.
@@ -155,11 +155,14 @@ CLASS lcl_gui_page_commit IMPLEMENTATION.
 
   METHOD render_form.
 
-    DATA: lo_user     TYPE REF TO lcl_persistence_user.
-    DATA: lv_user     TYPE string.
-    DATA: lv_email    TYPE string.
-    DATA: lv_s_param  TYPE string.
-    DATA: lo_settings TYPE REF TO lcl_settings.
+    CONSTANTS: lc_body_col_max TYPE i VALUE 150.
+
+    DATA: lo_user      TYPE REF TO lcl_persistence_user.
+    DATA: lv_user      TYPE string.
+    DATA: lv_email     TYPE string.
+    DATA: lv_s_param   TYPE string.
+    DATA: lo_settings  TYPE REF TO lcl_settings.
+    data: lv_body_size type i.
 
 * see https://git-scm.com/book/ch5-2.html
 * commit messages should be max 50 characters
@@ -202,8 +205,13 @@ CLASS lcl_gui_page_commit IMPLEMENTATION.
     ro_html->add( '<div class="row">' ).
     ro_html->add( '<label for="c-body">body</label>' ).
 
+    lv_body_size = lo_settings->get_commitmsg_body_size( ).
+    IF lv_body_size > lc_body_col_max.
+      lv_body_size = lc_body_col_max.
+    ENDIF.
     ro_html->add( |<textarea id="c-body" name="body" rows="10" cols="| &&
-                  |{ lo_settings->get_commitmsg_body_size( ) }" wrap="hard"></textarea>| ).
+                  |{ lv_body_size }"></textarea>| ).
+
     ro_html->add( '<input type="submit" class="hidden-submit">' ).
     ro_html->add( '</div>' ).
 

--- a/src/zabapgit_page_commit.prog.abap
+++ b/src/zabapgit_page_commit.prog.abap
@@ -37,10 +37,10 @@ CLASS lcl_gui_page_commit DEFINITION FINAL INHERITING FROM lcl_gui_page.
         RETURNING VALUE(ro_html) TYPE REF TO lcl_html
         RAISING   lcx_exception,
       render_text_input
-        IMPORTING iv_name        TYPE string
-                  iv_label       TYPE string
-                  iv_value       TYPE string OPTIONAL
-                  iv_max_length  TYPE string OPTIONAL
+        IMPORTING iv_name       TYPE string
+                  iv_label      TYPE string
+                  iv_value      TYPE string OPTIONAL
+                  iv_max_length TYPE string OPTIONAL
         RETURNING VALUE(ro_html) TYPE REF TO lcl_html.
 
 ENDCLASS.

--- a/src/zabapgit_page_commit.prog.abap
+++ b/src/zabapgit_page_commit.prog.abap
@@ -155,9 +155,11 @@ CLASS lcl_gui_page_commit IMPLEMENTATION.
 
   METHOD render_form.
 
-    DATA: lo_user  TYPE REF TO lcl_persistence_user,
-          lv_user  TYPE string,
-          lv_email TYPE string.
+    DATA: lo_user     TYPE REF TO lcl_persistence_user.
+    DATA: lv_user     TYPE string.
+    DATA: lv_email    TYPE string.
+    DATA: lv_s_param  TYPE string.
+    DATA: lo_settings TYPE REF TO lcl_settings.
 
 * see https://git-scm.com/book/ch5-2.html
 * commit messages should be max 50 characters
@@ -189,13 +191,18 @@ CLASS lcl_gui_page_commit IMPLEMENTATION.
                                      iv_label = 'committer e-mail'
                                      iv_value = lv_email ) ).
 
+    lo_settings = lcl_app=>settings( )->read( ).
+
+    lv_s_param = lo_settings->get_commitmsg_comment_length( ).
+
     ro_html->add( render_text_input( iv_name       = 'comment'
                                      iv_label      = 'comment'
-                                     iv_max_length = '72' ) ).
+                                     iv_max_length = lv_s_param ) ).
 
     ro_html->add( '<div class="row">' ).
     ro_html->add( '<label for="c-body">body</label>' ).
-    ro_html->add( '<textarea id="c-body" name="body" rows="10" cols="50"></textarea>' ).
+
+    ro_html->add( |<textarea id="c-body" name="body" rows="10" cols="{ lo_settings->get_commitmsg_body_size( ) }" wrap="hard"></textarea>| ).
     ro_html->add( '<input type="submit" class="hidden-submit">' ).
     ro_html->add( '</div>' ).
 

--- a/src/zabapgit_page_settings.prog.abap
+++ b/src/zabapgit_page_settings.prog.abap
@@ -300,11 +300,13 @@ CLASS lcl_gui_page_settings IMPLEMENTATION.
     ro_html->add( |<h2>Commit Message</h2>| ).
     ro_html->add( |<label for="comment_length">Max. length of comment</label>| ).
     ro_html->add( |<br>| ).
-    ro_html->add( `<input name="comment_length" type="number" step="10" size="3" maxlength="3" min="50" max="100" value="` && mo_settings->get_commitmsg_comment_length( ) && `">` ).
+    ro_html->add( |<input name="comment_length" type="number" step="10" size="3" maxlength="3" min="50" max="100"| &&
+                  | value="{ mo_settings->get_commitmsg_comment_length( ) }">| ).
     ro_html->add( |<br>| ).
     ro_html->add( |<label for="body_size">Max. line size of body</label>| ).
     ro_html->add( |<br>| ).
-    ro_html->add( `<input name="body_size" type="number" step="10" size="3"  maxlength="3" min="50" max="100" value="` && mo_settings->get_commitmsg_body_size( ) && `">` ).
+    ro_html->add( |<input name="body_size" type="number" step="10" size="3" maxlength="3" min="50" max="100"| &&
+                  | value="{ mo_settings->get_commitmsg_body_size( ) }">| ).
     ro_html->add( |<br>| ).
     ro_html->add( |<br>| ).
   ENDMETHOD.

--- a/src/zabapgit_page_settings.prog.abap
+++ b/src/zabapgit_page_settings.prog.abap
@@ -32,6 +32,8 @@ CLASS lcl_gui_page_settings DEFINITION FINAL INHERITING FROM lcl_gui_page.
       RETURNING VALUE(ro_html) TYPE REF TO lcl_html.
     METHODS render_max_lines
       RETURNING VALUE(ro_html) TYPE REF TO lcl_html.
+    METHODS render_commit_msg
+      RETURNING VALUE(ro_html) TYPE REF TO lcl_html.
     METHODS build_settings
       IMPORTING
         it_post_fields TYPE tihttpnvp.
@@ -64,9 +66,11 @@ CLASS lcl_gui_page_settings IMPLEMENTATION.
     ro_html->add( render_form_begin( ) ).
     ro_html->add( render_proxy( ) ).
     ro_html->add( |<hr>| ).
-    ro_html->add( render_development_internals( ) ).
-    ro_html->add( |<hr>| ).
     ro_html->add( render_max_lines( ) ).
+    ro_html->add( |<hr>| ).
+    ro_html->add( render_commit_msg( ) ).
+    ro_html->add( |<hr>| ).
+    ro_html->add( render_development_internals( ) ).
     ro_html->add( render_form_end( ) ).
 
   ENDMETHOD.  "render_content
@@ -99,6 +103,7 @@ CLASS lcl_gui_page_settings IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD lif_gui_page~on_event.
+* todo, check input values eg INT
 
     DATA:
       lt_post_fields TYPE tihttpnvp.
@@ -124,43 +129,81 @@ CLASS lcl_gui_page_settings IMPLEMENTATION.
 
   METHOD build_settings.
 
-    DATA: ls_post_field           TYPE ihttpnvp,
-          lv_max_lines_as_integer TYPE i.
+    DATA: lv_i_param_value         TYPE i.
+    FIELD-SYMBOLS: <ls_post_field> TYPE ihttpnvp.
 
 
     CREATE OBJECT mo_settings.
-    READ TABLE it_post_fields INTO ls_post_field WITH KEY name = 'proxy_url'.
+    READ TABLE it_post_fields ASSIGNING <ls_post_field> WITH KEY name = 'proxy_url'.
     IF sy-subrc <> 0.
       mv_error = abap_true.
     ENDIF.
-    mo_settings->set_proxy_url( ls_post_field-value ).
+    mo_settings->set_proxy_url( <ls_post_field>-value ).
 
-    READ TABLE it_post_fields INTO ls_post_field WITH KEY name = 'proxy_port'.
+    READ TABLE it_post_fields ASSIGNING <ls_post_field> WITH KEY name = 'proxy_port'.
     IF sy-subrc <> 0.
       mv_error = abap_true.
     ENDIF.
-    mo_settings->set_proxy_port( ls_post_field-value ).
+    mo_settings->set_proxy_port( <ls_post_field>-value ).
 
-    READ TABLE it_post_fields INTO ls_post_field WITH KEY name = 'proxy_auth'.
+    READ TABLE it_post_fields ASSIGNING <ls_post_field> WITH KEY name = 'proxy_auth'.
     IF sy-subrc = 0.
       mo_settings->set_proxy_authentication( abap_true ).
     ELSE.
       mo_settings->set_proxy_authentication( abap_false ).
     ENDIF.
 
-    READ TABLE it_post_fields INTO ls_post_field WITH KEY name = 'critical_tests'.
+    READ TABLE it_post_fields ASSIGNING <ls_post_field> WITH KEY name = 'critical_tests'.
     IF sy-subrc = 0.
       mo_settings->set_run_critical_tests( abap_true ).
     ELSE.
       mo_settings->set_run_critical_tests( abap_false ).
     ENDIF.
 
-    READ TABLE it_post_fields INTO ls_post_field WITH KEY name = 'max_lines'.
+    READ TABLE it_post_fields ASSIGNING <ls_post_field> WITH KEY name = 'max_lines'.
     IF sy-subrc = 0.
-      lv_max_lines_as_integer = ls_post_field-value.
-      mo_settings->set_max_lines( lv_max_lines_as_integer ).
+      lv_i_param_value = <ls_post_field>-value.
+      mo_settings->set_max_lines( lv_i_param_value ).
     ELSE.
       mo_settings->set_max_lines( 0 ).
+    ENDIF.
+
+    READ TABLE it_post_fields ASSIGNING <ls_post_field> WITH KEY name = 'comment_length'.
+    IF sy-subrc = 0.
+
+      lv_i_param_value = <ls_post_field>-value.
+
+      IF     lv_i_param_value < lcl_settings=>c_commitmsg_comment_length_dft.
+        lv_i_param_value = lcl_settings=>c_commitmsg_comment_length_dft.
+      ELSEIF lv_i_param_value > lcl_settings=>c_commitmsg_comment_length_max.
+        lv_i_param_value = lcl_settings=>c_commitmsg_comment_length_max.
+      ENDIF.
+
+      mo_settings->set_commitmsg_comment_length( lv_i_param_value ).
+
+    ELSE.
+
+      mo_settings->set_commitmsg_comment_length( lcl_settings=>c_commitmsg_comment_length_dft ).
+
+    ENDIF.
+
+    READ TABLE it_post_fields ASSIGNING <ls_post_field> WITH KEY name = 'body_size'.
+    IF sy-subrc = 0.
+
+      lv_i_param_value = <ls_post_field>-value.
+
+      IF     lv_i_param_value < lcl_settings=>c_commitmsg_body_size_dft.
+        lv_i_param_value = lcl_settings=>c_commitmsg_body_size_dft.
+      ELSEIF lv_i_param_value > lcl_settings=>c_commitmsg_body_size_max.
+        lv_i_param_value = lcl_settings=>c_commitmsg_body_size_max.
+      ENDIF.
+
+      mo_settings->set_commitmsg_body_size( lv_i_param_value ).
+
+    ELSE.
+
+      mo_settings->set_commitmsg_body_size( lcl_settings=>c_commitmsg_body_size_dft ).
+
     ENDIF.
 
   ENDMETHOD.
@@ -247,6 +290,21 @@ CLASS lcl_gui_page_settings IMPLEMENTATION.
     ro_html->add( |<label for="max_lines">Max. # of objects listed (0 = all)</label>| ).
     ro_html->add( |<br>| ).
     ro_html->add( `<input name="max_lines" type="text" size="5" value="` && mo_settings->get_max_lines( ) && `">` ).
+    ro_html->add( |<br>| ).
+    ro_html->add( |<br>| ).
+  ENDMETHOD.
+
+  METHOD render_commit_msg.
+    CREATE OBJECT ro_html.
+
+    ro_html->add( |<h2>Commit Message</h2>| ).
+    ro_html->add( |<label for="comment_length">Max. length of comment</label>| ).
+    ro_html->add( |<br>| ).
+    ro_html->add( `<input name="comment_length" type="number" step="10" size="3" maxlength="3" min="50" max="100" value="` && mo_settings->get_commitmsg_comment_length( ) && `">` ).
+    ro_html->add( |<br>| ).
+    ro_html->add( |<label for="body_size">Max. line size of body</label>| ).
+    ro_html->add( |<br>| ).
+    ro_html->add( `<input name="body_size" type="number" step="10" size="3"  maxlength="3" min="50" max="100" value="` && mo_settings->get_commitmsg_body_size( ) && `">` ).
     ro_html->add( |<br>| ).
     ro_html->add( |<br>| ).
   ENDMETHOD.

--- a/src/zabapgit_page_settings.prog.abap
+++ b/src/zabapgit_page_settings.prog.abap
@@ -173,10 +173,8 @@ CLASS lcl_gui_page_settings IMPLEMENTATION.
 
       lv_i_param_value = <ls_post_field>-value.
 
-      IF     lv_i_param_value < lcl_settings=>c_commitmsg_comment_length_dft.
+      IF lv_i_param_value < lcl_settings=>c_commitmsg_comment_length_dft.
         lv_i_param_value = lcl_settings=>c_commitmsg_comment_length_dft.
-      ELSEIF lv_i_param_value > lcl_settings=>c_commitmsg_comment_length_max.
-        lv_i_param_value = lcl_settings=>c_commitmsg_comment_length_max.
       ENDIF.
 
       mo_settings->set_commitmsg_comment_length( lv_i_param_value ).
@@ -192,10 +190,8 @@ CLASS lcl_gui_page_settings IMPLEMENTATION.
 
       lv_i_param_value = <ls_post_field>-value.
 
-      IF     lv_i_param_value < lcl_settings=>c_commitmsg_body_size_dft.
+      IF lv_i_param_value < lcl_settings=>c_commitmsg_body_size_dft.
         lv_i_param_value = lcl_settings=>c_commitmsg_body_size_dft.
-      ELSEIF lv_i_param_value > lcl_settings=>c_commitmsg_body_size_max.
-        lv_i_param_value = lcl_settings=>c_commitmsg_body_size_max.
       ENDIF.
 
       mo_settings->set_commitmsg_body_size( lv_i_param_value ).
@@ -298,14 +294,14 @@ CLASS lcl_gui_page_settings IMPLEMENTATION.
     CREATE OBJECT ro_html.
 
     ro_html->add( |<h2>Commit Message</h2>| ).
-    ro_html->add( |<label for="comment_length">Max. length of comment</label>| ).
+    ro_html->add( |<label for="comment_length">Max. length of comment (recommendation 50)</label>| ).
     ro_html->add( |<br>| ).
-    ro_html->add( |<input name="comment_length" type="number" step="10" size="3" maxlength="3" min="50" max="100"| &&
+    ro_html->add( |<input name="comment_length" type="number" step="10" size="3" maxlength="3" min="50"| &&
                   | value="{ mo_settings->get_commitmsg_comment_length( ) }">| ).
     ro_html->add( |<br>| ).
-    ro_html->add( |<label for="body_size">Max. line size of body</label>| ).
+    ro_html->add( |<label for="body_size">Max. line size of body (recommendation 72)</label>| ).
     ro_html->add( |<br>| ).
-    ro_html->add( |<input name="body_size" type="number" step="10" size="3" maxlength="3" min="50" max="100"| &&
+    ro_html->add( |<input name="body_size" type="number" step="10" size="3" maxlength="3" min="50"| &&
                   | value="{ mo_settings->get_commitmsg_body_size( ) }">| ).
     ro_html->add( |<br>| ).
     ro_html->add( |<br>| ).

--- a/src/zabapgit_persistence.prog.abap
+++ b/src/zabapgit_persistence.prog.abap
@@ -1535,9 +1535,7 @@ CLASS lcl_settings DEFINITION FINAL.
 
   PUBLIC SECTION.
     CONSTANTS: c_commitmsg_comment_length_dft TYPE i VALUE 50.
-    CONSTANTS: c_commitmsg_comment_length_max TYPE i VALUE 100.
     CONSTANTS: c_commitmsg_body_size_dft      TYPE i VALUE 72.
-    CONSTANTS: c_commitmsg_body_size_max      TYPE i VALUE 100.
 
     METHODS set_proxy_url
       IMPORTING


### PR DESCRIPTION
Two setting parameter to adjust commit comment length (50-100) and Body line size (72-100)