### PR TITLE
validate sub and super packages from installed repos 

### DIFF
--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -35,14 +35,21 @@ CLASS zcl_abapgit_repo_srv DEFINITION
         VALUE(rv_allowed) TYPE abap_bool .
     METHODS add
       IMPORTING
-        !io_repo TYPE REF TO zcl_abapgit_repo
+        io_repo TYPE REF TO zcl_abapgit_repo
       RAISING
         zcx_abapgit_exception .
+    METHODS validate_sub_super_packages
+      IMPORTING
+        iv_package TYPE devclass
+        it_repos   TYPE zif_abapgit_persistence=>tt_repo
+      RAISING
+        zcx_abapgit_exception.
+
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
+CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
 
 
   METHOD add.
@@ -323,7 +330,6 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
     DATA: lv_as4user TYPE tdevc-as4user,
           lt_repos   TYPE zif_abapgit_persistence=>tt_repo.
 
-
     IF iv_package IS INITIAL.
       zcx_abapgit_exception=>raise( 'add, package empty' ).
     ENDIF.
@@ -350,5 +356,30 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
       zcx_abapgit_exception=>raise( |Package { iv_package } already in use| ).
     ENDIF.
 
+    validate_sub_super_packages(
+      iv_package = iv_package
+      it_repos   = lt_repos ).
   ENDMETHOD.
+
+  METHOD validate_sub_super_packages.
+    DATA:
+      ls_repo     LIKE LINE OF it_repos,
+      lo_package  TYPE REF TO zif_abapgit_sap_package,
+      lt_packages TYPE zif_abapgit_sap_package=>ty_devclass_tt,
+      lo_repo     TYPE REF TO zcl_abapgit_repo.
+
+    LOOP AT it_repos INTO ls_repo.
+      lo_repo = get( ls_repo-key ).
+
+      lo_package = zcl_abapgit_factory=>get_sap_package( ls_repo-package ).
+      APPEND LINES OF lo_package->list_subpackages( ) TO lt_packages.
+      APPEND LINES OF lo_package->list_superpackages( ) TO lt_packages.
+      READ TABLE lt_packages TRANSPORTING NO FIELDS
+        WITH KEY table_line = iv_package.
+      IF sy-subrc = 0.
+        zcx_abapgit_exception=>raise( |Repository { lo_repo->get_name( ) } already contains { iv_package } | ).
+      ENDIF.
+    ENDLOOP.
+  ENDMETHOD.
+
 ENDCLASS.


### PR DESCRIPTION
Partially fix #1280 

Validate sub and super packages from installed repositories.

 For example, if you have repo `X` with package `A`, father of `B`,  and you try to install repo `Y` which contains package `B`, it will raise a message.

I could not figure it out how to check if you have `Y` installed and then tries to install repo `X`.

Can be tested using these repos: https://github.com/EduardoCopat/father-package and https://github.com/EduardoCopat/child-package