### PR TITLE
serialization: revive CLAS_NEW

### DIFF
--- a/src/objects/zcl_abapgit_object_clas_new.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas_new.clas.abap
@@ -1,0 +1,23 @@
+"! This class is just a different name for zcl_zabapgit_object_clas.
+"! It has been created to heal repositories of the brave ones who uses abapGit
+"! experimental features "! and had the luck to serialize their CLAS objects with
+"! the serializer LCL_OBJECT_CLAS_NEW.
+"! It can be removed on 2019-04 where we expect all CLAS object being
+"! re-serialized with the serializer LCL_OBJECT_CLAS.
+"! References: https://github.com/larshp/abapGit/pull/1311
+CLASS zcl_abapgit_object_clas_new DEFINITION PUBLIC INHERITING FROM zcl_abapgit_object_clas.
+
+  PROTECTED SECTION.
+    METHODS:
+      get_metadata REDEFINITION.
+
+ENDCLASS.
+
+CLASS zcl_abapgit_object_clas_new IMPLEMENTATION.
+
+  METHOD get_metadata.
+    rs_metadata = super->get_metadata( ).
+    rs_metadata-class = 'ZCL_ABAPGIT_OBJECT_CLAS'.
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/objects/zcl_abapgit_object_clas_new.clas.xml
+++ b/src/objects/zcl_abapgit_object_clas_new.clas.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_OBJECT_CLAS_NEW</CLSNAME>
+    <VERSION>1</VERSION>
+    <LANGU>E</LANGU>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
For some reason, we are using experimental features of abapGit.

Some time ago, all class were re-serialized with the serializer
LCL_OBJECT_CLASS_NEW.

After upgrade to 1.60, we started getting an error telling that CLAS
is not supported.

The CLASS NEW serializer became standard and the class has been renamed.

Unfortunately, our xml files still includes reference to the CLASS NEW.

I would just use a sed script, if knew all the affected repositories -
we have plenty of repositories versioned by abapGit.

This patch revives the CLASS NEW. It reports itself as the standard
class, so the CLASS NEW can be removed in year or two when all files
are re-serialized.

See commit 21d22d93f2e52154be0e07da256c7e25f364ca44