### PR TITLE
Delivery class of database table zabapgit changed

### DIFF
--- a/src/persist/zcl_abapgit_persist_migrate.clas.abap
+++ b/src/persist/zcl_abapgit_persist_migrate.clas.abap
@@ -293,7 +293,7 @@ CLASS zcl_abapgit_persist_migrate IMPLEMENTATION.
     ls_dd02v-ddlanguage = zif_abapgit_definitions=>gc_english.
     ls_dd02v-tabclass   = 'TRANSP'.
     ls_dd02v-ddtext     = c_text.
-    ls_dd02v-contflag   = 'A'.
+    ls_dd02v-contflag   = 'L'.
     ls_dd02v-exclass    = '1'.
 
     ls_dd09l-tabname  = zcl_abapgit_persistence_db=>c_tabname.


### PR DESCRIPTION
fixes #1424 

Delivery class has been changed to 'L' so that objects can be transported w/o act issues