### PR TITLE
WAPA: better delta handling

### DIFF
--- a/src/objects/zcl_abapgit_object_wapa.clas.abap
+++ b/src/objects/zcl_abapgit_object_wapa.clas.abap
@@ -27,15 +27,147 @@ CLASS zcl_abapgit_object_wapa DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
       read_page
         IMPORTING is_page        TYPE o2pagattr
         RETURNING VALUE(rs_page) TYPE ty_page
-        RAISING   zcx_abapgit_exception.
+        RAISING   zcx_abapgit_exception,
+      create_new_application
+        IMPORTING is_attributes TYPE o2applattr
+                  it_nodes      TYPE o2applnode_table
+                  it_navgraph   TYPE o2applgrap_table
+        RETURNING VALUE(ro_bsp) TYPE REF TO cl_o2_api_application
+        RAISING   zcx_abapgit_exception,
+      create_new_page
+        IMPORTING
+          is_page_attributes TYPE o2pagattr
+        RETURNING
+          VALUE(ro_page)     TYPE REF TO cl_o2_api_pages
+        RAISING
+          zcx_abapgit_exception,
+      delete_superfluous_pages
+        IMPORTING
+          it_local_pages  TYPE o2pagelist
+          it_remote_pages TYPE zcl_abapgit_object_wapa=>ty_pages_tt
+        RAISING
+          zcx_abapgit_exception.
 
 ENDCLASS.
 
+
+
 CLASS zcl_abapgit_object_wapa IMPLEMENTATION.
 
-  METHOD zif_abapgit_object~has_changed_since.
-    rv_changed = abap_true.
-  ENDMETHOD.  "zif_abapgit_object~has_changed_since
+
+  METHOD get_page_content.
+
+    DATA: lt_content TYPE o2pageline_table,
+          lv_string  TYPE string.
+
+    io_page->get_page(
+      IMPORTING
+        p_content = lt_content
+      EXCEPTIONS
+        invalid_call = 1
+        page_deleted = 2
+        OTHERS       = 3 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |WAPA - error from get_page_content| ).
+    ENDIF.
+
+    CONCATENATE LINES OF lt_content INTO lv_string SEPARATED BY zif_abapgit_definitions=>gc_newline RESPECTING BLANKS.
+
+    rv_content = zcl_abapgit_convert=>string_to_xstring_utf8( lv_string ).
+
+  ENDMETHOD.
+
+
+  METHOD read_page.
+
+    DATA: lv_name    TYPE o2applname,
+          ls_pagekey TYPE o2pagkey,
+          lv_content TYPE xstring,
+          lv_extra   TYPE string,
+          lv_ext     TYPE string,
+          lo_page    TYPE REF TO cl_o2_api_pages.
+
+
+    lv_name = ms_item-obj_name.
+
+    ls_pagekey-applname = lv_name.
+    ls_pagekey-pagekey = is_page-pagekey.
+
+    cl_o2_api_pages=>load(
+      EXPORTING
+        p_pagekey = ls_pagekey
+      IMPORTING
+        p_page    = lo_page ).
+
+    lo_page->get_attrs(
+      IMPORTING
+        p_attrs = rs_page-attributes ).
+
+    IF rs_page-attributes-pagetype <> so2_controller.
+
+      lo_page->get_event_handlers(
+        IMPORTING
+          p_ev_handler = rs_page-event_handlers
+        EXCEPTIONS
+          page_deleted = 1
+          invalid_call = 2 ).
+      ASSERT sy-subrc = 0.
+
+      lo_page->get_parameters(
+        IMPORTING
+          p_parameters = rs_page-parameters
+        EXCEPTIONS
+          page_deleted = 1
+          invalid_call = 2
+          OTHERS       = 3 ).
+      ASSERT sy-subrc = 0.
+
+      lo_page->get_type_source(
+        IMPORTING
+          p_source     = rs_page-types
+        EXCEPTIONS
+          page_deleted = 1
+          invalid_call = 2
+          OTHERS       = 3 ).
+      ASSERT sy-subrc = 0.
+
+      lv_content = get_page_content( lo_page ).
+      SPLIT is_page-pagename AT '.' INTO lv_extra lv_ext.
+      REPLACE ALL OCCURRENCES OF '/' IN lv_ext WITH '_-'.
+      REPLACE ALL OCCURRENCES OF '/' IN lv_extra WITH '_-'.
+      mo_files->add_raw(
+        iv_extra = lv_extra
+        iv_ext   = lv_ext
+        iv_data  = lv_content ).
+
+      CLEAR: rs_page-attributes-implclass.
+
+    ENDIF.
+
+    CLEAR: rs_page-attributes-author,
+           rs_page-attributes-createdon,
+           rs_page-attributes-changedby,
+           rs_page-attributes-changedon,
+           rs_page-attributes-changetime,
+           rs_page-attributes-gendate,
+           rs_page-attributes-gentime,
+           rs_page-attributes-devclass.
+
+  ENDMETHOD.
+
+
+  METHOD to_page_content.
+
+    DATA: lv_string TYPE string.
+
+
+    lv_string = zcl_abapgit_convert=>xstring_to_string_utf8( iv_content ).
+
+    SPLIT lv_string AT zif_abapgit_definitions=>gc_newline INTO TABLE rt_content.
+
+  ENDMETHOD.
+
 
   METHOD zif_abapgit_object~changed_by.
 
