### PR TITLE
added a host name to password popup title

### DIFF
--- a/src/zabapgit_password_dialog.prog.abap
+++ b/src/zabapgit_password_dialog.prog.abap
@@ -45,6 +45,9 @@ CLASS lcl_password_dialog DEFINITION FINAL.
 
   PRIVATE SECTION.
     CLASS-DATA gv_confirm TYPE abap_bool.
+    CLASS-METHODS enrich_title_by_hostname
+      IMPORTING
+        iv_repo_url TYPE string.
 
 ENDCLASS. "lcl_password_dialog DEFINITION
 
@@ -56,6 +59,9 @@ CLASS lcl_password_dialog IMPLEMENTATION.
     p_url      = iv_repo_url.
     p_user     = cv_user.
     gv_confirm = abap_false.
+
+
+    enrich_title_by_hostname( iv_repo_url ).
 
     CALL SELECTION-SCREEN c_dynnr STARTING AT 5 5 ENDING AT 60 8.
 
@@ -131,5 +137,18 @@ CLASS lcl_password_dialog IMPLEMENTATION.
     ENDCASE.
 
   ENDMETHOD.  "on_screen_event
+
+
+  METHOD enrich_title_by_hostname.
+
+    DATA lv_host TYPE string.
+
+    FIND REGEX 'https?://([^/^:]*)' IN iv_repo_url SUBMATCHES lv_host.
+    IF lv_host IS NOT INITIAL AND lv_host NE space.
+      CLEAR: s_title.
+      CONCATENATE 'Login:' lv_host INTO s_title IN CHARACTER MODE SEPARATED BY space.
+    ENDIF.
+
+  ENDMETHOD.
 
 ENDCLASS. " lcl_password_dialog IMPLEMENTATION


### PR DESCRIPTION
added a host name to password popup title
so tools like Keepass can use autotype to fill user and password