### PR TITLE
Improve usability of repository popup

### DIFF
--- a/src/zabapgit_forms.prog.abap
+++ b/src/zabapgit_forms.prog.abap
@@ -68,8 +68,8 @@ FORM branch_popup TABLES   tt_fields TYPE zif_abapgit_definitions=>ty_sval_tt
         lv_create       TYPE boolean.
 
   FIELD-SYMBOLS: <ls_furl>    LIKE LINE OF tt_fields,
-                 <ls_fbranch> LIKE LINE OF tt_fields.
-
+                 <ls_fbranch> LIKE LINE OF tt_fields,
+                 <ls_fpackage> LIKE LINE OF tt_fields.
 
   CLEAR cs_error.
 
@@ -99,6 +99,10 @@ FORM branch_popup TABLES   tt_fields TYPE zif_abapgit_definitions=>ty_sval_tt
 
   ELSEIF pv_code = 'COD2'.
     cv_show_popup = abap_true.
+
+    READ TABLE tt_fields ASSIGNING <ls_fpackage> WITH KEY fieldname = 'DEVCLASS'.
+    ASSERT sy-subrc = 0.
+    ls_package_data-devclass = <ls_fpackage>-value.
 
     lcl_popups=>popup_to_create_package( IMPORTING es_package_data = ls_package_data
                                                    ev_create       = lv_create ).

--- a/src/zabapgit_popups.prog.abap
+++ b/src/zabapgit_popups.prog.abap
@@ -127,7 +127,12 @@ CLASS lcl_popups DEFINITION FINAL.
         EXPORTING
           ev_url     TYPE abaptxt255-line
           ev_package TYPE tdevc-devclass
-          ev_branch  TYPE textl-line.
+          ev_branch  TYPE textl-line,
+
+      validate
+        IMPORTING
+          iv_package TYPE tdevc-devclass
+          iv_url     TYPE abaptxt255-line.
 
 ENDCLASS.
 
@@ -597,10 +602,8 @@ CLASS lcl_popups IMPLEMENTATION.
       lv_finished = abap_true.
 
       TRY.
-
-          " validate
-          lcl_url=>name( |{ lv_url }| ).
-          lcl_app=>repo_srv( )->validate_package( lv_package ).
+          validate( iv_url     = lv_url
+                    iv_package = lv_package ).
 
         CATCH zcx_abapgit_exception INTO lx_error.
           MESSAGE lx_error->text TYPE 'S' DISPLAY LIKE 'E'.
@@ -1033,6 +1036,11 @@ CLASS lcl_popups IMPLEMENTATION.
     READ TABLE it_fields INDEX 3 ASSIGNING <ls_field>.
     ASSERT sy-subrc = 0.
     ev_branch = <ls_field>-value.
+
+  ENDMETHOD.
+
+
+  METHOD validate.
 
   ENDMETHOD.
 

--- a/src/zabapgit_popups.prog.abap
+++ b/src/zabapgit_popups.prog.abap
@@ -132,7 +132,9 @@ CLASS lcl_popups DEFINITION FINAL.
       validate
         IMPORTING
           iv_package TYPE tdevc-devclass
-          iv_url     TYPE abaptxt255-line.
+          iv_url     TYPE abaptxt255-line
+        RAISING
+          zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -1041,6 +1043,9 @@ CLASS lcl_popups IMPLEMENTATION.
 
 
   METHOD validate.
+
+    lcl_url=>name( |{ iv_url }| ).
+    lcl_app=>repo_srv( )->validate_package( iv_package ).
 
   ENDMETHOD.
 

--- a/src/zabapgit_repo.prog.abap
+++ b/src/zabapgit_repo.prog.abap
@@ -134,7 +134,7 @@ CLASS lcl_repo_online DEFINITION INHERITING FROM lcl_repo FINAL.
                   io_stage   TYPE REF TO lcl_stage
         RAISING   zcx_abapgit_exception,
       get_unnecessary_local_objs
-        RETURNING VALUE(rt_unnecessary_local_objects) TYPE zif_abapgit_definitions=>TY_TADIR_TT
+        RETURNING VALUE(rt_unnecessary_local_objects) TYPE zif_abapgit_definitions=>ty_tadir_tt
         RAISING   zcx_abapgit_exception.
 
   PRIVATE SECTION.
@@ -219,6 +219,10 @@ CLASS lcl_repo_srv DEFINITION FINAL CREATE PRIVATE FRIENDS lcl_app.
                 iv_offline TYPE abap_bool
       RAISING   zcx_abapgit_exception.
 
+    METHODS validate_package
+      IMPORTING iv_package TYPE devclass
+      RAISING   zcx_abapgit_exception.
+
   PRIVATE SECTION.
 
     METHODS constructor.
@@ -227,16 +231,12 @@ CLASS lcl_repo_srv DEFINITION FINAL CREATE PRIVATE FRIENDS lcl_app.
           mo_persistence TYPE REF TO lcl_persistence_repo,
           mt_list        TYPE ty_repo_tt.
 
+    METHODS is_sap_object_allowed
+      RETURNING
+        VALUE(r_is_sap_object_allowed) TYPE abap_bool.
+
     METHODS add
       IMPORTING io_repo TYPE REF TO lcl_repo
       RAISING   zcx_abapgit_exception.
-
-    METHODS validate_package
-      IMPORTING iv_package TYPE devclass
-      RAISING   zcx_abapgit_exception.
-
-    METHODS is_sap_object_allowed
-      RETURNING
-        value(r_is_sap_object_allowed) TYPE abap_bool.
 
 ENDCLASS.                    "lcl_repo_srv DEFINITION


### PR DESCRIPTION
#1028 
The repository popup is reopened after an error occurs. So the user hasn't to redo his actions and doesn't need to refill the values.
![image](https://user-images.githubusercontent.com/17437789/32021228-0f995676-b9d3-11e7-9dd1-c110134a1487.png)
