### PR TITLE
CLAS: ignore deletion of non-existent objects

### DIFF
--- a/src/objects/zcl_abapgit_oo_class.clas.abap
+++ b/src/objects/zcl_abapgit_oo_class.clas.abap
@@ -273,8 +273,12 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
         no_access    = 4
         other        = 5
         OTHERS       = 6.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'Error from SEO_CLASS_DELETE_COMPLETE' ).
+    IF sy-subrc = 1.
+* ignore deletion of objects that does not exist
+* this can happen when the SXCI object is deleted before the implementing CLAS
+      RETURN.
+    ELSEIF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from SEO_CLASS_DELETE_COMPLETE: { sy-subrc }| ).
     ENDIF.
   ENDMETHOD.
 

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -320,7 +320,7 @@ INTERFACE zif_abapgit_definitions PUBLIC.
          END OF ty_s_user_settings.
 
   CONSTANTS gc_xml_version TYPE string VALUE 'v1.0.0' ##NO_TEXT.
-  CONSTANTS gc_abap_version TYPE string VALUE 'v1.68.0' ##NO_TEXT.
+  CONSTANTS gc_abap_version TYPE string VALUE 'v1.68.1' ##NO_TEXT.
   CONSTANTS:
     BEGIN OF gc_type,
       commit TYPE zif_abapgit_definitions=>ty_type VALUE 'commit', "#EC NOTEXT


### PR DESCRIPTION
CLAS: ignore deletion of non-existent objects

this can happen when the SXCI object is deleted before the implementing CLAS

plus better error message