### PR TITLE
FORM: Error of duplicity because SPRAS is case sensitive

### DIFF
--- a/src/objects/zcl_abapgit_object_form.clas.abap
+++ b/src/objects/zcl_abapgit_object_form.clas.abap
@@ -254,7 +254,17 @@ CLASS zcl_abapgit_object_form IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD _build_extra_from_header.
-    r_result = c_objectname_tdlines && '_' && ls_header-tdspras.
+
+    DATA: lv_tdspras type laiso.
+
+    CALL FUNCTION 'CONVERSION_EXIT_ISOLA_OUTPUT'
+      EXPORTING
+        input  = ls_header-tdspras
+      IMPORTING
+        output = lv_tdspras.
+
+    r_result = c_objectname_tdlines && '_' && lv_tdspras.
+
   ENDMETHOD.
 
   METHOD _get_last_changes.

--- a/src/objects/zcl_abapgit_object_form.clas.abap
+++ b/src/objects/zcl_abapgit_object_form.clas.abap
@@ -39,6 +39,12 @@ CLASS zcl_abapgit_object_form DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
       RETURNING
         VALUE(r_result) TYPE string.
 
+    METHODS _build_extra_from_header_old
+      IMPORTING
+        ls_header       TYPE tys_form_header
+      RETURNING
+        VALUE(r_result) TYPE string.
+
     METHODS _save_form
       IMPORTING
         it_lines     TYPE zcl_abapgit_object_form=>tyt_lines
@@ -267,6 +273,10 @@ CLASS zcl_abapgit_object_form IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD _build_extra_from_header_old.
+    r_result = c_objectname_tdlines && '_' && ls_header-tdspras.
+  ENDMETHOD.
+
   METHOD _get_last_changes.
 
     DATA: lv_form_name         TYPE thead-tdform.
@@ -317,9 +327,17 @@ CLASS zcl_abapgit_object_form IMPLEMENTATION.
     DATA lv_string TYPE string.
     DATA lo_xml TYPE REF TO zcl_abapgit_xml_input.
 
-    lv_string = mo_files->read_string( iv_extra =
-                               _build_extra_from_header( is_form_data-form_header )
-                                       iv_ext   = c_extension_xml ).
+    TRY.
+        lv_string = mo_files->read_string( iv_extra =
+                                   _build_extra_from_header( is_form_data-form_header )
+                                           iv_ext   = c_extension_xml ).
+      CATCH zcx_abapgit_exception.
+
+        lv_string = mo_files->read_string( iv_extra =
+                               _build_extra_from_header_old( is_form_data-form_header )
+                                           iv_ext   = c_extension_xml ).
+
+    ENDTRY.
 
     CREATE OBJECT lo_xml EXPORTING iv_xml = lv_string.
     lo_xml->read( EXPORTING iv_name = c_objectname_tdlines


### PR DESCRIPTION
Old code generate error of duplicity because SPRAS is case sensitive, but the name of files not.

New code use the 2-caracteres code for language.

Examples (T002):

SPRAS: 'C' -> LAISO: CS -> 'Czech'
SPRAS: 'c' -> LAISO: CA -> 'Catalan'