### PR TITLE
clone without pull #832

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -64,7 +64,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
     lo_helpsub->add( iv_txt = 'Tutorial'        iv_act = zif_abapgit_definitions=>gc_action-go_tutorial ) ##NO_TEXT.
     lo_helpsub->add( iv_txt = 'abapGit wiki'    iv_act = zif_abapgit_definitions=>gc_action-abapgit_wiki ) ##NO_TEXT.
 
-    ro_menu->add( iv_txt = '+ Clone'            iv_act = zif_abapgit_definitions=>gc_action-repo_clone ) ##NO_TEXT.
+    ro_menu->add( iv_txt = '+ Online'           iv_act = zif_abapgit_definitions=>gc_action-repo_newonline ) ##NO_TEXT.
     ro_menu->add( iv_txt = '+ Offline'          iv_act = zif_abapgit_definitions=>gc_action-repo_newoffline ) ##NO_TEXT.
     ro_menu->add( iv_txt = 'Explore'            iv_act = zif_abapgit_definitions=>gc_action-go_explore ) ##NO_TEXT.
 

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -162,7 +162,6 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
 
     DATA: lv_url  TYPE string,
           lv_key  TYPE zif_abapgit_persistence=>ty_repo-key,
-          lo_repo TYPE REF TO zcl_abapgit_repo_online,
           ls_item TYPE zif_abapgit_definitions=>ty_item.
 
 
@@ -276,9 +275,8 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
       WHEN zif_abapgit_definitions=>gc_action-repo_newonline.
         zcl_abapgit_services_repo=>new_online( lv_url ).
         ev_state = zif_abapgit_definitions=>gc_event_state-re_render.
-      WHEN zif_abapgit_definitions=>gc_action-repo_clone OR 'install'.    " Repo clone, 'install' is for explore page
-        lo_repo = zcl_abapgit_services_repo=>new_online( lv_url ).
-        zcl_abapgit_services_repo=>gui_deserialize( lo_repo ).
+      WHEN 'install'.    " 'install' is for explore page
+        zcl_abapgit_services_repo=>new_online( lv_url ).
         ev_state = zif_abapgit_definitions=>gc_event_state-re_render.
       WHEN zif_abapgit_definitions=>gc_action-repo_refresh_checksums.          " Rebuil local checksums
         zcl_abapgit_services_repo=>refresh_local_checksums( lv_key ).

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -162,6 +162,7 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
 
     DATA: lv_url  TYPE string,
           lv_key  TYPE zif_abapgit_persistence=>ty_repo-key,
+          lo_repo TYPE REF TO zcl_abapgit_repo_online,
           ls_item TYPE zif_abapgit_definitions=>ty_item.
 
 
@@ -272,8 +273,12 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
       WHEN zif_abapgit_definitions=>gc_action-repo_remove.                     " Repo remove
         zcl_abapgit_services_repo=>remove( lv_key ).
         ev_state = zif_abapgit_definitions=>gc_event_state-re_render.
+      WHEN zif_abapgit_definitions=>gc_action-repo_newonline.
+        zcl_abapgit_services_repo=>new_online( lv_url ).
+        ev_state = zif_abapgit_definitions=>gc_event_state-re_render.
       WHEN zif_abapgit_definitions=>gc_action-repo_clone OR 'install'.    " Repo clone, 'install' is for explore page
-        zcl_abapgit_services_repo=>clone( lv_url ).
+        lo_repo = zcl_abapgit_services_repo=>new_online( lv_url ).
+        zcl_abapgit_services_repo=>gui_deserialize( lo_repo ).
         ev_state = zif_abapgit_definitions=>gc_event_state-re_render.
       WHEN zif_abapgit_definitions=>gc_action-repo_refresh_checksums.          " Rebuil local checksums
         zcl_abapgit_services_repo=>refresh_local_checksums( lv_key ).

--- a/src/ui/zcl_abapgit_gui_view_tutorial.clas.abap
+++ b/src/ui/zcl_abapgit_gui_view_tutorial.clas.abap
@@ -26,7 +26,7 @@ CLASS ZCL_ABAPGIT_GUI_VIEW_TUTORIAL IMPLEMENTATION.
     ro_html->add( '<p><ul>' ).
 
     ro_html->add( `<li>To clone a remote repo (e.g. from github) click ` ).
-    ro_html->add_a( iv_txt = '+ Clone' iv_act = zif_abapgit_definitions=>gc_action-repo_clone ).
+    ro_html->add_a( iv_txt = '+ Online' iv_act = zif_abapgit_definitions=>gc_action-repo_newonline ).
     ro_html->add( ' from the top menu. This will copy a remote repo to your system.</li>' ).
 
     ro_html->add( `<li>To add a local package as a repo click ` ).

