### PR TITLE
Callbacks

### DIFF
--- a/src/zabapgit.prog.abap
+++ b/src/zabapgit.prog.abap
@@ -52,7 +52,6 @@ INCLUDE zabapgit_exit.
 INCLUDE zabapgit_stage.
 INCLUDE zabapgit_git_helpers.
 INCLUDE zabapgit_repo.
-INCLUDE zabapgit_callbacks.
 INCLUDE zabapgit_news.
 INCLUDE zabapgit_stage_logic.
 INCLUDE zabapgit_2fa.
@@ -62,6 +61,7 @@ INCLUDE zabapgit_objects.
 INCLUDE zabapgit_tadir.
 INCLUDE zabapgit_file_status.
 INCLUDE zabapgit_popups.
+INCLUDE zabapgit_callbacks.
 INCLUDE zabapgit_zip.
 INCLUDE zabapgit_objects_impl.
 

--- a/src/zabapgit.prog.abap
+++ b/src/zabapgit.prog.abap
@@ -86,6 +86,20 @@ INCLUDE zabapgit_migrations.          " Data migration routines
 INCLUDE zabapgit_forms.
 
 **********************************************************************
+LOAD-OF-PROGRAM.
+  DATA: gs_submit           TYPE zif_abapgit_definitions=>gty_callback_submit,
+        go_callback_adapter TYPE REF TO lcl_callback_adapter.
+
+  IMPORT submit = gs_submit FROM MEMORY ID 'AGT'.
+
+  IF sy-subrc = 0 AND gs_submit IS NOT INITIAL.
+    go_callback_adapter = lcl_callback_adapter=>get_instance(
+      io_repo = lcl_app=>repo_srv( )->get( gs_submit-repokey )
+      iv_use_submit = abap_false ).
+    go_callback_adapter->submit( iv_methname = gs_submit-callback iv_args = gs_submit-args ).
+    LEAVE PROGRAM.
+  ENDIF.
+
 INITIALIZATION.
   lcl_password_dialog=>on_screen_init( ).
 

--- a/src/zabapgit.prog.abap
+++ b/src/zabapgit.prog.abap
@@ -52,6 +52,7 @@ INCLUDE zabapgit_exit.
 INCLUDE zabapgit_stage.
 INCLUDE zabapgit_git_helpers.
 INCLUDE zabapgit_repo.
+INCLUDE zabapgit_callbacks.
 INCLUDE zabapgit_news.
 INCLUDE zabapgit_stage_logic.
 INCLUDE zabapgit_2fa.

--- a/src/zabapgit_callbacks.prog.abap
+++ b/src/zabapgit_callbacks.prog.abap
@@ -149,7 +149,7 @@ CLASS lcl_callback_adapter IMPLEMENTATION.
     ls_parameter-name = lc_parmname_new_version.
     ls_parameter-kind = cl_abap_objectdescr=>exporting.
     lr_new_version->* = iv_new_version.
