### PR TITLE
Fix for issue #995: Handling of includes without textpools

### DIFF
--- a/src/zabapgit_object_fugr.prog.abap
+++ b/src/zabapgit_object_fugr.prog.abap
@@ -333,8 +333,9 @@ CLASS lcl_object_fugr IMPLEMENTATION.
                            it_tpool   = lt_tpool
                            iv_package = iv_package ).
 
-      deserialize_textpool( iv_program = <lv_include>
-                            it_tpool   = lt_tpool ).
+      deserialize_textpool( iv_program    = <lv_include>
+                            it_tpool      = lt_tpool
+                            iv_is_include = abap_true ).
 
     ENDLOOP.
 

--- a/src/zabapgit_xml.prog.abap
+++ b/src/zabapgit_xml.prog.abap
@@ -374,8 +374,9 @@ CLASS lcl_xml_input IMPLEMENTATION.
 
     FIELD-SYMBOLS: <ls_rtab> LIKE LINE OF lt_rtab.
 
-
     ASSERT NOT iv_name IS INITIAL.
+
+    CLEAR cg_data. "Initialize result to avoid problems with empty values
 
     APPEND INITIAL LINE TO lt_rtab ASSIGNING <ls_rtab>.
     <ls_rtab>-name = iv_name.


### PR DESCRIPTION
Includes without a textpool (=include description) are created are either as includes with an empty description (first include) or using the description of the preceding textpool. This issue can be reproduced with function groups created on SAP releases older than 7.31.