### PR TITLE
Fix deserialization dependency ENHO -> ENHS

### DIFF
--- a/src/objects/zcl_abapgit_object_enho_hook.clas.abap
+++ b/src/objects/zcl_abapgit_object_enho_hook.clas.abap
@@ -133,7 +133,8 @@ CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
           lv_package         TYPE devclass,
           ls_original_object TYPE enh_hook_admin,
           lt_spaces          TYPE ty_spaces_tt,
-          lt_enhancements    TYPE enh_hook_impl_it.
+          lt_enhancements    TYPE enh_hook_impl_it,
+          lx_enh_root        TYPE REF TO cx_enh_root.
 
     FIELD-SYMBOLS: <ls_enhancement> LIKE LINE OF lt_enhancements.
 
@@ -184,10 +185,10 @@ CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
               spot             = <ls_enhancement>-spotname
               parent_full_name = <ls_enhancement>-parent_full_name ).
         ENDLOOP.
-        lo_hook_impl->if_enh_object~save( ).
+        lo_hook_impl->if_enh_object~save( run_dark = abap_true ).
         lo_hook_impl->if_enh_object~unlock( ).
-      CATCH cx_enh_root.
-        zcx_abapgit_exception=>raise( 'error deserializing ENHO hook' ).
+      CATCH cx_enh_root INTO lx_enh_root.
+        zcx_abapgit_exception=>raise( lx_enh_root->get_text( ) ).
     ENDTRY.
 
   ENDMETHOD.                    "zif_abapgit_object_enho~deserialize

--- a/src/zcl_abapgit_objects.clas.abap
+++ b/src/zcl_abapgit_objects.clas.abap
@@ -130,7 +130,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
+CLASS zcl_abapgit_objects IMPLEMENTATION.
 
 
   METHOD changed_by.
@@ -581,11 +581,17 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
       APPEND <ls_result> TO rt_results.
     ENDLOOP.
 
+* ENHS has to be handled before ENHO
+    LOOP AT it_results ASSIGNING <ls_result> WHERE obj_type = 'ENHS'.
+      APPEND <ls_result> TO rt_results.
+    ENDLOOP.
+
     LOOP AT it_results ASSIGNING <ls_result>
         WHERE obj_type <> 'IASP'
         AND obj_type <> 'PROG'
         AND obj_type <> 'XSLT'
-        AND obj_type <> 'PINF'.
+        AND obj_type <> 'PINF'
+        AND obj_type <> 'ENHS'.
       APPEND <ls_result> TO rt_results.
     ENDLOOP.
 


### PR DESCRIPTION
#1240 

Fixed the issue. 

Additionaly I set the run_dark = abap_true otherwise we get this message, although there isn't a syntax error.
![image](https://user-images.githubusercontent.com/17437789/37146857-445ac98e-22c5-11e8-9e0c-1d8a8b7aaee2.png)

I optimized the error handling so this message 
![image](https://user-images.githubusercontent.com/17437789/37146896-641d77a8-22c5-11e8-9a3d-e71b9c9f8fa0.png)
is shown instead of 
![image](https://user-images.githubusercontent.com/17437789/37146908-6b9c8a14-22c5-11e8-8305-b0a9d44bfdcc.png)

