### PR TITLE
Replacing per object 'overwrite local Object' dialog with checkbox list

### DIFF
--- a/src/zabapgit_objects_impl.prog.abap
+++ b/src/zabapgit_objects_impl.prog.abap
@@ -29,8 +29,10 @@ CLASS lcl_objects IMPLEMENTATION.
 
     ENDLOOP.
 
-    "all returned objects will be overwritten
-    ct_results = lcl_popups=>popup_select_obj_overwrite( lt_results_overwrite ).
+    if lines( lt_results_overwrite ) > 0.
+      "all returned objects will be overwritten
+      ct_results = lcl_popups=>popup_select_obj_overwrite( lt_results_overwrite ).
+    endif.
 
   ENDMETHOD.
 

--- a/src/zabapgit_objects_impl.prog.abap
+++ b/src/zabapgit_objects_impl.prog.abap
@@ -11,38 +11,26 @@ CLASS lcl_objects IMPLEMENTATION.
 
   METHOD warning_overwrite.
 
-    DATA: lv_index    TYPE i,
-          lv_answer   TYPE c,
-          lv_question TYPE string.
+    DATA: lt_results_overwrite LIKE ct_results.
 
     FIELD-SYMBOLS: <ls_result>  LIKE LINE OF ct_results.
 
-
     LOOP AT ct_results ASSIGNING <ls_result>
         WHERE NOT obj_type IS INITIAL.
-
-      lv_index = sy-tabix.
 
       IF <ls_result>-lstate IS NOT INITIAL
           AND <ls_result>-lstate <> lif_defs=>gc_state-deleted
           AND NOT ( <ls_result>-lstate = lif_defs=>gc_state-added
           AND <ls_result>-rstate IS INITIAL ).
-        lv_question = |It looks like object {
-          <ls_result>-obj_type } { <ls_result>-obj_name
-          } has been modified locally, overwrite object?|.
 
-        lv_answer = lcl_popups=>popup_to_confirm(
-          titlebar              = 'Warning'
-          text_question         = lv_question
-          display_cancel_button = abap_false ).             "#EC NOTEXT
-
-        IF lv_answer = '2'.
-          DELETE ct_results INDEX lv_index.
-        ENDIF.
-
+        "current object has been modified locally, add to table for popup
+        APPEND <ls_result> TO lt_results_overwrite.
       ENDIF.
 
     ENDLOOP.
+
+    "all returned objects will be overwritten
+    ct_results = lcl_popups=>popup_select_obj_overwrite( lt_results_overwrite ).
 
   ENDMETHOD.
 

--- a/src/zabapgit_popups.prog.abap
+++ b/src/zabapgit_popups.prog.abap
@@ -85,8 +85,8 @@ CLASS lcl_popups DEFINITION FINAL.
   PRIVATE SECTION.
     TYPES: ty_sval_tt TYPE STANDARD TABLE OF sval WITH DEFAULT KEY.
 
-    TYPES BEGIN OF t_popup_select_list.
-      TYPES selected TYPE flag.
+    TYPES: BEGIN OF t_popup_select_list,
+        selected TYPE flag.
       INCLUDE TYPE lif_defs=>ty_result.
     TYPES END OF t_popup_select_list.
 

--- a/src/zabapgit_popups.prog.abap
+++ b/src/zabapgit_popups.prog.abap
@@ -76,18 +76,46 @@ CLASS lcl_popups DEFINITION FINAL.
         RAISING   lcx_exception
                   lcx_cancel,
       popup_to_select_transports
-        RETURNING VALUE(rt_trkorr) TYPE trwbo_request_headers.
+        RETURNING VALUE(rt_trkorr) TYPE trwbo_request_headers,
+      popup_select_obj_overwrite
+        IMPORTING it_list TYPE lif_defs=>ty_results_tt
+        RETURNING VALUE(rt_list) TYPE lif_defs=>ty_results_tt
+        RAISING   lcx_exception.
 
   PRIVATE SECTION.
     TYPES: ty_sval_tt TYPE STANDARD TABLE OF sval WITH DEFAULT KEY.
 
