### PR TITLE
Bugfix access deleted branch in news page

### DIFF
--- a/src/zabapgit_news.prog.abap
+++ b/src/zabapgit_news.prog.abap
@@ -112,8 +112,13 @@ CLASS lcl_news IMPLEMENTATION.
 
     lv_last_seen = lcl_app=>user( )->get_repo_last_change_seen( lv_url ).
 
-    " Find changelog
-    lt_remote = io_repo->get_files_remote( ).
+    TRY.
+        " Find changelog
+        lt_remote = io_repo->get_files_remote( ).
+      CATCH lcx_exception.
+        RETURN.
+    ENDTRY.
+
     READ TABLE lt_remote ASSIGNING <file>
       WITH KEY path = lc_log_path filename = lc_log_filename.
 


### PR DESCRIPTION
#834 
Bugfix access deleted branch in news abapgit page. When the news page try to access a branch that doesn't exist anymore in the remote we catch the belonging exception and return.