### PR TITLE
Fix issue 1298 - 2FA behind HTTP Proxy

### DIFF
--- a/src/http/zcl_abapgit_2fa_auth_base.clas.abap
+++ b/src/http/zcl_abapgit_2fa_auth_base.clas.abap
@@ -28,7 +28,12 @@ CLASS zcl_abapgit_2fa_auth_base DEFINITION
       raise_comm_error_from_sy RAISING zcx_abapgit_2fa_comm_error.
     METHODS:
       "! @parameter rv_running | Internal session is currently active
-      is_session_running RETURNING VALUE(rv_running) TYPE abap_bool.
+      is_session_running RETURNING VALUE(rv_running) TYPE abap_bool,
+      "! Returns HTTP client configured with proxy (where required) for the given URL
+      get_http_client_for_url
+        IMPORTING iv_url           TYPE string
+        RETURNING VALUE(ri_client) TYPE REF TO if_http_client
+        RAISING   zcx_abapgit_2fa_comm_error.
   PRIVATE SECTION.
     DATA:
       mo_url_regex       TYPE REF TO cl_abap_regex,
@@ -37,7 +42,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_2FA_AUTH_BASE IMPLEMENTATION.
+CLASS zcl_abapgit_2fa_auth_base IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -101,4 +106,41 @@ CLASS ZCL_ABAPGIT_2FA_AUTH_BASE IMPLEMENTATION.
   METHOD supports_url.
     rv_supported = mo_url_regex->create_matcher( text = iv_url )->match( ).
   ENDMETHOD.
+
+  METHOD get_http_client_for_url.
+    DATA: lo_proxy       TYPE REF TO zcl_abapgit_proxy_config,
+          lo_abapgit_exc TYPE REF TO zcx_abapgit_exception,
+          lv_error_text  TYPE string.
+
+    CREATE OBJECT lo_proxy.
+    cl_http_client=>create_by_url(
+      EXPORTING
+        url                = iv_url
+        ssl_id             = 'ANONYM'
+        proxy_host         = lo_proxy->get_proxy_url( iv_url )
+        proxy_service      = lo_proxy->get_proxy_port( iv_url  )
+      IMPORTING
+        client             = ri_client
+      EXCEPTIONS
+        argument_not_found = 1
+        plugin_not_active  = 2
+        internal_error     = 3
+        OTHERS             = 4 ).
+    IF sy-subrc <> 0.
+      raise_comm_error_from_sy( ).
+    ENDIF.
+
+    IF lo_proxy->get_proxy_authentication( iv_url ) = abap_true.
+      TRY.
+          zcl_abapgit_proxy_auth=>run( ri_client ).
+        CATCH zcx_abapgit_exception INTO lo_abapgit_exc.
+          lv_error_text = lo_abapgit_exc->get_text( ).
+          IF lv_error_text IS INITIAL.
+            lv_error_text = `Proxy authentication error`.
+          ENDIF.
+          RAISE EXCEPTION TYPE zcx_abapgit_2fa_comm_error EXPORTING mv_text = lv_error_text previous = lo_abapgit_exc.
+      ENDTRY.
+    ENDIF.
+  ENDMETHOD.
+
 ENDCLASS.


### PR DESCRIPTION
Fix for issue #1298. Previously code was not checking if HTTP proxy authentication was required. Pushed basic method of getting a HTTP client with proxy configured in to 2FA base class. There's some overlap with logic in zcl_abapgit_http=>create_by_url but not extracted method at this point.

I've tested locally behind a proxy with GitHub 2FA enabled and disabled but not without proxy