### PR TITLE
html_utils: URL unescape parameter fields

### DIFF
--- a/src/zabapgit_html_action_utils.prog.abap
+++ b/src/zabapgit_html_action_utils.prog.abap
@@ -124,9 +124,11 @@ CLASS lcl_html_action_utils IMPLEMENTATION.
 
       field-name = substring_before( val = <substring>
                                      sub = '=' ).
+      field-name = cl_http_utility=>unescape_url( field-name ).
 
       field-value = substring_after( val = <substring>
                                      sub = '=' ).
+      field-value = cl_http_utility=>unescape_url( field-value ).
 
       INSERT field INTO TABLE rt_fields.
 


### PR DESCRIPTION
For some strange reason even post data is URL escaped on our
servers.

How I discovered this issue:
1. go to stage
2. leave some files in the state ?
3. click the Commit link
4. get the error 'process_stage_list: unknown method %3F'

URL decode '%3F' and see that the value is '?'.

The value is set to the hidden input fields in its unescaped form
in the function submitSapeventForm() but the value is escaped in
the method lif_gui_page~on_event of the class lcl_gui_page_stage.