### PR TITLE
Use the user's email & full name in automatic background mode

### DIFF
--- a/src/persist/zcl_abapgit_persist_background.clas.abap
+++ b/src/persist/zcl_abapgit_persist_background.clas.abap
@@ -13,6 +13,7 @@ CLASS zcl_abapgit_persist_background DEFINITION
     CONSTANTS: BEGIN OF c_amethod,
                  fixed TYPE string VALUE 'fixed' ##NO_TEXT,
                  auto  TYPE string VALUE 'auto' ##NO_TEXT,
+                 user  TYPE string VALUE 'user' ##NO_TEXT,
                END OF c_amethod.
 
     TYPES: BEGIN OF ty_xml,

--- a/src/ui/zcl_abapgit_gui_page_bkg.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_bkg.clas.abap
@@ -64,7 +64,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_BKG IMPLEMENTATION.
           lv_push    TYPE string,
           lv_pull    TYPE string,
           lv_afixed  TYPE string,
-          lv_aauto   TYPE string.
+          lv_aauto   TYPE string,
+          lv_auser   TYPE string.
 
 
     CREATE OBJECT ro_html.
@@ -98,6 +99,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_BKG IMPLEMENTATION.
     ENDCASE.
 
     CASE ls_per-amethod.
+      WHEN zcl_abapgit_persist_background=>c_amethod-user.
+        lv_auser = ' checked' ##NO_TEXT.
       WHEN zcl_abapgit_persist_background=>c_amethod-auto.
         lv_aauto = ' checked' ##NO_TEXT.
       WHEN OTHERS.
@@ -139,6 +142,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_BKG IMPLEMENTATION.
       lv_afixed && '>Fixed<br>' ) ##NO_TEXT.
     ro_html->add( '<input type="radio" name="amethod" value="auto"' &&
       lv_aauto && '>Automatic<br>' ) ##NO_TEXT.
+    ro_html->add( '<input type="radio" name="amethod" value="user"' &&
+      lv_auser && '>Automatic using SU01 user details<br>' ) ##NO_TEXT.
     ro_html->add( '<br>' ).
 
     ro_html->add( '<table>' ).

--- a/src/zcl_abapgit_background.clas.abap
+++ b/src/zcl_abapgit_background.clas.abap
@@ -117,7 +117,7 @@ CLASS zcl_abapgit_background IMPLEMENTATION.
     DELETE ADJACENT DUPLICATES FROM lt_users.
 
     LOOP AT lt_users INTO lv_changed_by.
-      CLEAR ls_comment.
+      CLEAR: ls_comment, ls_address, lt_return, lt_smtp.
 
       CALL FUNCTION 'BAPI_USER_GET_DETAIL'
         EXPORTING

--- a/src/zcl_abapgit_background.clas.abap
+++ b/src/zcl_abapgit_background.clas.abap
@@ -19,17 +19,19 @@ CLASS zcl_abapgit_background DEFINITION PUBLIC CREATE PUBLIC.
                   is_settings TYPE zcl_abapgit_persist_background=>ty_background
         RAISING   zcx_abapgit_exception,
       push_auto
-        IMPORTING io_repo TYPE REF TO zcl_abapgit_repo_online
+        IMPORTING io_repo     TYPE REF TO zcl_abapgit_repo_online
+                  is_settings TYPE zcl_abapgit_persist_background=>ty_background
         RAISING   zcx_abapgit_exception,
       determine_user_details
-        IMPORTING iv_changed_by  TYPE xubname
+        IMPORTING iv_method      TYPE string
+                  iv_changed_by  TYPE xubname
         RETURNING VALUE(rs_user) TYPE zif_abapgit_definitions=>ty_git_user.
 
 ENDCLASS.
 
 
 
-CLASS zcl_abapgit_background IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_BACKGROUND IMPLEMENTATION.
 
 
   METHOD build_comment.