-    ls_parameter-value = lr_old_version.
+    ls_parameter-value = lr_new_version.
     INSERT ls_parameter INTO TABLE lt_parameters.
 
     dyn_call_method( io_object     = mo_listener

--- a/src/zabapgit_callbacks.prog.abap
+++ b/src/zabapgit_callbacks.prog.abap
@@ -30,11 +30,17 @@ CLASS lcl_callback_adapter DEFINITION CREATE PRIVATE.
       lif_callback_listener.
     ALIASES:
       on_after_install FOR lif_callback_listener~on_after_install.
+    CONSTANTS:
+      gc_methname_on_after_install TYPE abap_methname VALUE 'ON_AFTER_INSTALL'.
     CLASS-METHODS:
       get_instance IMPORTING io_repo            TYPE REF TO lcl_repo
                              iv_force_new       TYPE abap_bool DEFAULT abap_false
                    RETURNING VALUE(ro_instance) TYPE REF TO lcl_callback_adapter
                    RAISING   zcx_abapgit_exception.
+    METHODS:
+      check_execution_allowed IMPORTING iv_methname       TYPE abap_methname
+                              RETURNING VALUE(rv_allowed) TYPE abap_bool
+                              RAISING   zcx_abapgit_exception.
   PROTECTED SECTION.
   PRIVATE SECTION.
     CLASS-METHODS:
@@ -44,10 +50,12 @@ CLASS lcl_callback_adapter DEFINITION CREATE PRIVATE.
     METHODS:
       constructor IMPORTING io_repo TYPE REF TO lcl_repo
                   RAISING   zcx_abapgit_exception,
-      init_listener RAISING cx_sy_create_object_error.
+      init_listener RAISING cx_sy_create_object_error,
+      is_dummy_listener RETURNING VALUE(rv_is_dummy) TYPE abap_bool.
     DATA:
-      mo_repository TYPE REF TO lcl_repo,
-      mo_listener   TYPE REF TO object.
+      mo_repository         TYPE REF TO lcl_repo,
+      mo_listener           TYPE REF TO object,
+      mv_callback_classname TYPE abap_classname.
 ENDCLASS.
 
 CLASS lcl_callback_adapter IMPLEMENTATION.
@@ -105,20 +113,17 @@ CLASS lcl_callback_adapter IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD init_listener.
-    DATA: lv_classname TYPE abap_classname.
+    mv_callback_classname = mo_repository->get_dot_abapgit( )->get_callback_classname( ).
 
-    lv_classname = mo_repository->get_dot_abapgit( )->get_callback_classname( ).
-
-    IF lv_classname IS NOT INITIAL.
-      CREATE OBJECT mo_listener TYPE (lv_classname).
+    IF mv_callback_classname IS NOT INITIAL.
+      CREATE OBJECT mo_listener TYPE (mv_callback_classname).
     ELSE.
       CREATE OBJECT mo_listener TYPE lcl_dummy_callback_listener.
     ENDIF.
   ENDMETHOD.
 
   METHOD lif_callback_listener~on_after_install.
-    CONSTANTS: lc_methname             TYPE abap_methname VALUE 'ON_AFTER_INSTALL',
-               lc_parmname_package     TYPE abap_parmname VALUE 'IV_PACKAGE',
+    CONSTANTS: lc_parmname_package     TYPE abap_parmname VALUE 'IV_PACKAGE',
                lc_parmname_old_version TYPE abap_parmname VALUE 'IV_OLD_VERSION',
                lc_parmname_new_version TYPE abap_parmname VALUE 'IV_NEW_VERSION'.
     DATA: lt_parameters  TYPE abap_parmbind_tab,
@@ -148,8 +153,31 @@ CLASS lcl_callback_adapter IMPLEMENTATION.
     INSERT ls_parameter INTO TABLE lt_parameters.
 
     dyn_call_method( io_object     = mo_listener
-                     iv_methname   = lc_methname
+                     iv_methname   = gc_methname_on_after_install
                      it_parameters = lt_parameters ).
+  ENDMETHOD.
+
+  METHOD check_execution_allowed.
+    IF is_dummy_listener( ) = abap_true.
+      rv_allowed = abap_true.
+      RETURN.
+    ENDIF.
+
+    " Prevent arbitrary code execution by allowing the user to take a look at the (possibly just
+    " pulled) callback implementation.
+    rv_allowed = lcl_popups=>popup_to_decide_callback_exec(
+                   iv_methname           = iv_methname
+                   iv_callback_classname = mv_callback_classname ).
+  ENDMETHOD.
+
+  METHOD is_dummy_listener.
+    DATA: lo_dummy       TYPE REF TO lcl_dummy_callback_listener ##NEEDED,
+          lo_class_descr TYPE REF TO cl_abap_classdescr,
+          lo_ref_descr   TYPE REF TO cl_abap_refdescr.
+
+    lo_ref_descr ?= cl_abap_typedescr=>describe_by_data( lo_dummy ).
+    lo_class_descr ?= lo_ref_descr->get_referenced_type( ).
+    rv_is_dummy = lo_class_descr->applies_to( mo_listener ).
   ENDMETHOD.
 
   METHOD dyn_call_method.

--- a/src/zabapgit_callbacks.prog.abap
+++ b/src/zabapgit_callbacks.prog.abap
@@ -15,9 +15,6 @@
 "! abapGit most of the time only exists in the development system this would cause a compiler error
 "! on import in QA / production systems.
 "! </p>
-"! <p>
-"! Version parameters are always taken from the <em>VERSION</em> attribute in .abapgit.xml.
-"! </p>
 INTERFACE lif_callback_listener.
   METHODS:
     "! Pull event listener
@@ -26,11 +23,7 @@ INTERFACE lif_callback_listener.
     "! pulled changes. Activation of all objects in the repository is not guaranteed.
     "! </p>
     "! @parameter iv_package | Installation package name
-    "! @parameter iv_old_version | Old version
-    "! @parameter iv_new_version | New version
-    on_after_pull IMPORTING iv_package     TYPE devclass
-                            iv_old_version TYPE string
-                            iv_new_version TYPE string,
+    on_after_pull IMPORTING iv_package     TYPE devclass,
     "! Uninstall event listener
     "! <p>
     "! This method is called just before a repository gets uninstalled.
@@ -210,16 +203,12 @@ CLASS lcl_callback_adapter IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD lif_callback_listener~on_after_pull.
-    CONSTANTS: lc_parmname_package     TYPE abap_parmname VALUE 'IV_PACKAGE',
-               lc_parmname_old_version TYPE abap_parmname VALUE 'IV_OLD_VERSION',
-               lc_parmname_new_version TYPE abap_parmname VALUE 'IV_NEW_VERSION'.
+    CONSTANTS: lc_parmname_package     TYPE abap_parmname VALUE 'IV_PACKAGE'.
     DATA: lt_parameters  TYPE abap_parmbind_tab,
           ls_parameter   TYPE abap_parmbind,
-          lr_package     TYPE REF TO devclass,
-          lr_old_version TYPE REF TO string,
-          lr_new_version TYPE REF TO string.
+          lr_package     TYPE REF TO devclass.
 
-    CREATE DATA: lr_package, lr_old_version, lr_new_version.
+    CREATE DATA: lr_package.
 
     IF check_listener_methimp_has_par( iv_methname = gc_methnames-on_after_pull
                                        iv_parmname = lc_parmname_package ).
@@ -227,24 +216,6 @@ CLASS lcl_callback_adapter IMPLEMENTATION.
       ls_parameter-kind = cl_abap_objectdescr=>exporting.
       lr_package->* = iv_package.
       ls_parameter-value = lr_package.
-      INSERT ls_parameter INTO TABLE lt_parameters.
-    ENDIF.
-
-    IF check_listener_methimp_has_par( iv_methname = gc_methnames-on_after_pull
-                                       iv_parmname = lc_parmname_old_version ).
-      ls_parameter-name = lc_parmname_old_version.
-      ls_parameter-kind = cl_abap_objectdescr=>exporting.
-      lr_old_version->* = iv_old_version.
-      ls_parameter-value = lr_old_version.
-      INSERT ls_parameter INTO TABLE lt_parameters.
-    ENDIF.
-
-    IF check_listener_methimp_has_par( iv_methname = gc_methnames-on_after_pull
-                                       iv_parmname = lc_parmname_new_version ).
-      ls_parameter-name = lc_parmname_new_version.
-      ls_parameter-kind = cl_abap_objectdescr=>exporting.
-      lr_new_version->* = iv_new_version.
-      ls_parameter-value = lr_new_version.
       INSERT ls_parameter INTO TABLE lt_parameters.
     ENDIF.
 

--- a/src/zabapgit_callbacks.prog.abap
+++ b/src/zabapgit_callbacks.prog.abap
@@ -117,7 +117,7 @@ CLASS lcl_callback_adapter DEFINITION CREATE PRIVATE.
     DATA:
       mo_repository         TYPE REF TO lcl_repo,
       mo_listener           TYPE REF TO object,
-      mv_callback_classname TYPE abap_classname,
+      mv_callback_classname TYPE string,
       mo_listener_descr     TYPE REF TO cl_abap_classdescr.
 ENDCLASS.
 

--- a/src/zabapgit_callbacks.prog.abap
+++ b/src/zabapgit_callbacks.prog.abap
@@ -4,9 +4,9 @@
 
 INTERFACE lif_callback_listener.
   METHODS:
-    on_after_install IMPORTING iv_package     TYPE devclass
-                               iv_old_version TYPE string
-                               iv_new_version TYPE string.
+    on_after_pull IMPORTING iv_package     TYPE devclass
+                            iv_old_version TYPE string
+                            iv_new_version TYPE string.
 ENDINTERFACE.
 
 CLASS lcl_dummy_callback_listener DEFINITION.
@@ -14,13 +14,13 @@ CLASS lcl_dummy_callback_listener DEFINITION.
     INTERFACES:
       lif_callback_listener.
     ALIASES:
-      on_after_install FOR lif_callback_listener~on_after_install.
+      on_after_pull FOR lif_callback_listener~on_after_pull.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
 
 CLASS lcl_dummy_callback_listener IMPLEMENTATION.
-  METHOD lif_callback_listener~on_after_install.
+  METHOD lif_callback_listener~on_after_pull.
   ENDMETHOD.
 ENDCLASS.
 
@@ -29,9 +29,9 @@ CLASS lcl_callback_adapter DEFINITION CREATE PRIVATE.
     INTERFACES:
       lif_callback_listener.
     ALIASES:
-      on_after_install FOR lif_callback_listener~on_after_install.
+      on_after_pull FOR lif_callback_listener~on_after_pull.
     CONSTANTS:
-      gc_methname_on_after_install TYPE abap_methname VALUE 'ON_AFTER_INSTALL'.
+      gc_methname_on_after_pull TYPE abap_methname VALUE 'ON_AFTER_PULL'.
     CLASS-METHODS:
       get_instance IMPORTING io_repo            TYPE REF TO lcl_repo
                              iv_force_new       TYPE abap_bool DEFAULT abap_false
@@ -99,7 +99,7 @@ CLASS lcl_callback_adapter IMPLEMENTATION.
   METHOD constructor.
     DATA: lx_ex TYPE REF TO cx_sy_create_object_error.
 
-    ASSERT: io_repo IS BOUND.
+    ASSERT io_repo IS BOUND.
     mo_repository = io_repo.
 
     TRY.
@@ -122,7 +122,7 @@ CLASS lcl_callback_adapter IMPLEMENTATION.
     ENDIF.
   ENDMETHOD.
 
-  METHOD lif_callback_listener~on_after_install.
+  METHOD lif_callback_listener~on_after_pull.
     CONSTANTS: lc_parmname_package     TYPE abap_parmname VALUE 'IV_PACKAGE',
                lc_parmname_old_version TYPE abap_parmname VALUE 'IV_OLD_VERSION',
                lc_parmname_new_version TYPE abap_parmname VALUE 'IV_NEW_VERSION'.
@@ -153,7 +153,7 @@ CLASS lcl_callback_adapter IMPLEMENTATION.
     INSERT ls_parameter INTO TABLE lt_parameters.
 
     dyn_call_method( io_object     = mo_listener
-                     iv_methname   = gc_methname_on_after_install
+                     iv_methname   = gc_methname_on_after_pull
                      it_parameters = lt_parameters ).
   ENDMETHOD.
 

--- a/src/zabapgit_callbacks.prog.abap
+++ b/src/zabapgit_callbacks.prog.abap
@@ -107,8 +107,7 @@ CLASS lcl_callback_adapter IMPLEMENTATION.
   METHOD init_listener.
     DATA: lv_classname TYPE abap_classname.
 
-    ##TODO.
-*    lv_classname = mo_repository->get_dot_abapgit( )->get_callback_classname( ).
+    lv_classname = mo_repository->get_dot_abapgit( )->get_callback_classname( ).
 
     IF lv_classname IS NOT INITIAL.
       CREATE OBJECT mo_listener TYPE (lv_classname).

--- a/src/zabapgit_callbacks.prog.abap
+++ b/src/zabapgit_callbacks.prog.abap
@@ -1,0 +1,170 @@
+*&---------------------------------------------------------------------*
+*& Include zabapgit_callbacks
+*&---------------------------------------------------------------------*
+
+INTERFACE lif_callback_listener.
+  METHODS:
+    on_after_install IMPORTING iv_package     TYPE devclass
+                               iv_old_version TYPE string
+                               iv_new_version TYPE string.
+ENDINTERFACE.
+
+CLASS lcl_dummy_callback_listener DEFINITION.
+  PUBLIC SECTION.
+    INTERFACES:
+      lif_callback_listener.
+    ALIASES:
+      on_after_install FOR lif_callback_listener~on_after_install.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+CLASS lcl_dummy_callback_listener IMPLEMENTATION.
+  METHOD lif_callback_listener~on_after_install.
+  ENDMETHOD.
+ENDCLASS.
+
+CLASS lcl_callback_adapter DEFINITION CREATE PRIVATE.
+  PUBLIC SECTION.
+    INTERFACES:
+      lif_callback_listener.
+    ALIASES:
+      on_after_install FOR lif_callback_listener~on_after_install.
+    CLASS-METHODS:
+      get_instance IMPORTING io_repo            TYPE REF TO lcl_repo
+                             iv_force_new       TYPE abap_bool DEFAULT abap_false
+                   RETURNING VALUE(ro_instance) TYPE REF TO lcl_callback_adapter
+                   RAISING   zcx_abapgit_exception.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    CLASS-METHODS:
+      dyn_call_method IMPORTING io_object     TYPE REF TO object
+                                iv_methname   TYPE abap_methname
+                                it_parameters TYPE abap_parmbind_tab.
+    METHODS:
+      constructor IMPORTING io_repo TYPE REF TO lcl_repo
+                  RAISING   zcx_abapgit_exception,
+      init_listener RAISING cx_sy_create_object_error.
+    DATA:
+      mo_repository TYPE REF TO lcl_repo,
+      mo_listener   TYPE REF TO object.
+ENDCLASS.
+
+CLASS lcl_callback_adapter IMPLEMENTATION.
+  METHOD get_instance.
+    TYPES: BEGIN OF lty_cache,
+             key      TYPE lcl_persistence_db=>ty_value,
+             instance TYPE REF TO lcl_callback_adapter,
+           END OF lty_cache.
+    STATICS: st_cache TYPE SORTED TABLE OF lty_cache WITH UNIQUE KEY key.
+    DATA: lr_cache TYPE REF TO lty_cache.
+
+    ASSERT io_repo IS BOUND AND io_repo->get_key( ) IS NOT INITIAL.
+
+    IF iv_force_new = abap_false.
+      READ TABLE st_cache WITH TABLE KEY key = io_repo->get_key( ) REFERENCE INTO lr_cache.
+      IF sy-subrc = 0 AND lr_cache IS BOUND.
+        ro_instance = lr_cache->instance.
+        ASSERT ro_instance IS BOUND.
+        FREE lr_cache.
+      ENDIF.
+    ENDIF.
+
+    IF ro_instance IS NOT BOUND.
+      CREATE OBJECT ro_instance
+        EXPORTING
+          io_repo = io_repo.
+
+      CREATE DATA lr_cache.
+      lr_cache->instance = ro_instance.
+      lr_cache->key = io_repo->get_key( ).
+
+      TRY.
+          INSERT lr_cache->* INTO TABLE st_cache.
+        CATCH cx_sy_itab_duplicate_key ##NO_HANDLER.
+          " Can occur if iv_force_new was set to true
+      ENDTRY.
+      FREE lr_cache.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD constructor.
+    DATA: lx_ex TYPE REF TO cx_sy_create_object_error.
+
+    ASSERT: io_repo IS BOUND.
+    mo_repository = io_repo.
+
+    TRY.
+        init_listener( ).
+      CATCH cx_sy_create_object_error INTO lx_ex.
+        RAISE EXCEPTION TYPE zcx_abapgit_exception
+          EXPORTING
+            previous = lx_ex
+            text     = lx_ex->get_text( ).
+    ENDTRY.
+  ENDMETHOD.
+
+  METHOD init_listener.
+    DATA: lv_classname TYPE abap_classname.
+
+    ##TODO.
+*    lv_classname = mo_repository->get_dot_abapgit( )->get_callback_classname( ).
+
+    IF lv_classname IS NOT INITIAL.
+      CREATE OBJECT mo_listener TYPE (lv_classname).
+    ELSE.
+      CREATE OBJECT mo_listener TYPE lcl_dummy_callback_listener.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD lif_callback_listener~on_after_install.
+    CONSTANTS: lc_methname             TYPE abap_methname VALUE 'ON_AFTER_INSTALL',
+               lc_parmname_package     TYPE abap_parmname VALUE 'IV_PACKAGE',
+               lc_parmname_old_version TYPE abap_parmname VALUE 'IV_OLD_VERSION',
+               lc_parmname_new_version TYPE abap_parmname VALUE 'IV_NEW_VERSION'.
+    DATA: lt_parameters  TYPE abap_parmbind_tab,
+          ls_parameter   TYPE abap_parmbind,
+          lr_package     TYPE REF TO devclass,
+          lr_old_version TYPE REF TO string,
+          lr_new_version TYPE REF TO string.
+
+    CREATE DATA: lr_package, lr_old_version, lr_new_version.
+
+    ls_parameter-name = lc_parmname_package.
+    ls_parameter-kind = cl_abap_objectdescr=>exporting.
+    lr_package->* = iv_package.
+    ls_parameter-value = lr_package.
+    INSERT ls_parameter INTO TABLE lt_parameters.
+
+    ls_parameter-name = lc_parmname_old_version.
+    ls_parameter-kind = cl_abap_objectdescr=>exporting.
+    lr_old_version->* = iv_old_version.
+    ls_parameter-value = lr_old_version.
+    INSERT ls_parameter INTO TABLE lt_parameters.
+
+    ls_parameter-name = lc_parmname_new_version.
+    ls_parameter-kind = cl_abap_objectdescr=>exporting.
+    lr_new_version->* = iv_new_version.
+    ls_parameter-value = lr_old_version.
+    INSERT ls_parameter INTO TABLE lt_parameters.
+
+    dyn_call_method( io_object     = mo_listener
+                     iv_methname   = lc_methname
+                     it_parameters = lt_parameters ).
+  ENDMETHOD.
+
+  METHOD dyn_call_method.
+    DATA: lx_ex TYPE REF TO cx_sy_dyn_call_error.
+
+    ASSERT: io_object IS BOUND,
+            iv_methname IS NOT INITIAL.
+
+    TRY.
+        CALL METHOD io_object->(iv_methname) PARAMETER-TABLE it_parameters.
+      CATCH cx_sy_dyn_call_error INTO lx_ex.
+        " If a short dump occurs here the listener object does not implement the callback methods
+        " correctly, see LIF_CALLBACK_LISTENER for the method signatures.
+        RAISE EXCEPTION lx_ex.
+    ENDTRY.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zabapgit_callbacks.prog.abap
+++ b/src/zabapgit_callbacks.prog.abap
@@ -247,11 +247,24 @@ CLASS lcl_callback_adapter IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    " Prevent arbitrary code execution by allowing the user to take a look at the (possibly just
-    " pulled) callback implementation.
-    rv_allowed = lcl_popups=>popup_to_decide_callback_exec(
-                   iv_methname           = iv_methname
-                   iv_callback_classname = mv_callback_classname ).
+    CASE mo_repository->get_callback_trust_level( ).
+      WHEN zif_abapgit_definitions=>gc_trust_levels-ask.
+        " Prevent arbitrary code execution by allowing the user to take a look at the (possibly just
+        " pulled) callback implementation.
+        rv_allowed = lcl_popups=>popup_to_decide_callback_exec(
+                       iv_methname           = iv_methname
+                       iv_callback_classname = mv_callback_classname ).
+
+      WHEN zif_abapgit_definitions=>gc_trust_levels-always.
+        rv_allowed = abap_true.
+
+      WHEN zif_abapgit_definitions=>gc_trust_levels-never.
+        rv_allowed = abap_false.
+
+      WHEN OTHERS.
+        ASSERT 1 = 2.
+
+    ENDCASE.
   ENDMETHOD.
 
   METHOD is_dummy_listener.

--- a/src/zabapgit_callbacks.prog.xml
+++ b/src/zabapgit_callbacks.prog.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_PROG" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <PROGDIR>
+    <NAME>ZABAPGIT_CALLBACKS</NAME>
+    <STATE>A</STATE>
+    <VARCL>X</VARCL>
+    <DBAPL>S</DBAPL>
+    <DBNA>D$</DBNA>
+    <SUBC>I</SUBC>
+    <FIXPT>X</FIXPT>
+    <LDBNAME>D$S</LDBNAME>
+    <UCCHECK>X</UCCHECK>
+   </PROGDIR>
+   <TPOOL>
+    <item>
+     <ID>R</ID>
+     <ENTRY>ZABAPGIT_CALLBACKS</ENTRY>
+     <LENGTH>18</LENGTH>
+    </item>
+   </TPOOL>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zabapgit_dot_abapgit.prog.abap
+++ b/src/zabapgit_dot_abapgit.prog.abap
@@ -19,11 +19,12 @@ CLASS lcl_dot_abapgit DEFINITION FINAL FRIENDS ltcl_dot_abapgit.
            END OF ty_requirement,
            ty_requirement_tt TYPE STANDARD TABLE OF ty_requirement WITH DEFAULT KEY,
            BEGIN OF ty_dot_abapgit,
-             master_language TYPE spras,
-             starting_folder TYPE string,
-             folder_logic    TYPE string,
-             ignore          TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
-             requirements    TYPE ty_requirement_tt,
+             master_language    TYPE spras,
+             starting_folder    TYPE string,
+             folder_logic       TYPE string,
+             ignore             TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
+             requirements       TYPE ty_requirement_tt,
+             callback_classname TYPE abap_classname,
            END OF ty_dot_abapgit.
 
     CLASS-METHODS:
@@ -66,7 +67,11 @@ CLASS lcl_dot_abapgit DEFINITION FINAL FRIENDS ltcl_dot_abapgit.
 *        IMPORTING iv_language TYPE spras,
       get_signature
         RETURNING VALUE(rs_signature) TYPE zif_abapgit_definitions=>ty_file_signature
-        RAISING   zcx_abapgit_exception.
+        RAISING   zcx_abapgit_exception,
+      get_callback_classname
+        RETURNING VALUE(rv_classname) TYPE abap_classname,
+      set_callback_classname
+        IMPORTING iv_classname TYPE abap_classname.
 
   PRIVATE SECTION.
     DATA: ms_data TYPE ty_dot_abapgit.
@@ -266,4 +271,11 @@ CLASS lcl_dot_abapgit IMPLEMENTATION.
 
   ENDMETHOD. "get_signature
 
+  METHOD get_callback_classname.
+    rv_classname = ms_data-callback_classname.
+  ENDMETHOD.
+
+  METHOD set_callback_classname.
+    ms_data-callback_classname = iv_classname.
+  ENDMETHOD.
 ENDCLASS.

--- a/src/zabapgit_dot_abapgit.prog.abap
+++ b/src/zabapgit_dot_abapgit.prog.abap
@@ -25,7 +25,6 @@ CLASS lcl_dot_abapgit DEFINITION FINAL FRIENDS ltcl_dot_abapgit.
              ignore             TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
              requirements       TYPE ty_requirement_tt,
              callback_classname TYPE abap_classname,
-             version            TYPE string,
            END OF ty_dot_abapgit.
 
     CLASS-METHODS:
@@ -72,11 +71,7 @@ CLASS lcl_dot_abapgit DEFINITION FINAL FRIENDS ltcl_dot_abapgit.
       get_callback_classname
         RETURNING VALUE(rv_classname) TYPE abap_classname,
       set_callback_classname
-        IMPORTING iv_classname TYPE abap_classname,
-      get_version
-        RETURNING VALUE(rv_version) TYPE string,
-      set_version
-        IMPORTING iv_version TYPE string.
+        IMPORTING iv_classname TYPE abap_classname.
 
   PRIVATE SECTION.
     DATA: ms_data TYPE ty_dot_abapgit.
@@ -282,13 +277,5 @@ CLASS lcl_dot_abapgit IMPLEMENTATION.
 
   METHOD set_callback_classname.
     ms_data-callback_classname = iv_classname.
-  ENDMETHOD.
-
-  METHOD get_version.
-    rv_version = ms_data-version.
-  ENDMETHOD.
-
-  METHOD set_version.
-    ms_data-version = iv_version.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zabapgit_dot_abapgit.prog.abap
+++ b/src/zabapgit_dot_abapgit.prog.abap
@@ -24,7 +24,7 @@ CLASS lcl_dot_abapgit DEFINITION FINAL FRIENDS ltcl_dot_abapgit.
              folder_logic       TYPE string,
              ignore             TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
              requirements       TYPE ty_requirement_tt,
-             callback_classname TYPE abap_classname,
+             callback_classname TYPE string,
            END OF ty_dot_abapgit.
 
     CLASS-METHODS:
@@ -69,9 +69,9 @@ CLASS lcl_dot_abapgit DEFINITION FINAL FRIENDS ltcl_dot_abapgit.
         RETURNING VALUE(rs_signature) TYPE zif_abapgit_definitions=>ty_file_signature
         RAISING   zcx_abapgit_exception,
       get_callback_classname
-        RETURNING VALUE(rv_classname) TYPE abap_classname,
+        RETURNING VALUE(rv_classname) TYPE string,
       set_callback_classname
-        IMPORTING iv_classname TYPE abap_classname.
+        IMPORTING iv_classname TYPE string.
 
   PRIVATE SECTION.
     DATA: ms_data TYPE ty_dot_abapgit.

--- a/src/zabapgit_dot_abapgit.prog.abap
+++ b/src/zabapgit_dot_abapgit.prog.abap
@@ -25,6 +25,7 @@ CLASS lcl_dot_abapgit DEFINITION FINAL FRIENDS ltcl_dot_abapgit.
              ignore             TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
              requirements       TYPE ty_requirement_tt,
              callback_classname TYPE abap_classname,
+             version            TYPE string,
            END OF ty_dot_abapgit.
 
     CLASS-METHODS:
@@ -71,7 +72,11 @@ CLASS lcl_dot_abapgit DEFINITION FINAL FRIENDS ltcl_dot_abapgit.
       get_callback_classname
         RETURNING VALUE(rv_classname) TYPE abap_classname,
       set_callback_classname
-        IMPORTING iv_classname TYPE abap_classname.
+        IMPORTING iv_classname TYPE abap_classname,
+      get_version
+        RETURNING VALUE(rv_version) TYPE string,
+      set_version
+        IMPORTING iv_version TYPE string.
 
   PRIVATE SECTION.
     DATA: ms_data TYPE ty_dot_abapgit.
@@ -277,5 +282,13 @@ CLASS lcl_dot_abapgit IMPLEMENTATION.
 
   METHOD set_callback_classname.
     ms_data-callback_classname = iv_classname.
+  ENDMETHOD.
+
+  METHOD get_version.
+    rv_version = ms_data-version.
+  ENDMETHOD.
+
+  METHOD set_version.
+    ms_data-version = iv_version.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zabapgit_page_repo_settings.prog.abap
+++ b/src/zabapgit_page_repo_settings.prog.abap
@@ -46,22 +46,48 @@ CLASS lcl_gui_page_repo_sett IMPLEMENTATION.
 
   METHOD render_content.
 
-    DATA: ls_dot TYPE lcl_dot_abapgit=>ty_dot_abapgit.
+    DATA: ls_dot         TYPE lcl_dot_abapgit=>ty_dot_abapgit,
+          lv_trust_level TYPE zif_abapgit_definitions=>gty_trust_level.
 
 
     ls_dot = mo_repo->get_dot_abapgit( )->get_data( ).
+    lv_trust_level = mo_repo->get_callback_trust_level( ).
 
     CREATE OBJECT ro_html.
     ro_html->add( '<div class="settings_container">' ).
     ro_html->add( '<form id="settings_form" method="post" action="sapevent:' &&
       c_action-save_settings && '">' ).
-    ro_html->add( '<br>' ).
+    ro_html->add( '<h2>Repository settings</h2>' ).
     ro_html->add( 'Folder logic: <input name="folder_logic" type="text" size="10" value="' &&
       ls_dot-folder_logic && '">' ).
     ro_html->add( '<br>' ).
     ro_html->add( 'Starting folder: <input name="starting_folder" type="text" size="10" value="' &&
       ls_dot-starting_folder && '">' ).
     ro_html->add( '<br>' ).
+
+    ro_html->add( |<hr>| ).
+    ro_html->add( |<h2>Local installation settings</h2>| ).
+    ro_html->add( |<label>Callback execution:| ).
+    ro_html->add( |<select name="callback_trust" size="1">| ).
+    ro_html->add( |<option value="{ zif_abapgit_definitions=>gc_trust_levels-ask }"| ).
+    IF lv_trust_level = zif_abapgit_definitions=>gc_trust_levels-ask.
+      ro_html->add( | selected| ).
+    ENDIF.
+    ro_html->add( |>Ask every time</option>| ).
+    ro_html->add( |<option value="{ zif_abapgit_definitions=>gc_trust_levels-always }"| ).
+    IF lv_trust_level = zif_abapgit_definitions=>gc_trust_levels-always.
+      ro_html->add( | selected| ).
+    ENDIF.
+    ro_html->add( |>Always execute</option>| ).
+    ro_html->add( |<option value="{ zif_abapgit_definitions=>gc_trust_levels-never }"| ).
+    IF lv_trust_level = zif_abapgit_definitions=>gc_trust_levels-never.
+      ro_html->add( | selected| ).
+    ENDIF.
+    ro_html->add( |>Never execute</option>| ).
+    ro_html->add( |</select>| ).
+    ro_html->add( |</label>| ).
+
+    ro_html->add( '<br><br>' ).
     ro_html->add( '<input type="submit" value="Save" class="submit">' ).
     ro_html->add( '</form>' ).
     ro_html->add( '</div>' ).
@@ -90,6 +116,11 @@ CLASS lcl_gui_page_repo_sett IMPLEMENTATION.
         lo_dot->set_starting_folder( ls_post_field-value ).
 
         mo_repo->set_dot_abapgit( lo_dot ).
+
+        READ TABLE lt_post_fields INTO ls_post_field WITH KEY name = 'callback_trust'.
+        ASSERT sy-subrc = 0.
+        mo_repo->set_callback_trust_level( ls_post_field-value ).
+
         mo_repo->refresh( ).
 
         ev_state = zif_abapgit_definitions=>gc_event_state-go_back.

--- a/src/zabapgit_popups.prog.abap
+++ b/src/zabapgit_popups.prog.abap
@@ -84,10 +84,6 @@ CLASS lcl_popups DEFINITION FINAL.
                   it_columns_to_display TYPE stringtab
         EXPORTING VALUE(et_list)        TYPE STANDARD TABLE
         RAISING   zcx_abapgit_exception,
-      popup_select_obj_overwrite
-        IMPORTING it_list        TYPE lif_defs=>ty_results_tt
-        RETURNING VALUE(rt_list) TYPE lif_defs=>ty_results_tt
-        RAISING   zcx_abapgit_exception,
       popup_to_decide_callback_exec
         IMPORTING iv_methname           TYPE abap_methname
                   iv_callback_classname TYPE abap_classname

--- a/src/zabapgit_popups.prog.abap
+++ b/src/zabapgit_popups.prog.abap
@@ -86,7 +86,7 @@ CLASS lcl_popups DEFINITION FINAL.
         RAISING   zcx_abapgit_exception,
       popup_to_decide_callback_exec
         IMPORTING iv_methname           TYPE abap_methname
-                  iv_callback_classname TYPE abap_classname
+                  iv_callback_classname TYPE string
         RETURNING VALUE(rv_execute)     TYPE abap_bool
         RAISING   zcx_abapgit_exception.
 
@@ -984,7 +984,11 @@ CLASS lcl_popups IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD popup_to_decide_callback_exec.
-    DATA: lv_answer TYPE c LENGTH 1.
+    CONSTANTS: lc_pattern TYPE string VALUE `\\PROGRAM\=(.+)\\CLASS\=.+`.
+    DATA: lv_answer TYPE c LENGTH 1,
+          lv_prog   TYPE progname.
+
+    FIND FIRST OCCURRENCE OF REGEX lc_pattern IN iv_callback_classname SUBMATCHES lv_prog.
 
     rv_execute = abap_undefined.
 
@@ -1012,15 +1016,24 @@ CLASS lcl_popups IMPLEMENTATION.
 
       IF lv_answer = '1'.
         rv_execute = abap_true.
-      ELSEIF lv_answer = 'C'.
+      ELSEIF lv_answer = 'A'.
         rv_execute = abap_false.
       ELSEIF lv_answer = '2'.
-        CALL FUNCTION 'RS_TOOL_ACCESS'
-          EXPORTING
-            operation     = 'SHOW'
-            object_name   = iv_callback_classname
-            object_type   = 'CLAS'
-            in_new_window = abap_true.
+        IF lv_prog IS NOT INITIAL.
+          CALL FUNCTION 'RS_TOOL_ACCESS'
+            EXPORTING
+              operation     = 'SHOW'
+              object_name   = lv_prog
+              object_type   = 'PROG'
+              in_new_window = abap_true.
+        ELSE.
+          CALL FUNCTION 'RS_TOOL_ACCESS'
+            EXPORTING
+              operation     = 'SHOW'
+              object_name   = iv_callback_classname
+              object_type   = 'CLAS'
+              in_new_window = abap_true.
+        ENDIF.
       ENDIF.
     ENDWHILE.
   ENDMETHOD.

--- a/src/zabapgit_popups.prog.abap
+++ b/src/zabapgit_popups.prog.abap
@@ -995,9 +995,9 @@ CLASS lcl_popups IMPLEMENTATION.
           text_question         = |The repository wants to execute the callback "| &&
                                   |{ iv_methname }". Allow execution?|
           text_button_1         = 'Allow'
-          icon_button_1         = icon_checked
-          text_button_2         = 'Display callback implementation'
-          icon_button_2         = icon_select_detail
+          icon_button_1         = 'ICON_CHECKED'
+          text_button_2         = 'View code'
+          icon_button_2         = 'ICON_SELECT_DETAIL'
           default_button        = '2'
           display_cancel_button = abap_true
           popup_type            = 'ICON_MESSAGE_QUESTION'

--- a/src/zabapgit_repo.prog.abap
+++ b/src/zabapgit_repo.prog.abap
@@ -59,7 +59,12 @@ CLASS lcl_repo DEFINITION ABSTRACT FRIENDS lcl_repo_srv.
         RAISING   zcx_abapgit_exception,
       is_offline
         RETURNING VALUE(rv_offline) TYPE abap_bool
-        RAISING   zcx_abapgit_exception.
+        RAISING   zcx_abapgit_exception,
+      set_callback_trust_level
+        IMPORTING iv_level TYPE zif_abapgit_definitions=>gty_trust_level
+        RAISING   zcx_abapgit_exception,
+      get_callback_trust_level
+        RETURNING VALUE(rv_level) TYPE zif_abapgit_definitions=>gty_trust_level.
 
   PROTECTED SECTION.
     DATA: mt_local              TYPE zif_abapgit_definitions=>ty_files_item_tt,
@@ -70,13 +75,14 @@ CLASS lcl_repo DEFINITION ABSTRACT FRIENDS lcl_repo_srv.
 
     METHODS:
       set
-        IMPORTING iv_sha1        TYPE zif_abapgit_definitions=>ty_sha1 OPTIONAL
-                  it_checksums   TYPE lcl_persistence_repo=>ty_local_checksum_tt OPTIONAL
-                  iv_url         TYPE lcl_persistence_repo=>ty_repo-url OPTIONAL
-                  iv_branch_name TYPE lcl_persistence_repo=>ty_repo-branch_name OPTIONAL
-                  iv_head_branch TYPE lcl_persistence_repo=>ty_repo-head_branch OPTIONAL
-                  iv_offline     TYPE lcl_persistence_repo=>ty_repo-offline OPTIONAL
-                  is_dot_abapgit TYPE lcl_persistence_repo=>ty_repo-dot_abapgit OPTIONAL
+        IMPORTING iv_sha1                 TYPE zif_abapgit_definitions=>ty_sha1 OPTIONAL
+                  it_checksums            TYPE lcl_persistence_repo=>ty_local_checksum_tt OPTIONAL
+                  iv_url                  TYPE lcl_persistence_repo=>ty_repo-url OPTIONAL
+                  iv_branch_name          TYPE lcl_persistence_repo=>ty_repo-branch_name OPTIONAL
+                  iv_head_branch          TYPE lcl_persistence_repo=>ty_repo-head_branch OPTIONAL
+                  iv_offline              TYPE lcl_persistence_repo=>ty_repo-offline OPTIONAL
+                  is_dot_abapgit          TYPE lcl_persistence_repo=>ty_repo-dot_abapgit OPTIONAL
+                  iv_callback_trust_level TYPE lcl_persistence_repo=>ty_repo-callback_trust_level OPTIONAL
         RAISING   zcx_abapgit_exception.
 
 ENDCLASS.                    "lcl_repo DEFINITION
@@ -134,7 +140,7 @@ CLASS lcl_repo_online DEFINITION INHERITING FROM lcl_repo FINAL.
                   io_stage   TYPE REF TO lcl_stage
         RAISING   zcx_abapgit_exception,
       get_unnecessary_local_objs
-        RETURNING VALUE(rt_unnecessary_local_objects) TYPE zif_abapgit_definitions=>TY_TADIR_TT
+        RETURNING VALUE(rt_unnecessary_local_objects) TYPE zif_abapgit_definitions=>ty_tadir_tt
         RAISING   zcx_abapgit_exception.
 
   PRIVATE SECTION.
@@ -237,6 +243,6 @@ CLASS lcl_repo_srv DEFINITION FINAL CREATE PRIVATE FRIENDS lcl_app.
 
     METHODS is_sap_object_allowed
       RETURNING
-        value(r_is_sap_object_allowed) TYPE abap_bool.
+        VALUE(r_is_sap_object_allowed) TYPE abap_bool.
 
 ENDCLASS.                    "lcl_repo_srv DEFINITION

--- a/src/zabapgit_repo_impl.prog.abap
+++ b/src/zabapgit_repo_impl.prog.abap
@@ -582,11 +582,7 @@ CLASS lcl_repo IMPLEMENTATION.
     update_local_checksums( lt_updated_files ).
 
     lo_callback_adapter = lcl_callback_adapter=>get_instance( me ).
-    IF lo_callback_adapter->check_execution_allowed(
-         lcl_callback_adapter=>gc_methnames-on_after_deserialize
-       ) = abap_true.
-      lo_callback_adapter->on_after_deserialize( get_package( ) ).
-    ENDIF.
+    lo_callback_adapter->on_after_deserialize( get_package( ) ).
 
   ENDMETHOD.
 

--- a/src/zabapgit_repo_impl.prog.abap
+++ b/src/zabapgit_repo_impl.prog.abap
@@ -413,7 +413,8 @@ CLASS lcl_repo IMPLEMENTATION.
       OR iv_branch_name IS SUPPLIED
       OR iv_head_branch IS SUPPLIED
       OR iv_offline IS SUPPLIED
-      OR is_dot_abapgit IS SUPPLIED.
+      OR is_dot_abapgit IS SUPPLIED
+      OR iv_callback_trust_level IS SUPPLIED.
 
     CREATE OBJECT lo_persistence.
 
@@ -464,6 +465,13 @@ CLASS lcl_repo IMPLEMENTATION.
         iv_key         = ms_data-key
         is_dot_abapgit = is_dot_abapgit ).
       ms_data-dot_abapgit = is_dot_abapgit.
