### PR TITLE
Background mode performance

### DIFF
--- a/src/zabapgit_git.prog.abap
+++ b/src/zabapgit_git.prog.abap
@@ -1203,6 +1203,7 @@ CLASS lcl_git_porcelain IMPLEMENTATION.
           lv_commit  TYPE xstring,
           lt_objects TYPE zif_abapgit_definitions=>ty_objects_tt,
           lv_pack    TYPE xstring,
+          lt_files   TYPE zif_abapgit_definitions=>ty_files_tt,
           ls_object  LIKE LINE OF lt_objects,
           ls_commit  TYPE lcl_git_pack=>ty_commit.
 
@@ -1282,6 +1283,15 @@ CLASS lcl_git_porcelain IMPLEMENTATION.
       iv_new         = rv_branch
       iv_branch_name = io_stage->get_branch_name( )
       iv_pack        = lv_pack ).
+
+* update objects in repo, we know what has been pushed
+    APPEND LINES OF io_repo->get_objects( ) TO lt_objects.
+    io_repo->set_objects( lt_objects ).
+    walk( EXPORTING it_objects = lt_objects
+                    iv_sha1 = ls_commit-tree
+                    iv_path = '/'
+          CHANGING ct_files = lt_files ).
+    io_repo->set_files_remote( lt_files ).
 
   ENDMETHOD.                    "receive_pack
 

--- a/src/zabapgit_repo.prog.abap
+++ b/src/zabapgit_repo.prog.abap
@@ -59,6 +59,9 @@ CLASS lcl_repo DEFINITION ABSTRACT FRIENDS lcl_repo_srv.
         RAISING   zcx_abapgit_exception,
       is_offline
         RETURNING VALUE(rv_offline) TYPE abap_bool
+        RAISING   zcx_abapgit_exception,
+      set_files_remote
+        IMPORTING it_files TYPE zif_abapgit_definitions=>ty_files_tt
         RAISING   zcx_abapgit_exception.
 
   PROTECTED SECTION.
@@ -126,6 +129,9 @@ CLASS lcl_repo_online DEFINITION INHERITING FROM lcl_repo FINAL.
         RETURNING VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
         RAISING   zcx_abapgit_exception,
       reset_status,
+      set_objects
+        IMPORTING it_objects TYPE zif_abapgit_definitions=>ty_objects_tt
+        RAISING   zcx_abapgit_exception,
       initialize
         RAISING zcx_abapgit_exception,
       rebuild_local_checksums REDEFINITION,
@@ -163,10 +169,6 @@ ENDCLASS.                    "lcl_repo_online DEFINITION
 CLASS lcl_repo_offline DEFINITION INHERITING FROM lcl_repo FINAL.
 
   PUBLIC SECTION.
-    METHODS:
-      set_files_remote
-        IMPORTING it_files TYPE zif_abapgit_definitions=>ty_files_tt
-        RAISING   zcx_abapgit_exception.
 
 ENDCLASS.                    "lcl_repo_offline DEFINITION
 

--- a/src/zabapgit_repo_impl.prog.abap
+++ b/src/zabapgit_repo_impl.prog.abap
@@ -7,12 +7,6 @@
 *----------------------------------------------------------------------*
 CLASS lcl_repo_offline IMPLEMENTATION.
 
-  METHOD set_files_remote.
-
-    mt_remote = it_files.
-
-  ENDMETHOD.
-
 ENDCLASS.                    "lcl_repo_offline IMPLEMENTATION
 
 *----------------------------------------------------------------------*
@@ -69,6 +63,10 @@ CLASS lcl_repo_online IMPLEMENTATION.
   METHOD reset_status.
     CLEAR mt_status.
   ENDMETHOD.  " reset_status.
+
+  METHOD set_objects.
+    mt_objects = it_objects.
+  ENDMETHOD.
 
   METHOD refresh.
 
@@ -716,6 +714,12 @@ CLASS lcl_repo IMPLEMENTATION.
 
   METHOD is_offline.
     rv_offline = ms_data-offline.
+  ENDMETHOD.
+
+  METHOD set_files_remote.
+
+    mt_remote = it_files.
+
   ENDMETHOD.
 
   METHOD refresh.

--- a/src/zabapgit_repo_impl.prog.abap
+++ b/src/zabapgit_repo_impl.prog.abap
@@ -205,10 +205,12 @@ CLASS lcl_repo_online IMPLEMENTATION.
 
     IF io_stage->get_branch_sha1( ) = get_sha1_local( ).
 * pushing to the branch currently represented by this repository object
+      mv_branch = lv_branch.
       set( iv_sha1 = lv_branch ).
+    ELSE.
+      refresh( ).
     ENDIF.
 
-    refresh( ).
     update_local_checksums( lt_updated_files ).
 
     IF lcl_stage_logic=>count( me ) = 0.


### PR DESCRIPTION
#833 

Skip refreshing after each push, as it already knows what has been pushed. Will also help performance when working with large repos.

Can somebody help testing this? Will merge it in a few days in case of no bugs found.