@@ -60,6 +62,49 @@ CLASS zcl_abapgit_background IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD determine_user_details.
+
+    DATA: lt_return  TYPE TABLE OF bapiret2,
+          ls_address TYPE bapiaddr3,
+          lt_smtp    TYPE TABLE OF bapiadsmtp,
+          ls_smtp    TYPE bapiadsmtp.
+
+*   IF the method is to use real user values, call the BAPI
+    IF iv_method = zcl_abapgit_persist_background=>c_amethod-user.
+
+      CALL FUNCTION 'BAPI_USER_GET_DETAIL'
+        EXPORTING
+          username = iv_changed_by
+        IMPORTING
+          address  = ls_address
+        TABLES
+          return   = lt_return
+          addsmtp  = lt_smtp.
+
+*     Choose the first email from SU01
+      SORT lt_smtp BY consnumber ASCENDING.
+
+      LOOP AT lt_smtp INTO ls_smtp.
+        rs_user-email = ls_smtp-e_mail.
+        EXIT.
+      ENDLOOP.
+
+*     Attempt to use the full name from SU01
+      rs_user-name = ls_address-fullname.
+    ENDIF.
+
+*   If no email, fall back to localhost/default email
+    IF rs_user-email IS INITIAL.
+      rs_user-email = |{ iv_changed_by }@localhost|.
+    ENDIF.
+
+*   If no full name maintained, just use changed by user name
+    IF rs_user-name IS INITIAL.
+      rs_user-name  = iv_changed_by.
+    ENDIF.
+  ENDMETHOD.
+
+
   METHOD push.
 
     IF lines( zcl_abapgit_stage_logic=>get( io_repo )-local ) = 0.
@@ -71,8 +116,10 @@ CLASS zcl_abapgit_background IMPLEMENTATION.
       WHEN zcl_abapgit_persist_background=>c_amethod-fixed.
         push_fixed( io_repo     = io_repo
                     is_settings = is_settings ).
-      WHEN zcl_abapgit_persist_background=>c_amethod-auto.
-        push_auto( io_repo ).
+      WHEN zcl_abapgit_persist_background=>c_amethod-auto
+        OR zcl_abapgit_persist_background=>c_amethod-user.
+        push_auto( io_repo     = io_repo
+                   is_settings = is_settings ).
       WHEN OTHERS.
         zcx_abapgit_exception=>raise( 'unknown push method' ).
     ENDCASE.
@@ -118,7 +165,9 @@ CLASS zcl_abapgit_background IMPLEMENTATION.
     LOOP AT lt_users INTO lv_changed_by.
       CLEAR: ls_comment.
 
-      ls_comment-committer = determine_user_details( lv_changed_by ).
+*     Fill user details
+      ls_comment-committer = determine_user_details( iv_method     = is_settings-amethod
+                                                     iv_changed_by = lv_changed_by ).
 
       CREATE OBJECT lo_stage
         EXPORTING
@@ -267,44 +316,5 @@ CLASS zcl_abapgit_background IMPLEMENTATION.
       EXPORTING
         type = lc_enq_type.
 
-  ENDMETHOD.
-
-  METHOD determine_user_details.
-
-    DATA: lt_return  TYPE TABLE OF bapiret2,
-          ls_address TYPE bapiaddr3,
-          lt_smtp    TYPE TABLE OF bapiadsmtp,
-          ls_smtp    TYPE bapiadsmtp.
-
-*   Call BAPI to get user details from SU01
-    CALL FUNCTION 'BAPI_USER_GET_DETAIL'
-      EXPORTING
-        username = iv_changed_by
-      IMPORTING
-        address  = ls_address
-      TABLES
-        return   = lt_return
-        addsmtp  = lt_smtp.
-
-*   Choose the first email from SU01
-    SORT lt_smtp BY consnumber ASCENDING.
-
-    LOOP AT lt_smtp INTO ls_smtp.
-      rs_user-email = ls_smtp-e_mail.
-      EXIT.
-    ENDLOOP.
-
-*   If no email, fall back to localhost/default email
-    IF rs_user-email IS INITIAL.
-      rs_user-email = |{ iv_changed_by }@localhost|.
-    ENDIF.
-
-*   Attempt to use the full name from SU01
-    rs_user-name = ls_address-fullname.
-
-*   If no full name maintained, just use changed by user name
-    IF rs_user-name IS INITIAL.
-      rs_user-name  = iv_changed_by.
-    ENDIF.
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
Use BAPI_USER_GET_DETAIL to read the committer user's email and full name from SU01 when committing in the background.

Useful for integration with git servers such as Gitlab where using the real email address will associate the commit with that user. It was the thing missing in our usage of abapGit.

One of the additional features from #245 ?

Let me know if you need me to do anything else for this.

Oli