### PR TITLE
Moving unit tests to the right classes, first step

### DIFF
--- a/src/objects/zcl_abapgit_object_enqu.clas.abap
+++ b/src/objects/zcl_abapgit_object_enqu.clas.abap
@@ -6,25 +6,10 @@ CLASS zcl_abapgit_object_enqu DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
 
 ENDCLASS.
 
-CLASS zcl_abapgit_object_enqu IMPLEMENTATION.
 
-  METHOD zif_abapgit_object~has_changed_since.
 
-    DATA: lv_date TYPE dats,
-          lv_time TYPE tims.
+CLASS ZCL_ABAPGIT_OBJECT_ENQU IMPLEMENTATION.
 
-    SELECT SINGLE as4date as4time FROM dd25l
-      INTO (lv_date, lv_time)
-      WHERE viewname = ms_item-obj_name
-      AND as4local = 'A'
-      AND as4vers  = '0000'.
-
-    rv_changed = check_timestamp(
-      iv_timestamp = iv_timestamp
-      iv_date      = lv_date
-      iv_time      = lv_time ).
-
-  ENDMETHOD.  "zif_abapgit_object~has_changed_since
 
   METHOD zif_abapgit_object~changed_by.
 
@@ -39,30 +24,11 @@ CLASS zcl_abapgit_object_enqu IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD zif_abapgit_object~get_metadata.
-    rs_metadata = get_metadata( ).
-    rs_metadata-ddic = abap_true.
-  ENDMETHOD.                    "zif_abapgit_object~get_metadata
 
-  METHOD zif_abapgit_object~exists.
+  METHOD zif_abapgit_object~compare_to_remote_version.
+    CREATE OBJECT ro_comparison_result TYPE zcl_abapgit_comparison_null.
+  ENDMETHOD.
 
-    DATA: lv_viewname TYPE dd25l-viewname.
-
-
-    SELECT SINGLE viewname FROM dd25l INTO lv_viewname
-      WHERE viewname = ms_item-obj_name
-      AND as4local = 'A'
-      AND as4vers = '0000'.
-    rv_bool = boolc( sy-subrc = 0 ).
-
-  ENDMETHOD.                    "zif_abapgit_object~exists
-
-  METHOD zif_abapgit_object~jump.
-
-    jump_se11( iv_radio = 'RSRD1-ENQU'
-               iv_field = 'RSRD1-ENQU_VAL' ).
-
-  ENDMETHOD.                    "jump
 
   METHOD zif_abapgit_object~delete.
 
@@ -86,6 +52,103 @@ CLASS zcl_abapgit_object_enqu IMPLEMENTATION.
     ENDIF.
 
   ENDMETHOD.                    "delete
