### PR TITLE
Issue 1005: Function include naming

### DIFF
--- a/src/zabapgit_object_fugr.prog.abap
+++ b/src/zabapgit_object_fugr.prog.abap
@@ -18,7 +18,6 @@ CLASS lcl_object_fugr DEFINITION INHERITING FROM lcl_objects_program FINAL.
 
     TYPES: BEGIN OF ty_function,
              funcname          TYPE rs38l_fnam,
-             include           TYPE progname,
              global_flag       TYPE rs38l-global,
              remote_call       TYPE rs38l-remote,
              update_task       TYPE rs38l-utask,


### PR DESCRIPTION
When deserializing functions, the corresponding include name is generated by SAP coding and may not match the include name from the original system. This difference is then considered as a local modification. Excluding the include name of the function from the serialized information would solve the issue.