### PR TITLE
change agent #1432

### DIFF
--- a/src/http/zcl_abapgit_http.clas.abap
+++ b/src/http/zcl_abapgit_http.clas.abap
@@ -205,7 +205,8 @@ CLASS ZCL_ABAPGIT_HTTP IMPLEMENTATION.
   METHOD get_agent.
 
 * bitbucket require agent prefix = "git/"
-    rv_agent = 'git/abapGit-' && zif_abapgit_definitions=>gc_abap_version.
+* also see https://github.com/larshp/abapGit/issues/1432
+    rv_agent = |git/2.0 (abapGit { zif_abapgit_definitions=>gc_abap_version })|.
 
   ENDMETHOD.
 

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -320,7 +320,7 @@ INTERFACE zif_abapgit_definitions PUBLIC.
          END OF ty_s_user_settings.
 
   CONSTANTS gc_xml_version TYPE string VALUE 'v1.0.0' ##NO_TEXT.
-  CONSTANTS gc_abap_version TYPE string VALUE 'v1.68.2' ##NO_TEXT.
+  CONSTANTS gc_abap_version TYPE string VALUE '1.68.2' ##NO_TEXT.
   CONSTANTS:
     BEGIN OF gc_type,
       commit TYPE zif_abapgit_definitions=>ty_type VALUE 'commit', "#EC NOTEXT


### PR DESCRIPTION
change agent #1432

example "git/2.0 (abapGit 1.68.0)"

removed "v" in front of version number