--- a/src/ui/zcl_abapgit_services_abapgit.clas.abap
+++ b/src/ui/zcl_abapgit_services_abapgit.clas.abap
@@ -77,10 +77,6 @@ CLASS ZCL_ABAPGIT_SERVICES_ABAPGIT IMPLEMENTATION.
         iv_branch_name = 'refs/heads/master'
         iv_package     = iv_package ) ##NO_TEXT.
 
-      lo_repo->initialize( ).
-      lo_repo->find_remote_dot_abapgit( ).
-      lo_repo->status( ). " check for errors
-
       zcl_abapgit_services_repo=>gui_deserialize( lo_repo ).
 
       zcl_abapgit_services_repo=>toggle_favorite( lo_repo->get_key( ) ).

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -1,84 +1,84 @@
-class ZCL_ABAPGIT_SERVICES_REPO definition
-  public
-  final
-  create public .
+CLASS zcl_abapgit_services_repo DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  class-methods NEW_ONLINE
-    importing
-      !IV_URL type STRING
-    returning
-      value(RO_REPO) type ref to ZCL_ABAPGIT_REPO_ONLINE
-    raising
-      ZCX_ABAPGIT_EXCEPTION
-      ZCX_ABAPGIT_CANCEL .
-  class-methods REFRESH
-    importing
-      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  class-methods REMOVE
-    importing
-      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
-    raising
-      ZCX_ABAPGIT_EXCEPTION
-      ZCX_ABAPGIT_CANCEL .
-  class-methods PURGE
-    importing
-      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
-    raising
-      ZCX_ABAPGIT_EXCEPTION
-      ZCX_ABAPGIT_CANCEL .
-  class-methods NEW_OFFLINE
-    raising
-      ZCX_ABAPGIT_EXCEPTION
-      ZCX_ABAPGIT_CANCEL .
-  class-methods REMOTE_ATTACH
-    importing
-      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
-    raising
-      ZCX_ABAPGIT_EXCEPTION
-      ZCX_ABAPGIT_CANCEL .
-  class-methods REMOTE_DETACH
-    importing
-      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
-    raising
-      ZCX_ABAPGIT_EXCEPTION
-      ZCX_ABAPGIT_CANCEL .
-  class-methods REMOTE_CHANGE
-    importing
-      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
-    raising
-      ZCX_ABAPGIT_EXCEPTION
-      ZCX_ABAPGIT_CANCEL .
-  class-methods REFRESH_LOCAL_CHECKSUMS
-    importing
-      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
-    raising
-      ZCX_ABAPGIT_EXCEPTION
-      ZCX_ABAPGIT_CANCEL .
-  class-methods TOGGLE_FAVORITE
-    importing
-      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  class-methods OPEN_SE80
-    importing
-      !IV_PACKAGE type DEVCLASS
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  class-methods TRANSPORT_TO_BRANCH
-    importing
-      !IV_REPOSITORY_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_VALUE
-    raising
-      ZCX_ABAPGIT_EXCEPTION
-      ZCX_ABAPGIT_CANCEL .
-  class-methods GUI_DESERIALIZE
-    importing
-      !IO_REPO type ref to ZCL_ABAPGIT_REPO
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
+    CLASS-METHODS new_online
+      IMPORTING
+        !iv_url        TYPE string
+      RETURNING
+        VALUE(ro_repo) TYPE REF TO zcl_abapgit_repo_online
+      RAISING
+        zcx_abapgit_exception
+        zcx_abapgit_cancel .
+    CLASS-METHODS refresh
+      IMPORTING
+        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS remove
+      IMPORTING
+        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      RAISING
+        zcx_abapgit_exception
+        zcx_abapgit_cancel .
+    CLASS-METHODS purge
+      IMPORTING
+        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      RAISING
+        zcx_abapgit_exception
+        zcx_abapgit_cancel .
+    CLASS-METHODS new_offline
+      RAISING
+        zcx_abapgit_exception
+        zcx_abapgit_cancel .
+    CLASS-METHODS remote_attach
+      IMPORTING
+        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      RAISING
+        zcx_abapgit_exception
+        zcx_abapgit_cancel .
+    CLASS-METHODS remote_detach
+      IMPORTING
+        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      RAISING
+        zcx_abapgit_exception
+        zcx_abapgit_cancel .
+    CLASS-METHODS remote_change
+      IMPORTING
+        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      RAISING
+        zcx_abapgit_exception
+        zcx_abapgit_cancel .
+    CLASS-METHODS refresh_local_checksums
+      IMPORTING
+        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      RAISING
+        zcx_abapgit_exception
+        zcx_abapgit_cancel .
+    CLASS-METHODS toggle_favorite
+      IMPORTING
+        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS open_se80
+      IMPORTING
+        !iv_package TYPE devclass
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS transport_to_branch
+      IMPORTING
+        !iv_repository_key TYPE zif_abapgit_persistence=>ty_value
+      RAISING
+        zcx_abapgit_exception
+        zcx_abapgit_cancel .
+    CLASS-METHODS gui_deserialize
+      IMPORTING
+        !io_repo TYPE REF TO zcl_abapgit_repo
+      RAISING
+        zcx_abapgit_exception .
   PRIVATE SECTION.
 
     CLASS-METHODS popup_overwrite

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -1,82 +1,84 @@
-CLASS zcl_abapgit_services_repo DEFINITION
-  PUBLIC
-  FINAL
-  CREATE PUBLIC .
+class ZCL_ABAPGIT_SERVICES_REPO definition
+  public
+  final
+  create public .
 
