### PR TITLE
package: a child inherits parent's appl. component

### DIFF
--- a/src/zcl_abapgit_sap_package.clas.abap
+++ b/src/zcl_abapgit_sap_package.clas.abap
@@ -200,6 +200,7 @@ CLASS ZCL_ABAPGIT_SAP_PACKAGE IMPLEMENTATION.
 
     ls_child-devclass  = iv_child.
     ls_child-dlvunit   = li_parent->software_component.
+    ls_child-component = li_parent->application_component.
     ls_child-ctext     = iv_child.
     ls_child-parentcl  = mv_package.
     ls_child-pdevclass = li_parent->transport_layer.


### PR DESCRIPTION
If a new package is not meant to be a local or a private package, it
must have assigned Application Component; otherwise the method
cl_package->if_package~create_new_package() raises the message
e050(pak) - component_missing.