### PR TITLE
ASSERTION_FAILED - ASSERT NOT rv_user IS INITIAL - bug #1071

### DIFF
--- a/src/zabapgit_object_docv.prog.abap
+++ b/src/zabapgit_object_docv.prog.abap
@@ -37,6 +37,9 @@ CLASS lcl_object_docv IMPLEMENTATION.
 
   METHOD lif_object~changed_by.
     rv_user = read( )-head-tdluser.
+	IF rv_user IS INITIAL.
+	  rv_user = c_user_unkown.
+	ENDIF.
   ENDMETHOD.                    "lif_object~changed_by
 
   METHOD read.

--- a/src/zabapgit_object_docv.prog.abap
+++ b/src/zabapgit_object_docv.prog.abap
@@ -37,9 +37,9 @@ CLASS lcl_object_docv IMPLEMENTATION.
 
   METHOD lif_object~changed_by.
     rv_user = read( )-head-tdluser.
-	IF rv_user IS INITIAL.
-	  rv_user = c_user_unkown.
-	ENDIF.
+    IF rv_user IS INITIAL.
+      rv_user = c_user_unkown.
+    ENDIF.
   ENDMETHOD.                    "lif_object~changed_by
 
   METHOD read.


### PR DESCRIPTION
Introduce coding to check for initial rv_user. Return c_user_unkown if no user could be retrieved.