### PR TITLE
Possible improvement for settings as described in issue #1032

### DIFF
--- a/src/zabapgit_persistence.prog.abap
+++ b/src/zabapgit_persistence.prog.abap
@@ -372,8 +372,9 @@ CLASS lcl_persist_settings DEFINITION FINAL.
     METHODS read
       RETURNING
         VALUE(ro_settings) TYPE REF TO lcl_settings.
-  PRIVATE SECTION.
 
+  PRIVATE SECTION.
+    DATA: mo_settings TYPE REF TO lcl_settings.
 
 ENDCLASS.
 
@@ -1879,15 +1880,30 @@ CLASS lcl_persist_settings IMPLEMENTATION.
 
   METHOD modify.
 
+    DATA: settings TYPE string.
+    settings = io_settings->get_settings_xml( ).
+
     lcl_app=>db( )->modify(
       iv_type       = lcl_settings=>c_dbtype_settings
       iv_value      = ''
-      iv_data       = io_settings->get_settings_xml( ) ).
+      iv_data       = settings ).
+
+    " Settings have been modified: Update Buffered Settings
+    IF mo_settings IS BOUND.
+      mo_settings->set_xml_settings( settings ).
+    ENDIF.
 
   ENDMETHOD.
 
   METHOD read.
 
+    IF mo_settings IS BOUND.
+      " Return Buffered Settings
+      ro_settings = mo_settings.
+      RETURN.
+    ENDIF.
+
+    " Settings have changed or have not yet been loaded
     CREATE OBJECT ro_settings.
 
     TRY.
@@ -1901,6 +1917,8 @@ CLASS lcl_persist_settings IMPLEMENTATION.
         ro_settings->set_defaults( ).
 
     ENDTRY.
+
+    mo_settings = ro_settings.
 
   ENDMETHOD.
 


### PR DESCRIPTION
As described in issue #1032, settings are currently read quite often when working with the object types (e.g. to determine if experimental features are active) and each access currently triggers a read on the database.
I have added a simple buffering for the settings, which reads the settings only once from the database per session and instance and then keeps the buffered data up to date when changes are commited.

There are currently two unsolved issues for which I need feedback before I can address them:

1. Since there can be multiple instances of the lcl_persist_settings class, in theory they can diverge in their state if modify is only called for one instance. At first glance this does not seem to be a big problem, because most accesses go though the singleton instance in lcl_app=>setting( ). But I'm not sure if really all settings accesses go through lcl_app.
2. I have not yet figured out how the unit test classes work, so I can't tell if buffering in the lcl_persist_settings class is compatible with the any automated test available for abapGit.

If you can provide feedback for these two issues, I can address them prior to a possible merge.