-  PUBLIC SECTION.
+public section.
 
-    CLASS-METHODS clone
-      IMPORTING
-        !iv_url TYPE string
-      RAISING
-        zcx_abapgit_exception
-        zcx_abapgit_cancel .
-    CLASS-METHODS refresh
-      IMPORTING
-        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS remove
-      IMPORTING
-        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
-      RAISING
-        zcx_abapgit_exception
-        zcx_abapgit_cancel .
-    CLASS-METHODS purge
-      IMPORTING
-        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
-      RAISING
-        zcx_abapgit_exception
-        zcx_abapgit_cancel .
-    CLASS-METHODS new_offline
-      RAISING
-        zcx_abapgit_exception
-        zcx_abapgit_cancel .
-    CLASS-METHODS remote_attach
-      IMPORTING
-        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
-      RAISING
-        zcx_abapgit_exception
-        zcx_abapgit_cancel .
-    CLASS-METHODS remote_detach
-      IMPORTING
-        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
-      RAISING
-        zcx_abapgit_exception
-        zcx_abapgit_cancel .
-    CLASS-METHODS remote_change
-      IMPORTING
-        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
-      RAISING
-        zcx_abapgit_exception
-        zcx_abapgit_cancel .
-    CLASS-METHODS refresh_local_checksums
-      IMPORTING
-        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
-      RAISING
-        zcx_abapgit_exception
-        zcx_abapgit_cancel .
-    CLASS-METHODS toggle_favorite
-      IMPORTING
-        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS open_se80
-      IMPORTING
-        !iv_package TYPE devclass
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS transport_to_branch
-      IMPORTING
-        !iv_repository_key TYPE zif_abapgit_persistence=>ty_value
-      RAISING
-        zcx_abapgit_exception
-        zcx_abapgit_cancel .
-    CLASS-METHODS gui_deserialize
-      IMPORTING
-        !io_repo TYPE REF TO zcl_abapgit_repo
-      RAISING
-        zcx_abapgit_exception .
+  class-methods NEW_ONLINE
+    importing
+      !IV_URL type STRING
+    returning
+      value(RO_REPO) type ref to ZCL_ABAPGIT_REPO_ONLINE
+    raising
+      ZCX_ABAPGIT_EXCEPTION
+      ZCX_ABAPGIT_CANCEL .
+  class-methods REFRESH
+    importing
+      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  class-methods REMOVE
+    importing
+      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
+    raising
+      ZCX_ABAPGIT_EXCEPTION
+      ZCX_ABAPGIT_CANCEL .
+  class-methods PURGE
+    importing
+      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
+    raising
+      ZCX_ABAPGIT_EXCEPTION
+      ZCX_ABAPGIT_CANCEL .
+  class-methods NEW_OFFLINE
+    raising
+      ZCX_ABAPGIT_EXCEPTION
+      ZCX_ABAPGIT_CANCEL .
+  class-methods REMOTE_ATTACH
+    importing
+      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
+    raising
+      ZCX_ABAPGIT_EXCEPTION
+      ZCX_ABAPGIT_CANCEL .
+  class-methods REMOTE_DETACH
+    importing
+      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
+    raising
+      ZCX_ABAPGIT_EXCEPTION
+      ZCX_ABAPGIT_CANCEL .
+  class-methods REMOTE_CHANGE
+    importing
+      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
+    raising
+      ZCX_ABAPGIT_EXCEPTION
+      ZCX_ABAPGIT_CANCEL .
+  class-methods REFRESH_LOCAL_CHECKSUMS
+    importing
+      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
+    raising
+      ZCX_ABAPGIT_EXCEPTION
+      ZCX_ABAPGIT_CANCEL .
+  class-methods TOGGLE_FAVORITE
+    importing
+      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  class-methods OPEN_SE80
+    importing
+      !IV_PACKAGE type DEVCLASS
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  class-methods TRANSPORT_TO_BRANCH
+    importing
+      !IV_REPOSITORY_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_VALUE
+    raising
+      ZCX_ABAPGIT_EXCEPTION
+      ZCX_ABAPGIT_CANCEL .
+  class-methods GUI_DESERIALIZE
+    importing
+      !IO_REPO type ref to ZCL_ABAPGIT_REPO
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
   PRIVATE SECTION.
 
     CLASS-METHODS popup_overwrite
