### PR TITLE
Proxy configuration user exit 

### DIFF
--- a/src/zabapgit.prog.abap
+++ b/src/zabapgit.prog.abap
@@ -48,6 +48,7 @@ INCLUDE zabapgit_folder_logic.
 INCLUDE zabapgit_requirements.
 INCLUDE zabapgit_authorizations.
 INCLUDE zabapgit_exit.
+INCLUDE zabapgit_proxy.
 
 INCLUDE zabapgit_stage.
 INCLUDE zabapgit_git_helpers.

--- a/src/zabapgit_2fa.prog.abap
+++ b/src/zabapgit_2fa.prog.abap
@@ -446,17 +446,18 @@ CLASS lcl_2fa_github_auth IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD is_2fa_required.
-    DATA: li_client   TYPE REF TO if_http_client,
-          lo_settings TYPE REF TO lcl_settings.
 
-    lo_settings = lcl_app=>settings( )->read( ).
+    DATA: li_client TYPE REF TO if_http_client,
+          lo_proxy  TYPE REF TO lcl_proxy_configuration.
+
+    lo_proxy = lcl_app=>proxy( ).
 
     cl_http_client=>create_by_url(
       EXPORTING
         url                = gc_github_api_url
         ssl_id             = 'ANONYM'
-        proxy_host         = lo_settings->get_proxy_url( )
-        proxy_service      = lo_settings->get_proxy_port( )
+        proxy_host         = lo_proxy->get_proxy_url( )
+        proxy_service      = lo_proxy->get_proxy_port(  )
       IMPORTING
         client             = li_client
       EXCEPTIONS

--- a/src/zabapgit_app.prog.abap
+++ b/src/zabapgit_app.prog.abap
@@ -7,6 +7,7 @@ CLASS lcl_persistence_user DEFINITION DEFERRED.
 CLASS lcl_repo_srv DEFINITION DEFERRED.
 CLASS lcl_persistence_db DEFINITION DEFERRED.
 CLASS lcl_persist_settings DEFINITION DEFERRED.
+CLASS lcl_proxy_configuration DEFINITION DEFERRED.
 
 *----------------------------------------------------------------------*
 *       CLASS lcl_app DEFINITION
@@ -32,11 +33,15 @@ CLASS lcl_app DEFINITION FINAL.
     CLASS-METHODS settings
       RETURNING VALUE(ro_settings) TYPE REF TO lcl_persist_settings.
 
+    CLASS-METHODS proxy
+      RETURNING VALUE(ro_proxy) TYPE REF TO lcl_proxy_configuration.
+
   PRIVATE SECTION.
     CLASS-DATA: go_gui          TYPE REF TO lcl_gui,
                 go_current_user TYPE REF TO lcl_persistence_user,
                 go_db           TYPE REF TO lcl_persistence_db,
                 go_repo_srv     TYPE REF TO lcl_repo_srv,
-                go_settings     TYPE REF TO lcl_persist_settings.
+                go_settings     TYPE REF TO lcl_persist_settings,
+                go_proxy        TYPE REF TO lcl_proxy_configuration.
 
 ENDCLASS.   "lcl_app

--- a/src/zabapgit_app_impl.prog.abap
+++ b/src/zabapgit_app_impl.prog.abap
@@ -57,7 +57,7 @@ CLASS lcl_app IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD proxy.
-   IF go_proxy IS NOT BOUND.
+    IF go_proxy IS NOT BOUND.
       CREATE OBJECT go_proxy.
     ENDIF.
     ro_proxy = go_proxy.

--- a/src/zabapgit_app_impl.prog.abap
+++ b/src/zabapgit_app_impl.prog.abap
@@ -56,4 +56,11 @@ CLASS lcl_app IMPLEMENTATION.
     ro_settings = go_settings.
   ENDMETHOD.
 
+  METHOD proxy.
+   IF go_proxy IS NOT BOUND.
+      CREATE OBJECT go_proxy.
+    ENDIF.
+    ro_proxy = go_proxy.
+  ENDMETHOD.
+
 ENDCLASS.   "lcl_app

--- a/src/zabapgit_exit.prog.abap
+++ b/src/zabapgit_exit.prog.abap
@@ -8,7 +8,17 @@ INTERFACE lif_exit.
     change_local_host
       CHANGING ct_hosts TYPE zif_abapgit_definitions=>ty_icm_sinfo2_tt,
     allow_sap_objects
-      RETURNING VALUE(rv_allowed) TYPE abap_bool.
+      RETURNING VALUE(rv_allowed) TYPE abap_bool,
+    change_proxy_url
+      IMPORTING iv_repo_url TYPE csequence
+      CHANGING  c_proxy_url TYPE string,
+    change_proxy_port
+      IMPORTING iv_repo_url  TYPE csequence
+      CHANGING  c_proxy_port TYPE string,
+    change_proxy_authentication
+      IMPORTING iv_repo_url            TYPE csequence
+      CHANGING  c_proxy_authentication TYPE abap_bool.
+
 
 ENDINTERFACE.
 
@@ -46,6 +56,22 @@ CLASS lcl_exit IMPLEMENTATION.
 
   METHOD lif_exit~allow_sap_objects.
     rv_allowed = abap_false.
+  ENDMETHOD.
+
+
+  METHOD lif_exit~change_proxy_url.
+* default behavior change nothing
+    RETURN.
+  ENDMETHOD.
+
+  METHOD lif_exit~change_proxy_port.
+* default behavior change nothing
+    RETURN.
+  ENDMETHOD.
+
+  METHOD lif_exit~change_proxy_authentication.
+* default behavior change nothing
+    RETURN.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/zabapgit_http.prog.abap
+++ b/src/zabapgit_http.prog.abap
@@ -414,21 +414,20 @@ CLASS lcl_http IMPLEMENTATION.
 
   METHOD create_by_url.
 
-    DATA: lv_uri      TYPE string,
-          lv_scheme   TYPE string,
-          li_client   TYPE REF TO if_http_client,
-          lo_settings TYPE REF TO lcl_settings,
-          lv_text     TYPE string.
+    DATA: lv_uri    TYPE string,
+          lv_scheme TYPE string,
+          li_client TYPE REF TO if_http_client,
+          lo_proxy_configuration  TYPE REF TO lcl_proxy_configuration,
+          lv_text   TYPE string.
 
-
-    lo_settings = lcl_app=>settings( )->read( ).
+    lo_proxy_configuration = lcl_app=>proxy( ).
 
     cl_http_client=>create_by_url(
       EXPORTING
         url           = lcl_url=>host( iv_url )
         ssl_id        = 'ANONYM'
-        proxy_host    = lo_settings->get_proxy_url( )
-        proxy_service = lo_settings->get_proxy_port( )
+        proxy_host    = lo_proxy_configuration->get_proxy_url( iv_url )
+        proxy_service = lo_proxy_configuration->get_proxy_port( iv_url )
       IMPORTING
         client        = li_client
       EXCEPTIONS
@@ -449,7 +448,7 @@ CLASS lcl_http IMPLEMENTATION.
       zcx_abapgit_exception=>raise( lv_text ).
     ENDIF.
 
-    IF lo_settings->get_proxy_authentication( ) = abap_true.
+    IF lo_proxy_configuration->get_proxy_authentication( iv_url ) = abap_true.
       lcl_proxy_auth=>run( li_client ).
     ENDIF.
 
@@ -502,7 +501,7 @@ CLASS lcl_http IMPLEMENTATION.
 
     DATA: lv_host TYPE string,
           lt_list TYPE zif_abapgit_definitions=>ty_icm_sinfo2_tt,
-          li_exit TYPE ref to lif_exit.
+          li_exit TYPE REF TO lif_exit.
 
     CALL FUNCTION 'ICM_GET_INFO2'
       TABLES

--- a/src/zabapgit_persistence.prog.abap
+++ b/src/zabapgit_persistence.prog.abap
@@ -2,7 +2,9 @@
 *&  Include           ZABAPGIT_PERSISTENCE
 *&---------------------------------------------------------------------*
 
+INTERFACE lif_exit DEFERRED.
 CLASS lcl_settings DEFINITION DEFERRED.
+CLASS lcl_exit DEFINITION DEFERRED.
 
 CLASS lcl_persist_migrate DEFINITION FINAL.
 

--- a/src/zabapgit_persistence.prog.abap
+++ b/src/zabapgit_persistence.prog.abap
@@ -2,9 +2,7 @@
 *&  Include           ZABAPGIT_PERSISTENCE
 *&---------------------------------------------------------------------*
 
-INTERFACE lif_exit DEFERRED.
 CLASS lcl_settings DEFINITION DEFERRED.
-CLASS lcl_exit DEFINITION DEFERRED.
 
 CLASS lcl_persist_migrate DEFINITION FINAL.
 

--- a/src/zabapgit_proxy.prog.abap
+++ b/src/zabapgit_proxy.prog.abap
@@ -1,0 +1,81 @@
+*&---------------------------------------------------------------------*
+*& Include zabapgit_proxy
+*&---------------------------------------------------------------------*
+
+CLASS lcl_proxy_configuration DEFINITION CREATE PUBLIC.
+
+  PUBLIC SECTION.
+    METHODS:
+      constructor,
+
+      get_proxy_url
+        IMPORTING
+          iv_repo_url         TYPE csequence OPTIONAL
+        RETURNING
+          VALUE(rv_proxy_url) TYPE string,
+
+      get_proxy_port
+        IMPORTING
+          iv_repo_url    TYPE csequence OPTIONAL
+        RETURNING
+          VALUE(rv_port) TYPE string,
+
+      get_proxy_authentication
+        IMPORTING
+          iv_repo_url    TYPE csequence OPTIONAL
+        RETURNING
+          VALUE(rv_auth) TYPE abap_bool.
+
+  PRIVATE SECTION.
+    DATA: mo_settings TYPE REF TO lcl_settings,
+          mi_exit     TYPE REF TO lif_exit.
+
+ENDCLASS.
+
+CLASS lcl_proxy_configuration IMPLEMENTATION.
+
+  METHOD constructor.
+
+    mo_settings = lcl_app=>settings( )->read( ).
+
+    mi_exit = lcl_exit=>get_instance( ).
+
+  ENDMETHOD.
+
+  METHOD get_proxy_url.
+
+    rv_proxy_url = mo_settings->get_proxy_url( ).
+
+    mi_exit->change_proxy_url(
+      EXPORTING
+        iv_repo_url = iv_repo_url
+      CHANGING
+        c_proxy_url = rv_proxy_url ).
+
+  ENDMETHOD.
+
+  METHOD get_proxy_port.
+
+    rv_port = mo_settings->get_proxy_port( ).
+
+    mi_exit->change_proxy_port(
+      EXPORTING
+        iv_repo_url  = iv_repo_url
+      CHANGING
+        c_proxy_port = rv_port ).
+
+  ENDMETHOD.
+
+  METHOD get_proxy_authentication.
+
+    rv_auth = mo_settings->get_proxy_authentication( ).
+
+    mi_exit->change_proxy_authentication(
+      EXPORTING
+        iv_repo_url            = iv_repo_url
+      CHANGING
+        c_proxy_authentication = rv_auth ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/zabapgit_proxy.prog.xml
+++ b/src/zabapgit_proxy.prog.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_PROG" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <PROGDIR>
+    <NAME>ZABAPGIT_PROXY</NAME>
+    <STATE>A</STATE>
+    <VARCL>X</VARCL>
+    <DBAPL>S</DBAPL>
+    <DBNA>D$</DBNA>
+    <SUBC>I</SUBC>
+    <FIXPT>X</FIXPT>
+    <LDBNAME>D$S</LDBNAME>
+    <UCCHECK>X</UCCHECK>
+   </PROGDIR>
+   <TPOOL>
+    <item>
+     <ID>R</ID>
+     <ENTRY>ZABAPGIT_PROXY</ENTRY>
+     <LENGTH>14</LENGTH>
+    </item>
+   </TPOOL>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
#1013 
This change introduces a separate class lcl_proxy_configuration for proxy configuration. This class provides 3 methods to access the  proxy settings:
- get_proxy_url
- get_proxy_port
- get_proxy_authentication

All three first fetch the data from the appropriate setting and afterwards call userexit methods where exemptions can be programmed. Note that currently the only information which can be examined in the userexit is the repository url.

Here is an example implementation for the userexit.
https://github.com/christianguenter2/abapGitExampleUserExitForProxy/blob/c64d40c87740bab8141cbaf5ea62694673227981/zabapgit_user_exit.prog.abap#L30-L59

Is this reasonable? Or should we move the proxy userexits also to a separate class to avoid syntax errors in existing userexit implementations?