+    ENDIF.
+
+    IF iv_callback_trust_level IS SUPPLIED.
+      lo_persistence->update_callback_trust_level(
+        iv_key                  = ms_data-key
+        iv_callback_trust_level = iv_callback_trust_level ).
+      ms_data-callback_trust_level = iv_callback_trust_level.
     ENDIF.
 
   ENDMETHOD.
@@ -797,6 +805,14 @@ CLASS lcl_repo IMPLEMENTATION.
     set( it_checksums = lt_checksums ).
 
   ENDMETHOD.  " rebuild_local_checksums.
+
+  METHOD get_callback_trust_level.
+    rv_level = ms_data-callback_trust_level.
+  ENDMETHOD.
+
+  METHOD set_callback_trust_level.
+    set( iv_callback_trust_level = iv_level ).
+  ENDMETHOD.
 
 ENDCLASS.                    "lcl_repo IMPLEMENTATION
 

--- a/src/zabapgit_repo_impl.prog.abap
+++ b/src/zabapgit_repo_impl.prog.abap
@@ -548,8 +548,9 @@ CLASS lcl_repo IMPLEMENTATION.
 
   METHOD deserialize.
 
-    DATA: lt_updated_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt,
-          lt_requirements  TYPE STANDARD TABLE OF lcl_dot_abapgit=>ty_requirement.
+    DATA: lt_updated_files    TYPE zif_abapgit_definitions=>ty_file_signatures_tt,
+          lt_requirements     TYPE STANDARD TABLE OF lcl_dot_abapgit=>ty_requirement,
+          lo_callback_adapter TYPE REF TO lcl_callback_adapter.
 
 
     find_remote_dot_abapgit( ).
