### PR TITLE
Docs: remove repeating abapGit, add meta tags

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: abapGit Docs
+title: abapGit documentation
 keep_files: [explore.html, repos.json]
 highlighter: rouge
 defaults:

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -4,4 +4,6 @@
 <link rel="stylesheet" href="main.css">
 <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/octicons/4.4.0/font/octicons.min.css">
 <title>{% if page.title %}{{ site.title }} - {{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+<meta name="description" content="{% if page.title %}{{ site.title }} - {{ page.title }}{% else %}{{ site.title }} - Home{% endif %}" />
+<meta name="keywords" content="abapGit,abapGit documentation" />
 </head>

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,5 +1,6 @@
 <div class="page-head">
 	<div class="wrap">
-		<a href="./"><img class="head-logo" src="img/logo.svg" height="40" alt="abapGit"></a><span class="head-title">abapGit documentation</span>
+		<a href="./"><img class="head-logo" src="img/logo.svg" height="40" alt="abapGit"></a>
+		<span class="head-title"> &#x25BA; documentation</span>
 	</div>
 </div>


### PR DESCRIPTION
to #1018

- added meta tags
- removed text "abapGit" (finally decided on "arrow" version)
- also changed site title from Docs to "documentation". Guess it is better :)