+
+
+  METHOD zif_abapgit_object~deserialize.
+
+    DATA: lv_name  TYPE ddobjname,
+          ls_dd25v TYPE dd25v,
+          lt_dd26e TYPE TABLE OF dd26e,
+          lt_dd27p TYPE TABLE OF dd27p.
+
+
+    io_xml->read( EXPORTING iv_name = 'DD25V'
+                  CHANGING cg_data = ls_dd25v ).
+    io_xml->read( EXPORTING iv_name = 'DD26E_TABLE'
+                  CHANGING cg_data = lt_dd26e ).
+    io_xml->read( EXPORTING iv_name = 'DD27P_TABLE'
+                  CHANGING cg_data = lt_dd27p ).
+
+    corr_insert( iv_package ).
+
+    lv_name = ms_item-obj_name.
+
+    CALL FUNCTION 'DDIF_ENQU_PUT'
+      EXPORTING
+        name              = lv_name
+        dd25v_wa          = ls_dd25v
+      TABLES
+        dd26e_tab         = lt_dd26e
+        dd27p_tab         = lt_dd27p
+      EXCEPTIONS
+        enqu_not_found    = 1
+        name_inconsistent = 2
+        enqu_inconsistent = 3
+        put_failure       = 4
+        put_refused       = 5
+        OTHERS            = 6.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( 'error from DDIF_ENQU_PUT' ).
+    ENDIF.
+
+    zcl_abapgit_objects_activation=>add_item( ms_item ).
+
+  ENDMETHOD.                    "deserialize
+
+
+  METHOD zif_abapgit_object~exists.
+
+    DATA: lv_viewname TYPE dd25l-viewname.
+
+
+    SELECT SINGLE viewname FROM dd25l INTO lv_viewname
+      WHERE viewname = ms_item-obj_name
+      AND as4local = 'A'
+      AND as4vers = '0000'.
+    rv_bool = boolc( sy-subrc = 0 ).
+
+  ENDMETHOD.                    "zif_abapgit_object~exists
+
+
+  METHOD zif_abapgit_object~get_metadata.
+    rs_metadata = get_metadata( ).
+    rs_metadata-ddic = abap_true.
+  ENDMETHOD.                    "zif_abapgit_object~get_metadata
+
+
+  METHOD zif_abapgit_object~has_changed_since.
+
+    DATA: lv_date TYPE dats,
+          lv_time TYPE tims.
+
+    SELECT SINGLE as4date as4time FROM dd25l
+      INTO (lv_date, lv_time)
+      WHERE viewname = ms_item-obj_name
+      AND as4local = 'A'
+      AND as4vers  = '0000'.
+
+    rv_changed = check_timestamp(
+      iv_timestamp = iv_timestamp
+      iv_date      = lv_date
+      iv_time      = lv_time ).
+
+  ENDMETHOD.  "zif_abapgit_object~has_changed_since
+
+
+  METHOD zif_abapgit_object~is_locked.
+
+    rv_is_locked = abap_false.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_object~jump.
+
+    jump_se11( iv_radio = 'RSRD1-ENQU'
+               iv_field = 'RSRD1-ENQU_VAL' ).
+
+  ENDMETHOD.                    "jump
+
 
   METHOD zif_abapgit_object~serialize.
 
@@ -129,56 +192,4 @@ CLASS zcl_abapgit_object_enqu IMPLEMENTATION.
                  iv_name = 'DD27P_TABLE' ).
 
   ENDMETHOD.                    "serialize
-
-  METHOD zif_abapgit_object~deserialize.
-
-    DATA: lv_name  TYPE ddobjname,
-          ls_dd25v TYPE dd25v,
-          lt_dd26e TYPE TABLE OF dd26e,
-          lt_dd27p TYPE TABLE OF dd27p.
-
-
-    io_xml->read( EXPORTING iv_name = 'DD25V'
-                  CHANGING cg_data = ls_dd25v ).
-    io_xml->read( EXPORTING iv_name = 'DD26E_TABLE'
-                  CHANGING cg_data = lt_dd26e ).
-    io_xml->read( EXPORTING iv_name = 'DD27P_TABLE'
-                  CHANGING cg_data = lt_dd27p ).
-
-    corr_insert( iv_package ).
-
-    lv_name = ms_item-obj_name.
-
-    CALL FUNCTION 'DDIF_ENQU_PUT'
-      EXPORTING
-        name              = lv_name
-        dd25v_wa          = ls_dd25v
-      TABLES
-        dd26e_tab         = lt_dd26e
-        dd27p_tab         = lt_dd27p
-      EXCEPTIONS
-        enqu_not_found    = 1
-        name_inconsistent = 2
-        enqu_inconsistent = 3
-        put_failure       = 4
-        put_refused       = 5
-        OTHERS            = 6.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'error from DDIF_ENQU_PUT' ).
-    ENDIF.
-
-    zcl_abapgit_objects_activation=>add_item( ms_item ).
-
-  ENDMETHOD.                    "deserialize
-
-  METHOD zif_abapgit_object~compare_to_remote_version.
-    CREATE OBJECT ro_comparison_result TYPE zcl_abapgit_comparison_null.
-  ENDMETHOD.
-
-  METHOD zif_abapgit_object~is_locked.
-
-    rv_is_locked = abap_false.
-
-  ENDMETHOD.
-
-ENDCLASS.                    "zcl_abapgit_object_enqu IMPLEMENTATION
+ENDCLASS.