@@ -61,38 +193,11 @@ CLASS zcl_abapgit_object_wapa IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD zif_abapgit_object~get_metadata.
-    rs_metadata = get_metadata( ).
-  ENDMETHOD.                    "zif_abapgit_object~get_metadata
 
-  METHOD zif_abapgit_object~exists.
+  METHOD zif_abapgit_object~compare_to_remote_version.
+    CREATE OBJECT ro_comparison_result TYPE zcl_abapgit_comparison_null.
+  ENDMETHOD.
 
-    DATA: lv_name TYPE o2applname.
-
-
-    lv_name = ms_item-obj_name.
-
-    cl_o2_api_application=>load(
-      EXPORTING
-        p_application_name  = lv_name
-      EXCEPTIONS
-        object_not_existing = 1
-        permission_failure  = 2
-        error_occured       = 3 ).
-    rv_bool = boolc( sy-subrc = 0 ).
-
-  ENDMETHOD.                    "zif_abapgit_object~exists
-
-  METHOD zif_abapgit_object~jump.
-
-    CALL FUNCTION 'RS_TOOL_ACCESS'
-      EXPORTING
-        operation     = 'SHOW'
-        object_name   = ms_item-obj_name
-        object_type   = ms_item-obj_type
-        in_new_window = abap_true.
-
-  ENDMETHOD.                    "jump
 
   METHOD zif_abapgit_object~delete.
 
@@ -190,22 +295,25 @@ CLASS zcl_abapgit_object_wapa IMPLEMENTATION.
 
   ENDMETHOD.                    "delete
 
+
   METHOD zif_abapgit_object~deserialize.
 
-    DATA: lo_bsp        TYPE REF TO cl_o2_api_application,
-          ls_attributes TYPE o2applattr,
-          lt_nodes      TYPE o2applnode_table,
-          lt_navgraph   TYPE o2applgrap_table,
-          lv_objkey     TYPE seu_objkey,
-          lv_obj_name   TYPE string,
-          ls_item       LIKE ms_item,
-          lv_extra      TYPE string,
-          lv_content    TYPE xstring,
-          lv_ext        TYPE string,
-          lo_page       TYPE REF TO cl_o2_api_pages,
-          lt_pages_info TYPE ty_pages_tt.
+    DATA: lo_bsp            TYPE REF TO cl_o2_api_application,
+          ls_attributes     TYPE o2applattr,
+          lt_nodes          TYPE o2applnode_table,
+          lt_navgraph       TYPE o2applgrap_table,
+          lv_obj_name       TYPE string,
+          lv_extra          TYPE string,
+          lv_ext            TYPE string,
+          lo_page           TYPE REF TO cl_o2_api_pages,
+          lt_pages_info     TYPE ty_pages_tt,
+          ls_pagekey        TYPE o2pagkey,
+          ls_local_page     TYPE zcl_abapgit_object_wapa=>ty_page,
+          lv_remote_content TYPE o2pageline_table,
+          lv_local_content  TYPE o2pageline_table,
+          lt_local_pages    TYPE o2pagelist.
 