@@ -571,6 +572,13 @@ CLASS lcl_repo IMPLEMENTATION.
     CLEAR: mt_local, mv_last_serialization.
 
     update_local_checksums( lt_updated_files ).
+
+    lo_callback_adapter = lcl_callback_adapter=>get_instance( me ).
+    IF lo_callback_adapter->check_execution_allowed(
+         lcl_callback_adapter=>gc_methnames-on_after_deserialize
+       ) = abap_true.
+      lo_callback_adapter->on_after_deserialize( get_package( ) ).
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/zabapgit_services_git.prog.abap
+++ b/src/zabapgit_services_git.prog.abap
@@ -153,11 +153,11 @@ CLASS lcl_services_git IMPLEMENTATION.
 
     lo_callback_adapter = lcl_callback_adapter=>get_instance( lo_repo ).
     IF lo_callback_adapter->check_execution_allowed(
-         lcl_callback_adapter=>gc_methname_on_after_install
+         lcl_callback_adapter=>gc_methname_on_after_pull
        ) = abap_true.
-      lo_callback_adapter->on_after_install( iv_package     = lo_repo->get_package( )
-                                             iv_old_version = lv_old_version
-                                             iv_new_version = lv_new_version ).
+      lo_callback_adapter->on_after_pull( iv_package     = lo_repo->get_package( )
+                                          iv_old_version = lv_old_version
+                                          iv_new_version = lv_new_version ).
     ENDIF.
 
     COMMIT WORK.