@@ -94,38 +96,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_services_repo IMPLEMENTATION.
-
-
-  METHOD clone.
-
-    DATA: lo_repo  TYPE REF TO zcl_abapgit_repo_online,
-          ls_popup TYPE zcl_abapgit_popups=>ty_popup.
-
-
-    ls_popup = zcl_abapgit_popups=>repo_popup( iv_url ).
-    IF ls_popup-cancel = abap_true.
-      RAISE EXCEPTION TYPE zcx_abapgit_cancel.
-    ENDIF.
-
-    lo_repo = zcl_abapgit_repo_srv=>get_instance( )->new_online(
-      iv_url         = ls_popup-url
-      iv_branch_name = ls_popup-branch_name
-      iv_package     = ls_popup-package ).
-
-    toggle_favorite( lo_repo->get_key( ) ).
-
-    lo_repo->initialize( ).
-    lo_repo->find_remote_dot_abapgit( ).
-    lo_repo->status( ). " check for errors
-
-    gui_deserialize( lo_repo ).
-
-    zcl_abapgit_persistence_user=>get_instance( )->set_repo_show( lo_repo->get_key( ) ). " Set default repo for user
-
-    COMMIT WORK.
-
-  ENDMETHOD.  "clone
+CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
 
 
   METHOD gui_deserialize.
@@ -182,6 +153,31 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
     COMMIT WORK.
 
   ENDMETHOD.  "new_offline
+
+
+  METHOD new_online.
+
+    DATA: ls_popup TYPE zcl_abapgit_popups=>ty_popup.
+
+
+    ls_popup = zcl_abapgit_popups=>repo_popup( iv_url ).
+    IF ls_popup-cancel = abap_true.
+      RAISE EXCEPTION TYPE zcx_abapgit_cancel.
+    ENDIF.
+
+    ro_repo = zcl_abapgit_repo_srv=>get_instance( )->new_online(
+      iv_url         = ls_popup-url
+      iv_branch_name = ls_popup-branch_name
+      iv_package     = ls_popup-package ).
+
+    toggle_favorite( ro_repo->get_key( ) ).
+
+* Set default repo for user
+    zcl_abapgit_persistence_user=>get_instance( )->set_repo_show( ro_repo->get_key( ) ).
+
+    COMMIT WORK.
+
+  ENDMETHOD.
 
 
   METHOD open_se80.

--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -273,6 +273,9 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
 
     add( ro_repo ).
 
+    ro_repo->initialize( ).
+    ro_repo->find_remote_dot_abapgit( ).
+
   ENDMETHOD.                    "new_online
 
 

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -352,6 +352,7 @@ INTERFACE zif_abapgit_definitions PUBLIC.
       repo_remove              TYPE string VALUE 'repo_remove',
       repo_settings            TYPE string VALUE 'repo_settings',
       repo_purge               TYPE string VALUE 'repo_purge',
+      repo_newonline           TYPE string VALUE 'repo_newonline',
       repo_newoffline          TYPE string VALUE 'repo_newoffline',
       repo_remote_attach       TYPE string VALUE 'repo_remote_attach',
       repo_remote_detach       TYPE string VALUE 'repo_remote_detach',

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -347,7 +347,6 @@ INTERFACE zif_abapgit_definitions PUBLIC.
   CONSTANTS gc_author_regex TYPE string VALUE '^([\\\w\s\.@\-_1-9\(\) ]+) <(.*)> (\d{10})\s?.\d{4}$' ##NO_TEXT.
   CONSTANTS:
     BEGIN OF gc_action,
-      repo_clone               TYPE string VALUE 'repo_clone',
       repo_refresh             TYPE string VALUE 'repo_refresh',
       repo_remove              TYPE string VALUE 'repo_remove',
       repo_settings            TYPE string VALUE 'repo_settings',


### PR DESCRIPTION
clone without pull #832

Changes the behavior to new online without pulling, this is symmetric with new offline functionality

and cleans up some of the repo API

![image](https://user-images.githubusercontent.com/5888506/39860355-488789d0-543d-11e8-974d-83b03542311f.png)

after "+ Online" the user must choose to pull, this is especially useful if an existing package with existing objects are used