### PR TITLE
Limit Progress Indicator Updates

### DIFF
--- a/src/utils/zcl_abapgit_progress.clas.abap
+++ b/src/utils/zcl_abapgit_progress.clas.abap
@@ -21,7 +21,10 @@ CLASS zcl_abapgit_progress DEFINITION
         !iv_current   TYPE i
       RETURNING
         VALUE(rv_pct) TYPE i .
-  PRIVATE SECTION.
+private section.
+
+  data MV_CV_TIME_NEXT type SY-UZEIT .
+  data MV_CV_DATUM_NEXT type SY-DATUM .
 ENDCLASS.
 
 
@@ -52,14 +55,31 @@ CLASS ZCL_ABAPGIT_PROGRESS IMPLEMENTATION.
 
   METHOD show.
 
-    DATA: lv_pct TYPE i.
+    DATA: lv_pct  TYPE i.
+    DATA: lv_time TYPE t.
+
+    CONSTANTS: c_wait_secs TYPE i VALUE 2.
 
     lv_pct = calc_pct( iv_current ).
 
-    CALL FUNCTION 'SAPGUI_PROGRESS_INDICATOR'
-      EXPORTING
-        percentage = lv_pct
-        text       = iv_text.
+    GET TIME.
+    lv_time = sy-uzeit.
+    IF mv_cv_time_next IS INITIAL AND mv_cv_datum_next IS INITIAL.
+      mv_cv_time_next  = lv_time.
+      mv_cv_datum_next = sy-datum.
+    ENDIF.
+
+    "We only do a progress indication if enough time has passed
+    IF lv_time  >= mv_cv_time_next  AND sy-datum = mv_cv_datum_next  OR
+       sy-datum >  mv_cv_datum_next.
+
+      CALL FUNCTION 'SAPGUI_PROGRESS_INDICATOR'
+        EXPORTING
+          percentage = lv_pct
+          text       = iv_text.
+      mv_cv_time_next = lv_time + c_wait_secs.
+
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/utils/zcl_abapgit_progress.clas.abap
+++ b/src/utils/zcl_abapgit_progress.clas.abap
@@ -21,10 +21,10 @@ CLASS zcl_abapgit_progress DEFINITION
         !iv_current   TYPE i
       RETURNING
         VALUE(rv_pct) TYPE i .
-private section.
+  PRIVATE SECTION.
 
-  data MV_CV_TIME_NEXT type SY-UZEIT .
-  data MV_CV_DATUM_NEXT type SY-DATUM .
+    DATA mv_cv_time_next TYPE sy-uzeit .
+    DATA mv_cv_datum_next TYPE sy-datum .
 ENDCLASS.
 
 

--- a/src/utils/zcl_abapgit_progress.clas.abap
+++ b/src/utils/zcl_abapgit_progress.clas.abap
@@ -80,6 +80,12 @@ CLASS ZCL_ABAPGIT_PROGRESS IMPLEMENTATION.
       mv_cv_time_next = lv_time + c_wait_secs.
 
     ENDIF.
+    IF sy-datum > mv_cv_datum_next.
+      mv_cv_datum_next = sy-datum.
+    ENDIF.
+    IF mv_cv_time_next < lv_time.
+      mv_cv_datum_next = sy-datum + 1.
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/utils/zcl_abapgit_progress.clas.abap
+++ b/src/utils/zcl_abapgit_progress.clas.abap
@@ -60,8 +60,6 @@ CLASS ZCL_ABAPGIT_PROGRESS IMPLEMENTATION.
 
     CONSTANTS: c_wait_secs TYPE i VALUE 2.
 
-    lv_pct = calc_pct( iv_current ).
-
     GET TIME.
     lv_time = sy-uzeit.
     IF mv_cv_time_next IS INITIAL AND mv_cv_datum_next IS INITIAL.
@@ -72,6 +70,8 @@ CLASS ZCL_ABAPGIT_PROGRESS IMPLEMENTATION.
     "We only do a progress indication if enough time has passed
     IF lv_time  >= mv_cv_time_next  AND sy-datum = mv_cv_datum_next  OR
        sy-datum >  mv_cv_datum_next.
+
+      lv_pct = calc_pct( iv_current ).
 
       CALL FUNCTION 'SAPGUI_PROGRESS_INDICATOR'
         EXPORTING

--- a/src/utils/zcl_abapgit_progress.clas.xml
+++ b/src/utils/zcl_abapgit_progress.clas.xml
@@ -14,6 +14,20 @@
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
    </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCL_ABAPGIT_PROGRESS</CLSNAME>
+     <CMPNAME>MV_CV_DATUM_NEXT</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Date or Earliest, Next Progress Display</DESCRIPT>
+    </SEOCOMPOTX>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCL_ABAPGIT_PROGRESS</CLSNAME>
+     <CMPNAME>MV_CV_TIME_NEXT</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Time of Earliest, Next Progress Display</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
   </asx:values>
  </asx:abap>
 </abapGit>


### PR DESCRIPTION
Fixed an issue with the progress indicator updates, where updates of the progress indicator would flush the message queue of SAP GUI and cause a GUI crash or hang.
The problem is described in SAP note **#2084109** and seems to occur for large repositories (especially after installing SAP GUI 7.50 PL6)
The fix limites the updates sent to the progress indicator to one update every 2 seconds.
I could have used `CL_PROGRESS_INDICATOR` instead, but that SAP class uses a fixed interval of 10 seconds, which seemed excessive.