### PR TITLE
Performance Improvement in X_TO_BITBYTE Conversion

### DIFF
--- a/src/utils/zcl_abapgit_convert.clas.abap
+++ b/src/utils/zcl_abapgit_convert.clas.abap
@@ -159,10 +159,14 @@ CLASS ZCL_ABAPGIT_CONVERT IMPLEMENTATION.
 
     CLEAR rv_bitbyte.
 
-    DO 8 TIMES.
-      GET BIT sy-index OF iv_x INTO lv_b.
-      CONCATENATE rv_bitbyte lv_b INTO rv_bitbyte.
-    ENDDO.
+    GET BIT 1 OF iv_x INTO rv_bitbyte+0(1).
+    GET BIT 2 OF iv_x INTO rv_bitbyte+1(1).
+    GET BIT 3 OF iv_x INTO rv_bitbyte+2(1).
+    GET BIT 4 OF iv_x INTO rv_bitbyte+3(1).
+    GET BIT 5 OF iv_x INTO rv_bitbyte+4(1).
+    GET BIT 6 OF iv_x INTO rv_bitbyte+5(1).
+    GET BIT 7 OF iv_x INTO rv_bitbyte+6(1).
+    GET BIT 8 OF iv_x INTO rv_bitbyte+7(1).
 
   ENDMETHOD.                    "x_to_bitbyte
 ENDCLASS.


### PR DESCRIPTION
Since X_TO_BITBYTE only converts a single byte to a bitstring, it is faster to use direct addressing instead of a loop/concatenate pair, since concatenate on characters has to process the whole char array in each run.