### PR TITLE
Set transport request if needed during uninstall or reset local

### DIFF
--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -229,7 +229,7 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
           lt_unnecessary_local_objs TYPE zif_abapgit_definitions=>ty_tadir_tt,
           lt_selected               LIKE lt_unnecessary_local_objs,
           lt_columns                TYPE stringtab,
-          ls_checks                 TYPE zif_abapgit_definitions=>ty_deserialize_checks.
+          ls_checks                 TYPE zif_abapgit_definitions=>ty_delete_checks.
 
     lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
 
@@ -272,7 +272,7 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
         ls_checks = lo_repo->delete_checks( ).
         IF ls_checks-transport-required = abap_true.
           ls_checks-transport-transport = zcl_abapgit_ui_factory=>get_popups(
-                                            )->popup_transport_request(  ls_checks-transport-type ).
+                                            )->popup_transport_request( ls_checks-transport-type ).
         ENDIF.
 
         zcl_abapgit_objects=>delete( it_tadir  = lt_selected

--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -228,7 +228,8 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
           lv_answer                 TYPE c LENGTH 1,
           lt_unnecessary_local_objs TYPE zif_abapgit_definitions=>ty_tadir_tt,
           lt_selected               LIKE lt_unnecessary_local_objs,
-          lt_columns                TYPE stringtab.
+          lt_columns                TYPE stringtab,
+          ls_checks                 TYPE zif_abapgit_definitions=>ty_deserialize_checks.
 
     lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
 
@@ -268,7 +269,14 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
           et_list              = lt_selected ).
 
       IF lines( lt_selected ) > 0.
-        zcl_abapgit_objects=>delete( lt_selected ).
+        ls_checks = lo_repo->delete_checks( ).
+        IF ls_checks-transport-required = abap_true.
+          ls_checks-transport-transport = zcl_abapgit_ui_factory=>get_popups(
+                                            )->popup_transport_request(  ls_checks-transport-type ).
+        ENDIF.
+
+        zcl_abapgit_objects=>delete( it_tadir  = lt_selected
+                                     is_checks = ls_checks ).
 * update repo cache
         lo_repo->refresh( ).
       ENDIF.

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -283,7 +283,7 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
           lo_repo     TYPE REF TO zcl_abapgit_repo,
           lv_package  TYPE devclass,
           lv_question TYPE c LENGTH 100,
-          ls_checks   TYPE zif_abapgit_definitions=>ty_deserialize_checks.
+          ls_checks   TYPE zif_abapgit_definitions=>ty_delete_checks.
 
 
     lo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -282,7 +282,8 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
           lv_answer   TYPE c LENGTH 1,
           lo_repo     TYPE REF TO zcl_abapgit_repo,
           lv_package  TYPE devclass,
-          lv_question TYPE c LENGTH 100.
+          lv_question TYPE c LENGTH 100,
+          ls_checks   TYPE zif_abapgit_definitions=>ty_deserialize_checks.
 
 
     lo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
@@ -311,7 +312,14 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
 
     ENDIF.
 
-    zcl_abapgit_repo_srv=>get_instance( )->purge( lo_repo ).
+    ls_checks = lo_repo->delete_checks( ).
+    IF ls_checks-transport-required = abap_true.
+      ls_checks-transport-transport = zcl_abapgit_ui_factory=>get_popups(
+                                        )->popup_transport_request(  ls_checks-transport-type ).
+    ENDIF.
+
+    zcl_abapgit_repo_srv=>get_instance( )->purge( io_repo   = lo_repo
+                                                  is_checks = ls_checks ).
 
     COMMIT WORK.
 

--- a/src/zcl_abapgit_objects.clas.abap
+++ b/src/zcl_abapgit_objects.clas.abap
@@ -43,7 +43,7 @@ CLASS zcl_abapgit_objects DEFINITION
     CLASS-METHODS delete
       IMPORTING
         !it_tadir  TYPE zif_abapgit_definitions=>ty_tadir_tt
-        !is_checks TYPE zif_abapgit_definitions=>ty_deserialize_checks OPTIONAL
+        !is_checks TYPE zif_abapgit_definitions=>ty_delete_checks OPTIONAL
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS jump
@@ -206,7 +206,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_objects IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
 
   METHOD changed_by.
@@ -733,6 +733,40 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
   ENDMETHOD.                    "jump
 
 
+  METHOD map_results_to_items.
+
+    DATA: ls_item LIKE LINE OF rt_items.
+    FIELD-SYMBOLS: <ls_result> TYPE zif_abapgit_definitions=>ty_result.
+
+    LOOP AT it_results ASSIGNING <ls_result>.
+
+      ls_item-devclass = <ls_result>-package.
+      ls_item-obj_type = <ls_result>-obj_type.
+      ls_item-obj_name = <ls_result>-obj_name.
+      INSERT ls_item INTO TABLE rt_items.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD map_tadir_to_items.
+
+    DATA: ls_item LIKE LINE OF rt_items.
+    FIELD-SYMBOLS: <ls_tadir> TYPE zif_abapgit_definitions=>ty_tadir.
+
+    LOOP AT it_tadir ASSIGNING <ls_tadir>.
+
+      ls_item-devclass = <ls_tadir>-devclass.
+      ls_item-obj_type = <ls_tadir>-object.
+      ls_item-obj_name = <ls_tadir>-obj_name.
+      INSERT ls_item INTO TABLE rt_items.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
   METHOD prioritize_deser.
 
     FIELD-SYMBOLS: <ls_result> LIKE LINE OF it_results.
@@ -985,38 +1019,4 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
     ENDLOOP.
 
   ENDMETHOD.
