### PR TITLE
DDLS: fix a syntax error on ABAP <7.4

### DIFF
--- a/src/objects/zcl_abapgit_object_ddls.clas.abap
+++ b/src/objects/zcl_abapgit_object_ddls.clas.abap
@@ -254,7 +254,8 @@ CLASS ZCL_ABAPGIT_OBJECT_DDLS IMPLEMENTATION.
           lt_clr_comps TYPE STANDARD TABLE OF fieldname WITH DEFAULT KEY.
 
     FIELD-SYMBOLS: <lg_data>  TYPE any,
-                   <lg_field> TYPE any.
+                   <lg_field> TYPE any,
+                   <lv_comp>  LIKE LINE OF lt_clr_comps.
 
 
     CREATE DATA lr_data TYPE ('DDDDLSRCV').
@@ -281,7 +282,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DDLS IMPLEMENTATION.
     APPEND 'ACTFLAG' TO lt_clr_comps.
     APPEND 'CHGFLAG' TO lt_clr_comps.
 
-    LOOP AT lt_clr_comps ASSIGNING field-symbol(<lv_comp>).
+    LOOP AT lt_clr_comps ASSIGNING <lv_comp>.
       ASSIGN COMPONENT <lv_comp> OF STRUCTURE <lg_data> TO <lg_field>.
       ASSERT sy-subrc = 0.
       CLEAR <lg_field>.


### PR DESCRIPTION
Introduced in 2f9e46421b7010812cff57ab0ff5a3c3547de13d
Reported as https://github.com/larshp/abapGit/commit/2f9e46421b7010812cff57ab0ff5a3c3547de13d#r28962636
Thank you, @testitorleaveit