### PR TITLE
Improved HTTP error display

### DIFF
--- a/src/zabapgit_http.prog.abap
+++ b/src/zabapgit_http.prog.abap
@@ -216,7 +216,7 @@ CLASS lcl_http_client IMPLEMENTATION.
           code    = lv_code
           message = lv_message ).
 
-      lv_text = |HTTP error { lv_code } occured: { lv_code }|.
+      lv_text = |HTTP error { lv_code } occured: { lv_message }|.
 
 *      CASE sy-subrc.
 *        WHEN 1.

--- a/src/zabapgit_http.prog.abap
+++ b/src/zabapgit_http.prog.abap
@@ -209,7 +209,13 @@ CLASS lcl_http_client IMPLEMENTATION.
         http_invalid_state         = 2
         http_processing_failed     = 3
         OTHERS                     = 4 ).
+
     IF sy-subrc <> 0.
+      " in case of HTTP_COMMUNICATION_FAILURE
+      " make sure:
+      " a) SSL is setup properly in STRUST
+      " b) no firewalls
+      " check trace file in transaction SMICM
 
       mi_client->get_last_error(
         IMPORTING
@@ -217,21 +223,6 @@ CLASS lcl_http_client IMPLEMENTATION.
           message = lv_message ).
 
       lv_text = |HTTP error { lv_code } occured: { lv_message }|.
-
-*      CASE sy-subrc.
-*        WHEN 1.
-*          " make sure:
-*          " a) SSL is setup properly in STRUST
-*          " b) no firewalls
-*          " check trace file in transaction SMICM
-*          lv_text = 'HTTP Communication Failure'.           "#EC NOTEXT
-*        WHEN 2.
-*          lv_text = 'HTTP Invalid State'.                   "#EC NOTEXT
-*        WHEN 3.
-*          lv_text = 'HTTP Processing failed'.               "#EC NOTEXT
-*        WHEN OTHERS.
-*          lv_text = 'Another error occured'.                "#EC NOTEXT
-*      ENDCASE.
 
       zcx_abapgit_exception=>raise( lv_text ).
     ENDIF.

--- a/src/zabapgit_http.prog.abap
+++ b/src/zabapgit_http.prog.abap
@@ -198,7 +198,9 @@ CLASS lcl_http_client IMPLEMENTATION.
 
   METHOD send_receive.
 
-    DATA lv_text TYPE string.
+    DATA: lv_text    TYPE string,
+          lv_code    TYPE i,
+          lv_message TYPE string.
 
     mi_client->send( ).
     mi_client->receive(
@@ -208,20 +210,29 @@ CLASS lcl_http_client IMPLEMENTATION.
         http_processing_failed     = 3
         OTHERS                     = 4 ).
     IF sy-subrc <> 0.
-      CASE sy-subrc.
-        WHEN 1.
-          " make sure:
-          " a) SSL is setup properly in STRUST
-          " b) no firewalls
-          " check trace file in transaction SMICM
-          lv_text = 'HTTP Communication Failure'.           "#EC NOTEXT
-        WHEN 2.
-          lv_text = 'HTTP Invalid State'.                   "#EC NOTEXT
-        WHEN 3.
-          lv_text = 'HTTP Processing failed'.               "#EC NOTEXT
-        WHEN OTHERS.
-          lv_text = 'Another error occured'.                "#EC NOTEXT
-      ENDCASE.
+
+      mi_client->get_last_error(
+        IMPORTING
+          code    = lv_code
+          message = lv_message ).
+
+      lv_text = |HTTP error { lv_code } occured: { lv_code }|.
+
+*      CASE sy-subrc.
+*        WHEN 1.
+*          " make sure:
+*          " a) SSL is setup properly in STRUST
+*          " b) no firewalls
+*          " check trace file in transaction SMICM
+*          lv_text = 'HTTP Communication Failure'.           "#EC NOTEXT
+*        WHEN 2.
+*          lv_text = 'HTTP Invalid State'.                   "#EC NOTEXT
+*        WHEN 3.
+*          lv_text = 'HTTP Processing failed'.               "#EC NOTEXT
+*        WHEN OTHERS.
+*          lv_text = 'Another error occured'.                "#EC NOTEXT
+*      ENDCASE.
+
       zcx_abapgit_exception=>raise( lv_text ).
     ENDIF.
 
@@ -502,7 +513,7 @@ CLASS lcl_http IMPLEMENTATION.
 
     DATA: lv_host TYPE string,
           lt_list TYPE zif_abapgit_definitions=>ty_icm_sinfo2_tt,
-          li_exit TYPE ref to lif_exit.
+          li_exit TYPE REF TO lif_exit.
 
     CALL FUNCTION 'ICM_GET_INFO2'
       TABLES


### PR DESCRIPTION
#1026 
Display e.g.
![image](https://user-images.githubusercontent.com/17437789/32017436-fdc7e5a4-b9c6-11e7-9971-050828a7ba05.png)
Instead of
![image](https://user-images.githubusercontent.com/17437789/32017434-f87f3c78-b9c6-11e7-99ba-293ff7408ac4.png)

Other examples
![image](https://user-images.githubusercontent.com/17437789/32017477-23341768-b9c7-11e7-9459-055154534f51.png)
![image](https://user-images.githubusercontent.com/17437789/32017479-24b2f442-b9c7-11e7-833d-0b8eb514f3cb.png)