-    FIELD-SYMBOLS: <ls_page> LIKE LINE OF lt_pages_info.
+    FIELD-SYMBOLS: <ls_remote_page>       LIKE LINE OF lt_pages_info.
 
 
     io_xml->read( EXPORTING iv_name = 'ATTRIBUTES'
@@ -217,71 +325,102 @@ CLASS zcl_abapgit_object_wapa IMPLEMENTATION.
 
     ls_attributes-devclass = iv_package.
 
-    IF me->zif_abapgit_object~exists( ) = abap_true.
-      me->zif_abapgit_object~delete( ).
-    ENDIF.
-
-    cl_o2_api_application=>create_new(
+    cl_o2_api_application=>load(
       EXPORTING
-        p_application_data      = ls_attributes
-        p_nodes                 = lt_nodes
-        p_navgraph              = lt_navgraph
+        p_application_name  = ls_attributes-applname    " Application Name
       IMPORTING
-        p_application           = lo_bsp
+        p_application       = lo_bsp    " Instance Created
       EXCEPTIONS
-        object_already_existing = 1
-        object_just_created     = 2
-        not_authorized          = 3
-        undefined_name          = 4
-        author_not_existing     = 5
-        action_cancelled        = 6
-        error_occured           = 7
-        invalid_parameter       = 8 ).
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |WAPA - error from create_new: { sy-subrc }| ).
-    ENDIF.
+        object_not_existing = 1
+        permission_failure  = 2
+        error_occured       = 3
+        OTHERS              = 4 ).
 
-    lo_bsp->save( ).
+    CASE sy-subrc.
+      WHEN 0.
 
-    lo_bsp->set_changeable(
-      p_changeable           = abap_false
-      p_complete_application = abap_true ).
+        cl_o2_api_pages=>get_all_pages(
+          EXPORTING
+            p_applname = ls_attributes-applname
+            p_version  = c_active
+          IMPORTING
+            p_pages    = lt_local_pages ).
 
-    ls_item-obj_type = 'WAPD'.
-    ls_item-obj_name = ms_item-obj_name.
-    zcl_abapgit_objects_activation=>add_item( ls_item ).
+      WHEN 1.
 
-    lv_objkey = ls_item-obj_name.
-* todo, hmm, the WAPD is not added to the worklist during activation
-    cl_o2_api_application=>activate( lv_objkey ).
+        lo_bsp = create_new_application( is_attributes = ls_attributes
+                                         it_nodes      = lt_nodes
+                                         it_navgraph   = lt_navgraph ).
 
-    LOOP AT lt_pages_info ASSIGNING <ls_page>.
-      cl_o2_api_pages=>create_new_page(
+      WHEN OTHERS.
+
+        zcx_abapgit_exception=>raise( |Error { sy-subrc } from CL_O2_API_APPLICATION=>LOAD| ).
+
+    ENDCASE.
+
+    LOOP AT lt_pages_info ASSIGNING <ls_remote_page>.
+
+      ls_pagekey-applname = <ls_remote_page>-attributes-applname.
+      ls_pagekey-pagekey = <ls_remote_page>-attributes-pagekey.
+
+      cl_o2_api_pages=>load(
         EXPORTING
-          p_pageattrs = <ls_page>-attributes
+          p_pagekey             = ls_pagekey
         IMPORTING
-          p_page      = lo_page ).
+          p_page                = lo_page
+        EXCEPTIONS
+          object_not_existing   = 1
+          version_not_existing  = 2
+          OTHERS                = 3 ).
 
-      IF <ls_page>-attributes-pagetype <> so2_controller.
+      CASE sy-subrc.
+        WHEN 0.
 
-        SPLIT <ls_page>-attributes-pagename AT '.' INTO lv_extra lv_ext.
-        REPLACE ALL OCCURRENCES OF '/' IN lv_extra WITH '_-'.
-        REPLACE ALL OCCURRENCES OF '/' IN lv_ext WITH '_-'.
-        lv_content = mo_files->read_raw( iv_extra = lv_extra
-                                         iv_ext   = lv_ext ).
-        lo_page->set_page( to_page_content( lv_content ) ).
+          ls_local_page = read_page( <ls_remote_page>-attributes ).
 
