### PR TITLE
Fix FGroup Serialization involving Namespaces

### DIFF
--- a/src/zabapgit_object_fugr.prog.abap
+++ b/src/zabapgit_object_fugr.prog.abap
@@ -464,7 +464,15 @@ CLASS lcl_object_fugr IMPLEMENTATION.
 
 * handle generated maintenance views
     APPEND INITIAL LINE TO rt_includes ASSIGNING <lv_include>.
-    <lv_include> = |L{ ms_item-obj_name }T00|.
+    if ms_item-obj_name(1) <> '/'.
+      "FGroup name does not contain a namespace
+      <lv_include> = |L{ ms_item-obj_name }T00|.
+    else.
+      "FGroup name contains a namespace
+      lv_offset_ns = find( val = ms_item-obj_name+1 sub = '/' ).
+      lv_offset_ns = lv_offset_ns + 2.
+      <lv_include> = |{ ms_item-obj_name(lv_offset_ns) }L{ ms_item-obj_name+lv_offset_ns }T00|.
+    endif.
 
     IF lines( rt_includes ) > 0.
       SELECT progname cnam FROM reposrc


### PR DESCRIPTION
Extended existing logic to add generic t00 include, to handle function groups with namespaces correctly.