-    CLASS-METHODS: add_field
-      IMPORTING iv_tabname    TYPE sval-tabname
-                iv_fieldname  TYPE sval-fieldname
-                iv_fieldtext  TYPE sval-fieldtext
-                iv_value      TYPE clike DEFAULT ''
-                iv_field_attr TYPE sval-field_attr DEFAULT ''
-      CHANGING  ct_fields     TYPE ty_sval_tt.
+    TYPES BEGIN OF t_popup_select_list.
+      TYPES selected TYPE flag.
+      INCLUDE TYPE lif_defs=>ty_result.
+    TYPES END OF t_popup_select_list.
+
+    TYPES: t_popup_select_list_tt TYPE STANDARD TABLE OF t_popup_select_list WITH DEFAULT KEY.
+
+    CLASS-DATA:
+    mtr_select_list TYPE REF TO t_popup_select_list_tt,
+    mo_select_list_popup TYPE REF TO cl_salv_table.
+
+    CLASS-METHODS:
+      add_field
+        IMPORTING iv_tabname    TYPE sval-tabname
+                  iv_fieldname  TYPE sval-fieldname
+                  iv_fieldtext  TYPE sval-fieldtext
+                  iv_value      TYPE clike DEFAULT ''
+                  iv_field_attr TYPE sval-field_attr DEFAULT ''
+        CHANGING  ct_fields     TYPE ty_sval_tt,
+
+      on_select_list_link_click
+        FOR EVENT link_click OF cl_salv_events_table
+        IMPORTING
+          !row
+          !column,
+
+      on_select_list_function_click
+        FOR EVENT added_function OF cl_salv_events_table
+        IMPORTING
+          !e_salv_function.
+
 
 ENDCLASS.
 
@@ -697,6 +725,109 @@ CLASS lcl_popups IMPLEMENTATION.
     READ TABLE lt_fields INDEX 2 ASSIGNING <ls_field>.
     ASSERT sy-subrc = 0.
     rs_transport_branch-commit_text = <ls_field>-value.