--- a/src/zabapgit_services_git.prog.abap
+++ b/src/zabapgit_services_git.prog.abap
@@ -134,8 +134,7 @@ CLASS lcl_services_git IMPLEMENTATION.
 
   METHOD pull.
 
-    DATA: lo_repo             TYPE REF TO lcl_repo_online,
-          lo_callback_adapter TYPE REF TO lcl_callback_adapter.
+    DATA: lo_repo             TYPE REF TO lcl_repo_online.
 
     lo_repo ?= lcl_app=>repo_srv( )->get( iv_key ).
 
@@ -145,13 +144,6 @@ CLASS lcl_services_git IMPLEMENTATION.
 
     lo_repo->refresh( ).
     lo_repo->deserialize( ).
-
-    lo_callback_adapter = lcl_callback_adapter=>get_instance( lo_repo ).
-    IF lo_callback_adapter->check_execution_allowed(
-         lcl_callback_adapter=>gc_methnames-on_after_pull
-       ) = abap_true.
-      lo_callback_adapter->on_after_pull( lo_repo->get_package( ) ).
-    ENDIF.
 
     COMMIT WORK.
 

--- a/src/zabapgit_services_git.prog.abap
+++ b/src/zabapgit_services_git.prog.abap
@@ -153,7 +153,7 @@ CLASS lcl_services_git IMPLEMENTATION.
 
     lo_callback_adapter = lcl_callback_adapter=>get_instance( lo_repo ).
     IF lo_callback_adapter->check_execution_allowed(
-         lcl_callback_adapter=>gc_methname_on_after_pull
+         lcl_callback_adapter=>gc_methnames-on_after_pull
        ) = abap_true.
       lo_callback_adapter->on_after_pull( iv_package     = lo_repo->get_package( )
                                           iv_old_version = lv_old_version

--- a/src/zabapgit_services_git.prog.abap
+++ b/src/zabapgit_services_git.prog.abap
@@ -134,7 +134,7 @@ CLASS lcl_services_git IMPLEMENTATION.
 
   METHOD pull.
 
-    DATA: lo_repo             TYPE REF TO lcl_repo_online.
+    DATA: lo_repo TYPE REF TO lcl_repo_online.
 
     lo_repo ?= lcl_app=>repo_srv( )->get( iv_key ).
 

--- a/src/zabapgit_services_git.prog.abap
+++ b/src/zabapgit_services_git.prog.abap
@@ -135,12 +135,9 @@ CLASS lcl_services_git IMPLEMENTATION.
   METHOD pull.
 
     DATA: lo_repo             TYPE REF TO lcl_repo_online,
-          lo_callback_adapter TYPE REF TO lcl_callback_adapter,
-          lv_old_version      TYPE string,
-          lv_new_version      TYPE string.
+          lo_callback_adapter TYPE REF TO lcl_callback_adapter.
 
     lo_repo ?= lcl_app=>repo_srv( )->get( iv_key ).
-    lv_old_version = lo_repo->get_dot_abapgit( )->get_version( ).
 
     IF lo_repo->is_write_protected( ) = abap_true.
       zcx_abapgit_exception=>raise( 'Cannot pull. Local code is write-protected by repo config' ).
@@ -149,15 +146,11 @@ CLASS lcl_services_git IMPLEMENTATION.
     lo_repo->refresh( ).
     lo_repo->deserialize( ).
 
-    lv_new_version = lo_repo->get_dot_abapgit( )->get_version( ).
-
     lo_callback_adapter = lcl_callback_adapter=>get_instance( lo_repo ).
     IF lo_callback_adapter->check_execution_allowed(
          lcl_callback_adapter=>gc_methnames-on_after_pull
        ) = abap_true.
-      lo_callback_adapter->on_after_pull( iv_package     = lo_repo->get_package( )
-                                          iv_old_version = lv_old_version
-                                          iv_new_version = lv_new_version ).
+      lo_callback_adapter->on_after_pull( lo_repo->get_package( ) ).
     ENDIF.
 
     COMMIT WORK.

--- a/src/zabapgit_services_repo.prog.abap
+++ b/src/zabapgit_services_repo.prog.abap
@@ -57,8 +57,8 @@ CLASS lcl_services_repo IMPLEMENTATION.
 
   METHOD clone.
 
-    DATA: lo_repo             TYPE REF TO lcl_repo_online,
-          ls_popup            TYPE lcl_popups=>ty_popup.
+    DATA: lo_repo  TYPE REF TO lcl_repo_online,
+          ls_popup TYPE lcl_popups=>ty_popup.
 
 
     ls_popup = lcl_popups=>repo_popup( iv_url ).

--- a/src/zabapgit_services_repo.prog.abap
+++ b/src/zabapgit_services_repo.prog.abap
@@ -57,8 +57,9 @@ CLASS lcl_services_repo IMPLEMENTATION.
 
   METHOD clone.
 
-    DATA: lo_repo  TYPE REF TO lcl_repo_online,
-          ls_popup TYPE lcl_popups=>ty_popup.
+    DATA: lo_repo             TYPE REF TO lcl_repo_online,
+          ls_popup            TYPE lcl_popups=>ty_popup,
+          lo_callback_adapter TYPE REF TO lcl_callback_adapter.
 
 
     ls_popup = lcl_popups=>repo_popup( iv_url ).
@@ -81,6 +82,13 @@ CLASS lcl_services_repo IMPLEMENTATION.
     lcl_app=>user( )->set_repo_show( lo_repo->get_key( ) ). " Set default repo for user
 
     COMMIT WORK.
+
+    lo_callback_adapter = lcl_callback_adapter=>get_instance( lo_repo ).
+    IF lo_callback_adapter->check_execution_allowed(
+         lcl_callback_adapter=>gc_methnames-on_after_install
+       ) = abap_true.
+      lo_callback_adapter->on_after_install( iv_package = lo_repo->get_package( ) ).
+    ENDIF.
 
   ENDMETHOD.  "clone
 

--- a/src/zabapgit_services_repo.prog.abap
+++ b/src/zabapgit_services_repo.prog.abap
@@ -125,11 +125,12 @@ CLASS lcl_services_repo IMPLEMENTATION.
 
   METHOD purge.
 
-    DATA: lt_tadir    TYPE zif_abapgit_definitions=>ty_tadir_tt,
-          lv_answer   TYPE c LENGTH 1,
-          lo_repo     TYPE REF TO lcl_repo,
-          lv_package  TYPE devclass,
-          lv_question TYPE c LENGTH 100.
+    DATA: lt_tadir            TYPE zif_abapgit_definitions=>ty_tadir_tt,
+          lv_answer           TYPE c LENGTH 1,
+          lo_repo             TYPE REF TO lcl_repo,
+          lv_package          TYPE devclass,
+          lv_question         TYPE c LENGTH 100,
+          lo_callback_adapter TYPE REF TO lcl_callback_adapter.
 
 
     lo_repo = lcl_app=>repo_srv( )->get( iv_key ).
@@ -158,6 +159,13 @@ CLASS lcl_services_repo IMPLEMENTATION.
 
       IF lv_answer = '2'.
         RAISE EXCEPTION TYPE lcx_cancel.
+      ENDIF.
+
+      lo_callback_adapter = lcl_callback_adapter=>get_instance( lo_repo ).
+      IF lo_callback_adapter->check_execution_allowed(
+           lcl_callback_adapter=>gc_methnames-on_before_uninstall
+         ) = abap_true.
+        lo_callback_adapter->on_before_uninstall( iv_package = lo_repo->get_package( ) ).
       ENDIF.
 
       lcl_objects=>delete( lt_tadir ).

--- a/src/zabapgit_services_repo.prog.abap
+++ b/src/zabapgit_services_repo.prog.abap
@@ -58,8 +58,7 @@ CLASS lcl_services_repo IMPLEMENTATION.
   METHOD clone.
 
     DATA: lo_repo             TYPE REF TO lcl_repo_online,
-          ls_popup            TYPE lcl_popups=>ty_popup,
-          lo_callback_adapter TYPE REF TO lcl_callback_adapter.
+          ls_popup            TYPE lcl_popups=>ty_popup.
 
 
     ls_popup = lcl_popups=>repo_popup( iv_url ).
@@ -82,13 +81,6 @@ CLASS lcl_services_repo IMPLEMENTATION.
     lcl_app=>user( )->set_repo_show( lo_repo->get_key( ) ). " Set default repo for user
 
     COMMIT WORK.
-
-    lo_callback_adapter = lcl_callback_adapter=>get_instance( lo_repo ).
-    IF lo_callback_adapter->check_execution_allowed(
-         lcl_callback_adapter=>gc_methnames-on_after_install
-       ) = abap_true.
-      lo_callback_adapter->on_after_install( iv_package = lo_repo->get_package( ) ).
-    ENDIF.
 
   ENDMETHOD.  "clone
 

--- a/src/zabapgit_services_repo.prog.abap
+++ b/src/zabapgit_services_repo.prog.abap
@@ -162,11 +162,7 @@ CLASS lcl_services_repo IMPLEMENTATION.
       ENDIF.
 
       lo_callback_adapter = lcl_callback_adapter=>get_instance( lo_repo ).
-      IF lo_callback_adapter->check_execution_allowed(
-           lcl_callback_adapter=>gc_methnames-on_before_uninstall
-         ) = abap_true.
-        lo_callback_adapter->on_before_uninstall( iv_package = lo_repo->get_package( ) ).
-      ENDIF.
+      lo_callback_adapter->on_before_uninstall( iv_package = lo_repo->get_package( ) ).
 
       lcl_objects=>delete( lt_tadir ).
 

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -267,7 +267,12 @@ INTERFACE zif_abapgit_definitions
     END OF gc_version.
 
   TYPES:
-    gty_trust_level TYPE string.
+    gty_trust_level TYPE string,
+    BEGIN OF gty_callback_submit,
+      repokey  TYPE c LENGTH 12,
+      callback TYPE abap_methname,
+      args     TYPE xstring,
+    END OF gty_callback_submit.
   CONSTANTS:
     "! Trust levels for repository callback execution
     "! <p>

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -266,4 +266,20 @@ INTERFACE zif_abapgit_definitions
       inactive TYPE r3state VALUE 'I',
     END OF gc_version.
 
+  TYPES:
+    gty_trust_level TYPE string.
+  CONSTANTS:
+    "! Trust levels for repository callback execution
+    "! <p>
+    "! These can be changed for each repository in the repo settings page. Default is ASK.
+    "! </p>
+    BEGIN OF gc_trust_levels,
+      "! Ask wether the callback should be executed or not
+      ask    TYPE gty_trust_level VALUE 'ASK',
+      "! Always execute callbacks for the repository without confirmation dialog
+      always TYPE gty_trust_level VALUE 'ALWAYS',
+      "! Never execute callbacks for the repository
+      never  TYPE gty_trust_level VALUE 'NEVER',
+    END OF gc_trust_levels.
+
 ENDINTERFACE.


### PR DESCRIPTION
Fixes #686

I added inline documentation for the implementation details. Some notes on the "workflow" to subscribe to these new events:
- Manually copy the method signatures of `LIF_CALLBACK_LISTENER` into a listener class within an abapGit repository
- Register the listener in the .abapgit.xml attribute `CALLBACK_CLASSNAME`
- Implement the callback methods

Side effects that might need discussion:
- For the old / new version parameters in the pull callback I introduced a version attribute to .abapgit.xml. I think this would be needed at some point in the future anyways and the alternative would be comparing commit hashes since tags aren't there yet.

Example: https://github.com/flaiker/callback-example

Local classes should also work (with the full name), though I haven't tested that yet. I also noticed some edge cases, where the type descriptor cache still has an old version (callback class was just pulled and activated and the cl_abap_typedescr=>admin_tab still contains the old descriptor reference). Probably need to do the system-call oneself, don't know of any way to clear that cache without leaving and reentering abapGit.

Note that these events are _dev-system-only_ (I should add that to the documentation). To do something useful with them in a multi system landscape you need to generate transport requests in the callback method implementations (possibly with XPRA report execution).