-        lo_page->set_event_handlers( <ls_page>-event_handlers ).
-        lo_page->set_parameters( <ls_page>-parameters ).
-        lo_page->set_type_source( <ls_page>-types ).
+        WHEN 1.
+
+          lo_page = create_new_page( <ls_remote_page>-attributes ).
+
+        WHEN 2.
+
+          " Do nothing...
+
+        WHEN OTHERS.
+
+          zcx_abapgit_exception=>raise( |Error { sy-subrc } from CL_O2_API_PAGES=>LOAD| ).
+
+      ENDCASE.
+
+      SPLIT <ls_remote_page>-attributes-pagename AT '.' INTO lv_extra lv_ext.
+      REPLACE ALL OCCURRENCES OF '/' IN lv_extra WITH '_-'.
+      REPLACE ALL OCCURRENCES OF '/' IN lv_ext WITH '_-'.
+
+      lv_remote_content = to_page_content( mo_files->read_raw( iv_extra = lv_extra
+                                                               iv_ext   = lv_ext ) ).
+      lv_local_content = to_page_content( get_page_content( lo_page ) ).
+
+      IF ls_local_page = <ls_remote_page>
+      AND lv_local_content = lv_remote_content.
+        " no changes -> nothing to do
+        CONTINUE.
+      ENDIF.
+
+      IF <ls_remote_page>-attributes-pagetype <> so2_controller.
+
+        lo_page->set_page( lv_remote_content ).
+
+        lo_page->set_event_handlers( <ls_remote_page>-event_handlers ).
+        lo_page->set_parameters( <ls_remote_page>-parameters ).
+        lo_page->set_type_source( <ls_remote_page>-types ).
 
       ENDIF.
 
       lo_page->save( p_with_all_texts = abap_true ).
 
       lv_obj_name = cl_wb_object_type=>get_concatenated_key_from_id(
-        p_key_component1 = <ls_page>-attributes-applname
-        p_key_component2 = <ls_page>-attributes-pagekey
+        p_key_component1 = <ls_remote_page>-attributes-applname
+        p_key_component2 = <ls_remote_page>-attributes-pagekey
         p_external_id    = 'WG ' ).
 
       zcl_abapgit_objects_activation=>add( iv_type = 'WAPP'
@@ -289,7 +428,59 @@ CLASS zcl_abapgit_object_wapa IMPLEMENTATION.
 
     ENDLOOP.
 
+    delete_superfluous_pages( it_local_pages  = lt_local_pages
+                              it_remote_pages = lt_pages_info ).
+
   ENDMETHOD.                    "deserialize
+
+
+  METHOD zif_abapgit_object~exists.
+
+    DATA: lv_name TYPE o2applname.
+
+
+    lv_name = ms_item-obj_name.
+
+    cl_o2_api_application=>load(
+      EXPORTING
+        p_application_name  = lv_name
+      EXCEPTIONS
+        object_not_existing = 1
+        permission_failure  = 2
+        error_occured       = 3 ).
+    rv_bool = boolc( sy-subrc = 0 ).
+
+  ENDMETHOD.                    "zif_abapgit_object~exists
+
+
+  METHOD zif_abapgit_object~get_metadata.
+    rs_metadata = get_metadata( ).
+  ENDMETHOD.                    "zif_abapgit_object~get_metadata
+
+
+  METHOD zif_abapgit_object~has_changed_since.
+    rv_changed = abap_true.
+  ENDMETHOD.  "zif_abapgit_object~has_changed_since
+
+
+  METHOD zif_abapgit_object~is_locked.
+
+    rv_is_locked = abap_false.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_object~jump.
+
+    CALL FUNCTION 'RS_TOOL_ACCESS'
+      EXPORTING
+        operation     = 'SHOW'
+        object_name   = ms_item-obj_name
+        object_type   = ms_item-obj_type
+        in_new_window = abap_true.
+
+  ENDMETHOD.                    "jump
+
 
   METHOD zif_abapgit_object~serialize.
 
@@ -358,125 +549,102 @@ CLASS zcl_abapgit_object_wapa IMPLEMENTATION.
 
   ENDMETHOD.                    "serialize
 
-  METHOD read_page.
+  METHOD create_new_application.
 
-    DATA: lv_name    TYPE o2applname,
-          ls_pagekey TYPE o2pagkey,
-          lv_content TYPE xstring,
-          lv_extra   TYPE string,
-          lv_ext     TYPE string,
-          lo_page    TYPE REF TO cl_o2_api_pages.
+    DATA: ls_item   LIKE ms_item,
+          lv_objkey TYPE seu_objkey.
 
-
-    lv_name = ms_item-obj_name.
-
-    ls_pagekey-applname = lv_name.
-    ls_pagekey-pagekey = is_page-pagekey.
-
-    cl_o2_api_pages=>load(
+    cl_o2_api_application=>create_new(
       EXPORTING
-        p_pagekey = ls_pagekey
+        p_application_data      = is_attributes
+        p_nodes                 = it_nodes
+        p_navgraph              = it_navgraph
       IMPORTING
-        p_page    = lo_page ).
-
-    lo_page->get_attrs(
-      IMPORTING
-        p_attrs = rs_page-attributes ).
-
-    IF rs_page-attributes-pagetype <> so2_controller.
-
-      lo_page->get_event_handlers(
-        IMPORTING
-          p_ev_handler = rs_page-event_handlers
-        EXCEPTIONS
-          page_deleted = 1
-          invalid_call = 2 ).
-      ASSERT sy-subrc = 0.
-
-      lo_page->get_parameters(
-        IMPORTING
-          p_parameters = rs_page-parameters
-        EXCEPTIONS
-          page_deleted = 1
-          invalid_call = 2
-          OTHERS       = 3 ).
-      ASSERT sy-subrc = 0.
-
-      lo_page->get_type_source(
-        IMPORTING
-          p_source     = rs_page-types
-        EXCEPTIONS
-          page_deleted = 1
-          invalid_call = 2
-          OTHERS       = 3 ).
-      ASSERT sy-subrc = 0.
-
-      lv_content = get_page_content( lo_page ).
-      SPLIT is_page-pagename AT '.' INTO lv_extra lv_ext.
-      REPLACE ALL OCCURRENCES OF '/' IN lv_ext WITH '_-'.
-      REPLACE ALL OCCURRENCES OF '/' IN lv_extra WITH '_-'.
-      mo_files->add_raw(
-        iv_extra = lv_extra
-        iv_ext   = lv_ext
-        iv_data  = lv_content ).
-
-      CLEAR: rs_page-attributes-implclass.
-
-    ENDIF.
-
-    CLEAR: rs_page-attributes-author,
-           rs_page-attributes-createdon,
-           rs_page-attributes-changedby,
-           rs_page-attributes-changedon,
-           rs_page-attributes-changetime,
-           rs_page-attributes-gendate,
-           rs_page-attributes-gentime,
-           rs_page-attributes-devclass.
-
-  ENDMETHOD.
-
-  METHOD to_page_content.
-
-    DATA: lv_string TYPE string.
-
-
-    lv_string = zcl_abapgit_convert=>xstring_to_string_utf8( iv_content ).
-
-    SPLIT lv_string AT zif_abapgit_definitions=>gc_newline INTO TABLE rt_content.
-
-  ENDMETHOD.
-
-  METHOD get_page_content.
-
-    DATA: lt_content TYPE o2pageline_table,
-          lv_string  TYPE string.
-
-    io_page->get_page(
-      IMPORTING
-        p_content = lt_content
+        p_application           = ro_bsp
       EXCEPTIONS
-        invalid_call = 1
-        page_deleted = 2
-        OTHERS       = 3 ).
+        object_already_existing = 1
+        object_just_created     = 2
+        not_authorized          = 3
+        undefined_name          = 4
+        author_not_existing     = 5
+        action_cancelled        = 6
+        error_occured           = 7
+        invalid_parameter       = 8 ).
 
     IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |WAPA - error from get_page_content| ).