--- a/src/objects/zcl_abapgit_object_enqu.clas.testclasses.abap
+++ b/src/objects/zcl_abapgit_object_enqu.clas.testclasses.abap
@@ -1,0 +1,24 @@
+CLASS ltcl_serialize DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT FINAL.
+
+  PRIVATE SECTION.
+
+    METHODS:
+      serialize FOR TESTING RAISING zcx_abapgit_exception.
+
+ENDCLASS.
+
+CLASS ltcl_serialize IMPLEMENTATION.
+
+  METHOD serialize.
+
+    DATA: ls_item  TYPE zif_abapgit_definitions=>ty_item.
+
+
+    ls_item-obj_type = 'ENQU'.
+    ls_item-obj_name = 'E_USR04'.
+
+    zcl_abapgit_test_serialize=>check( ls_item ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/test/package.devc.xml
+++ b/src/test/package.devc.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <DEVC>
+    <CTEXT>Unit Test Utilities</CTEXT>
+   </DEVC>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/test/zcl_abapgit_test_serialize.clas.abap
+++ b/src/test/zcl_abapgit_test_serialize.clas.abap
@@ -1,0 +1,33 @@
+CLASS zcl_abapgit_test_serialize DEFINITION
+  PUBLIC
+  CREATE PUBLIC
+  FOR TESTING .
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS check
+      IMPORTING
+        !is_item TYPE zif_abapgit_definitions=>ty_item
+      RAISING
+        zcx_abapgit_exception .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPGIT_TEST_SERIALIZE IMPLEMENTATION.
+
+
+  METHOD check.
+
+    DATA: lt_files TYPE zif_abapgit_definitions=>ty_files_tt.
+
+    lt_files = zcl_abapgit_objects=>serialize(
+      is_item     = is_item
+      iv_language = zif_abapgit_definitions=>gc_english ).
+
+    cl_abap_unit_assert=>assert_not_initial( lt_files ).
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/test/zcl_abapgit_test_serialize.clas.xml
+++ b/src/test/zcl_abapgit_test_serialize.clas.xml
@@ -3,16 +3,16 @@
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <VSEOCLASS>
-    <CLSNAME>ZCL_ABAPGIT_OBJECT_ENQU</CLSNAME>
+    <CLSNAME>ZCL_ABAPGIT_TEST_SERIALIZE</CLSNAME>
     <VERSION>1</VERSION>
     <LANGU>E</LANGU>
+    <DESCRIPT>Serialize</DESCRIPT>
+    <CATEGORY>05</CATEGORY>
     <EXPOSURE>2</EXPOSURE>
     <STATE>1</STATE>
-    <CLSFINAL>X</CLSFINAL>
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
-    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>

--- a/src/zcl_abapgit_objects.clas.testclasses.abap
+++ b/src/zcl_abapgit_objects.clas.testclasses.abap
@@ -166,7 +166,6 @@ CLASS ltcl_serialize DEFINITION FOR TESTING RISK LEVEL HARMLESS DURATION SHORT F
         IMPORTING is_item TYPE zif_abapgit_definitions=>ty_item
         RAISING   zcx_abapgit_exception,
       serialize_tabl FOR TESTING RAISING zcx_abapgit_exception,
-      serialize_enqu FOR TESTING RAISING zcx_abapgit_exception,
       serialize_shlp FOR TESTING RAISING zcx_abapgit_exception,
       serialize_view FOR TESTING RAISING zcx_abapgit_exception,
       serialize_auth FOR TESTING RAISING zcx_abapgit_exception,
@@ -187,18 +186,6 @@ ENDCLASS.                    "ltcl_serialize DEFINITION
 *
 *----------------------------------------------------------------------*
 CLASS ltcl_serialize IMPLEMENTATION.
-
-  METHOD serialize_enqu.
-
-    DATA: ls_item  TYPE zif_abapgit_definitions=>ty_item.
-
-
-    ls_item-obj_type = 'ENQU'.
-    ls_item-obj_name = 'E_USR04'.
-
-    check( ls_item ).
-
-  ENDMETHOD.                    "lcl_abap_unit
 
   METHOD serialize_shlp.
 


### PR DESCRIPTION
Moving objects tests from the objects class to the right object

+ Test for ENQU moved to ENQU class
+ Global unit test utility class `zcl_abapgit_test_serialize` created for testing object serialization

Sorry about the reordering of methods