-
-  METHOD map_tadir_to_items.
-
-    DATA: ls_item LIKE LINE OF rt_items.
-    FIELD-SYMBOLS: <ls_tadir> TYPE zif_abapgit_definitions=>ty_tadir.
-
-    LOOP AT it_tadir ASSIGNING <ls_tadir>.
-
-      ls_item-devclass = <ls_tadir>-devclass.
-      ls_item-obj_type = <ls_tadir>-object.
-      ls_item-obj_name = <ls_tadir>-obj_name.
-      INSERT ls_item INTO TABLE rt_items.
-
-    ENDLOOP.
-
-  ENDMETHOD.
-
-
-  METHOD map_results_to_items.
-
-    DATA: ls_item LIKE LINE OF rt_items.
-    FIELD-SYMBOLS: <ls_result> TYPE zif_abapgit_definitions=>ty_result.
-
-    LOOP AT it_results ASSIGNING <ls_result>.
-
-      ls_item-devclass = <ls_result>-package.
-      ls_item-obj_type = <ls_result>-obj_type.
-      ls_item-obj_name = <ls_result>-obj_name.
-      INSERT ls_item INTO TABLE rt_items.
-
-    ENDLOOP.
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/zcl_abapgit_objects.clas.testclasses.abap
+++ b/src/zcl_abapgit_objects.clas.testclasses.abap
@@ -84,7 +84,7 @@ CLASS ltcl_dangerous IMPLEMENTATION.
           quit = if_aunit_constants=>no ).
     ENDLOOP.
 
-    zcl_abapgit_objects=>delete( lt_tadir ).
+    zcl_abapgit_objects=>delete( it_tadir = lt_tadir ).
     lt_tadir = zcl_abapgit_factory=>get_tadir( )->read( c_package ).
     LOOP AT lt_tadir ASSIGNING <ls_tadir>.
       lv_msg = |Not deleted properly { <ls_tadir>-object } { <ls_tadir>-obj_name }|.

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -14,7 +14,7 @@ CLASS zcl_abapgit_repo DEFINITION
         zcx_abapgit_exception .
     METHODS delete_checks
       RETURNING
-        VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_deserialize_checks
+        VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_delete_checks
       RAISING
         zcx_abapgit_exception .
     METHODS constructor

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -12,6 +12,11 @@ CLASS zcl_abapgit_repo DEFINITION
         VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_deserialize_checks
       RAISING
         zcx_abapgit_exception .
+    METHODS delete_checks
+      RETURNING
+        VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_deserialize_checks
+      RAISING
+        zcx_abapgit_exception .
     METHODS constructor
       IMPORTING
         !is_data TYPE zif_abapgit_persistence=>ty_repo .
@@ -124,7 +129,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
+CLASS zcl_abapgit_repo IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -201,6 +206,16 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
     lt_requirements = get_dot_abapgit( )->get_data( )-requirements.
     rs_checks-requirements-met = zcl_abapgit_requirement_helper=>is_requirements_met(
       lt_requirements ).
+
+  ENDMETHOD.
+
+
+  METHOD delete_checks.
+
+    DATA: li_package TYPE REF TO zif_abapgit_sap_package.
+
+    li_package = zcl_abapgit_factory=>get_sap_package( get_package( ) ).
+    rs_checks-transport-required = li_package->are_changes_recorded_in_tr_req( ).
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -285,7 +285,8 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
 
     lt_tadir = zcl_abapgit_factory=>get_tadir( )->read( io_repo->get_package( ) ).
 
-    zcl_abapgit_objects=>delete( lt_tadir ).
+    zcl_abapgit_objects=>delete( it_tadir  = lt_tadir
+                                 is_checks = is_checks ).
 
     delete( io_repo ).
 

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -128,7 +128,10 @@ INTERFACE zif_abapgit_definitions PUBLIC.
            warning_package TYPE ty_overwrite_tt,
            requirements    TYPE ty_requirements,
            transport       TYPE ty_transport,
-         END OF ty_deserialize_checks.
+         END OF ty_deserialize_checks,
+         BEGIN OF ty_delete_checks,
+           transport TYPE ty_transport,
+         END OF ty_delete_checks.
 
   TYPES:
     BEGIN OF ty_metadata,

--- a/src/zif_abapgit_repo_srv.intf.abap
+++ b/src/zif_abapgit_repo_srv.intf.abap
@@ -47,7 +47,7 @@ INTERFACE zif_abapgit_repo_srv
   METHODS purge
     IMPORTING
       !io_repo  TYPE REF TO zcl_abapgit_repo
-      is_checks TYPE zif_abapgit_definitions=>ty_deserialize_checks
+      is_checks TYPE zif_abapgit_definitions=>ty_delete_checks
     RAISING
       zcx_abapgit_exception .
   METHODS switch_repo_type

--- a/src/zif_abapgit_repo_srv.intf.abap
+++ b/src/zif_abapgit_repo_srv.intf.abap
@@ -46,7 +46,8 @@ INTERFACE zif_abapgit_repo_srv
       zcx_abapgit_exception .
   METHODS purge
     IMPORTING
-      !io_repo TYPE REF TO zcl_abapgit_repo
+      !io_repo  TYPE REF TO zcl_abapgit_repo
+      is_checks TYPE zif_abapgit_definitions=>ty_deserialize_checks
     RAISING
       zcx_abapgit_exception .
   METHODS switch_repo_type


### PR DESCRIPTION
- this ensures that the transport request is set when objects are deleted. E.g. during uninstall or reset local.
- introduces new concept 'delete_checks' which works similar to 'deserialize_checks'

#1554