+  ENDMETHOD.
+
+  METHOD popup_select_obj_overwrite.
+    DATA:
+          ls_list       LIKE LINE OF it_list,
+          ls_popup_list TYPE t_popup_select_list,
+          lt_popup_list TYPE t_popup_select_list_tt,
+          lo_events     TYPE REF TO cl_salv_events_table,
+          lo_columns    TYPE REF TO cl_salv_columns_table,
+          lt_columns    TYPE salv_t_column_ref,
+          ls_column     TYPE salv_s_column_ref,
+          lo_column     TYPE REF TO cl_salv_column_list.
+
+    LOOP AT it_list INTO ls_list.
+      MOVE-CORRESPONDING ls_list TO ls_popup_list.
+      APPEND ls_popup_list TO lt_popup_list.
+    ENDLOOP.
+
+    TRY.
+        cl_salv_table=>factory( IMPORTING r_salv_table = mo_select_list_popup
+                                CHANGING t_table = lt_popup_list ).
+
+        GET REFERENCE OF lt_popup_list INTO mtr_select_list.
+        mo_select_list_popup->set_screen_status( pfstatus = 'ST850'
+                                                 report = 'SAPLKKBL' ).
+
+        mo_select_list_popup->set_screen_popup( start_column = 1
+                                                end_column = 65
+                                                start_line = 1
+                                                end_line = 20 ).
+
+        lo_events = mo_select_list_popup->get_event( ).
+
+        SET HANDLER on_select_list_link_click FOR lo_events.
+        SET HANDLER on_select_list_function_click FOR lo_events.
+
+        lo_columns = mo_select_list_popup->get_columns( ).
+        lo_columns->set_optimize( abap_true ).
+        lt_columns = lo_columns->get( ).
+
+        LOOP AT lt_columns INTO ls_column.
+          CASE ls_column-columnname.
+            WHEN 'OBJ_TYPE' OR 'OBJ_NAME'.
+
+            WHEN 'SELECTED'.
+              lo_column ?= ls_column-r_column.
+              lo_column->set_cell_type( if_salv_c_cell_type=>checkbox_hotspot ).
+              lo_column->set_output_length( 20 ).
+              lo_column->set_short_text( 'Overwrite?' ).
+              lo_column->set_medium_text( 'Overwr. Lcl Object?' ).
+              lo_column->set_long_text( 'Overwrite Local Object?' ).
+
+            WHEN OTHERS.
+              ls_column-r_column->set_technical( abap_true ).
+
+          ENDCASE.
+        ENDLOOP.
+
+        mo_select_list_popup->display( ).
+
+      CATCH cx_salv_msg.
+        lcx_exception=>raise( 'Error from POPUP_SELECT_OBJ_OVERWRITE' ).
+    ENDTRY.
+
+    LOOP AT lt_popup_list INTO ls_popup_list WHERE selected = abap_true.
+      MOVE-CORRESPONDING ls_popup_list TO ls_list.
+      APPEND ls_list TO rt_list.
+    ENDLOOP.
+
+    CLEAR:
+    mo_select_list_popup,
+    mtr_select_list.
+
+  ENDMETHOD.
+
+  METHOD on_select_list_function_click.
+    CASE e_salv_function.
+      WHEN 'GOON'.
+        mo_select_list_popup->close_screen( ).
+      WHEN 'ABR'.
+        "Canceled: clear list to overwrite nothing
+        CLEAR mtr_select_list->*.
+        mo_select_list_popup->close_screen( ).
+    ENDCASE.
+  ENDMETHOD.
+
+  METHOD on_select_list_link_click.
+    DATA:
+          lsr_line TYPE REF TO t_popup_select_list,
+          lv_line  TYPE sytabix.
+
+    lv_line = row.
+
+    READ TABLE mtr_select_list->* REFERENCE INTO lsr_line INDEX lv_line.
+    IF sy-subrc = 0.
+      IF lsr_line->selected = abap_true.
+        lsr_line->selected = abap_false.
+      ELSE.
+        lsr_line->selected = abap_true.
+      ENDIF.
+    ENDIF.
+
+    mo_select_list_popup->refresh( ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/zabapgit_popups.prog.abap
+++ b/src/zabapgit_popups.prog.abap
@@ -729,14 +729,15 @@ CLASS lcl_popups IMPLEMENTATION.
 
   METHOD popup_select_obj_overwrite.
     DATA:
-          ls_list       LIKE LINE OF it_list,
-          ls_popup_list TYPE t_popup_select_list,
-          lt_popup_list TYPE t_popup_select_list_tt,
-          lo_events     TYPE REF TO cl_salv_events_table,
-          lo_columns    TYPE REF TO cl_salv_columns_table,
-          lt_columns    TYPE salv_t_column_ref,
-          ls_column     TYPE salv_s_column_ref,
-          lo_column     TYPE REF TO cl_salv_column_list.
+          ls_list         LIKE LINE OF it_list,
+          ls_popup_list   TYPE t_popup_select_list,
+          lt_popup_list   TYPE t_popup_select_list_tt,
+          lo_events       TYPE REF TO cl_salv_events_table,
+          lo_columns      TYPE REF TO cl_salv_columns_table,
+          lt_columns      TYPE salv_t_column_ref,
+          ls_column       TYPE salv_s_column_ref,
+          lo_column       TYPE REF TO cl_salv_column_list,
+          lo_table_header TYPE REF TO cl_salv_form_text.
 
     LOOP AT it_list INTO ls_list.
       MOVE-CORRESPONDING ls_list TO ls_popup_list.
@@ -760,6 +761,12 @@ CLASS lcl_popups IMPLEMENTATION.
 
         SET HANDLER on_select_list_link_click FOR lo_events.
         SET HANDLER on_select_list_function_click FOR lo_events.
+
+        CREATE OBJECT lo_table_header
+          EXPORTING
+            text = |The following Objects have been modified locally. Select the Objects which should be overwritten.|.
+
+        mo_select_list_popup->set_top_of_list( lo_table_header ).
 
         lo_columns = mo_select_list_popup->get_columns( ).
         lo_columns->set_optimize( abap_true ).


### PR DESCRIPTION
When Pulling local objects are checked if they have been modified. If so there was a confirmation popup for each objects. This has been replaced with a popup table allowing to have a look at all modified objects at once and selecting a checkbox to confirm that all selected objects should be overwritten.