+      zcx_abapgit_exception=>raise( |WAPA - error from create_new: { sy-subrc }| ).
     ENDIF.
 
-    CONCATENATE LINES OF lt_content INTO lv_string SEPARATED BY zif_abapgit_definitions=>gc_newline RESPECTING BLANKS.
+    ro_bsp->save( ).
 
-    rv_content = zcl_abapgit_convert=>string_to_xstring_utf8( lv_string ).
+    ro_bsp->set_changeable(
+      p_changeable           = abap_false
+      p_complete_application = abap_true ).
+
+    ls_item-obj_type = 'WAPD'.
+    ls_item-obj_name = ms_item-obj_name.
+    zcl_abapgit_objects_activation=>add_item( ls_item ).
+
+    lv_objkey = ls_item-obj_name.
+* todo, hmm, the WAPD is not added to the worklist during activation
+    cl_o2_api_application=>activate( lv_objkey ).
+
 
   ENDMETHOD.
 
-  METHOD zif_abapgit_object~compare_to_remote_version.
-    CREATE OBJECT ro_comparison_result TYPE zcl_abapgit_comparison_null.
+
+  METHOD create_new_page.
+
+    cl_o2_api_pages=>create_new_page(
+      EXPORTING
+        p_pageattrs = is_page_attributes
+      IMPORTING
+        p_page      = ro_page
+      EXCEPTIONS
+        object_already_exists = 1
+        invalid_name          = 2
+        error_occured         = 3
+        o2appl_not_existing   = 4
+        OTHERS                = 5 ).
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error { sy-subrc } from CL_O2_API_PAGES=>CREATE_NEW_PAGE| ).
+    ENDIF.
+
   ENDMETHOD.
 
-  METHOD zif_abapgit_object~is_locked.
 
-    rv_is_locked = abap_false.
+  METHOD delete_superfluous_pages.
+
+    DATA: ls_pagekey TYPE o2pagkey.
+    FIELD-SYMBOLS: <ls_local_page> LIKE LINE OF it_local_pages.
+
+    " delete local pages which doesn't exists remotely
+    LOOP AT it_local_pages ASSIGNING <ls_local_page>.
+
+      READ TABLE it_remote_pages WITH KEY attributes-pagekey = <ls_local_page>-pagekey
+                               TRANSPORTING NO FIELDS.
+      IF sy-subrc <> 0.
+        " page exists locally but not remotely -> delete
+
+        ls_pagekey-applname = <ls_local_page>-applname.
+        ls_pagekey-pagekey = <ls_local_page>-pagekey.
+
+        cl_o2_page=>delete_page_for_application(
+          EXPORTING
+            p_pagekey           = ls_pagekey
+          EXCEPTIONS
+            object_not_existing = 1
+            error_occured       = 2 ).
+
+        IF sy-subrc <> 0.
+          zcx_abapgit_exception=>raise( |Error { sy-subrc } from CL_O2_PAGE=>DELETE_PAGE_FOR_APPLICATION| ).
+        ENDIF.
+
+      ENDIF.
+
+    ENDLOOP.
+
 
   ENDMETHOD.
 
-ENDCLASS.                    "zcl_abapgit_object_tran IMPLEMENTATION
+ENDCLASS.

--- a/src/zcl_abapgit_objects.clas.abap
+++ b/src/zcl_abapgit_objects.clas.abap
@@ -646,8 +646,11 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
 
     rt_results = zcl_abapgit_file_status=>status( io_repo ).
     DELETE rt_results WHERE match = abap_true.     " Full match
-    SORT rt_results BY obj_type ASCENDING obj_name ASCENDING.
-    DELETE ADJACENT DUPLICATES FROM rt_results COMPARING obj_type obj_name.
+    SORT rt_results
+      BY obj_type ASCENDING
+         obj_name ASCENDING
+         filename ASCENDING.
+    DELETE ADJACENT DUPLICATES FROM rt_results COMPARING obj_type obj_name filename.
 
     DELETE rt_results WHERE obj_type IS INITIAL.
     DELETE rt_results WHERE lstate = zif_abapgit_definitions=>gc_state-added AND rstate IS INITIAL.


### PR DESCRIPTION
- improve delta handling while WAPA serialization
- adjust files_to_deserialize logic. This is needed because otherwise not all BSP files are considered. 

#1528