### PR TITLE
Remove local SHA1 from online repository #1485, #1509

### DIFF
--- a/src/git/zcl_abapgit_git_porcelain.clas.abap
+++ b/src/git/zcl_abapgit_git_porcelain.clas.abap
@@ -27,7 +27,7 @@ CLASS zcl_abapgit_git_porcelain DEFINITION
       IMPORTING
         !io_repo TYPE REF TO zcl_abapgit_repo_online
         !iv_name TYPE string
-        !iv_from TYPE zif_abapgit_definitions=>ty_sha1
+        iv_from  TYPE zif_abapgit_definitions=>ty_sha1
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS create_tag
@@ -198,8 +198,6 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
 
     IF iv_name CS ` `.
       zcx_abapgit_exception=>raise( 'Branch name cannot contain blank spaces' ).
-    ELSEIF iv_from = ''.
-      zcx_abapgit_exception=>raise( 'New branch, "from" SHA1 empty' ).
     ENDIF.
 
 * "client MUST send an empty packfile"
@@ -720,7 +718,7 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
     zcl_abapgit_git_transport=>receive_pack(
       iv_url         = io_repo->get_url( )
       iv_old         = c_zero
-      iv_new         = io_repo->get_sha1_local( )
+      iv_new         = is_tag-sha1
       iv_branch_name = is_tag-name
       iv_pack        = lv_pack ).
 

--- a/src/persist/zcl_abapgit_persistence_repo.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_repo.clas.abap
@@ -10,12 +10,6 @@ CLASS zcl_abapgit_persistence_repo DEFINITION
         VALUE(rt_repos) TYPE zif_abapgit_persistence=>tt_repo
       RAISING
         zcx_abapgit_exception .
-    METHODS update_sha1
-      IMPORTING
-        !iv_key         TYPE zif_abapgit_persistence=>ty_repo-key
-        !iv_branch_sha1 TYPE zif_abapgit_persistence=>ty_repo_xml-sha1
-      RAISING
-        zcx_abapgit_exception .
     METHODS update_local_checksums
       IMPORTING
         !iv_key       TYPE zif_abapgit_persistence=>ty_repo-key
@@ -114,7 +108,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_PERSISTENCE_REPO IMPLEMENTATION.
+CLASS zcl_abapgit_persistence_repo IMPLEMENTATION.
 
 
   METHOD add.
@@ -125,7 +119,6 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_REPO IMPLEMENTATION.
 
     ls_repo-url          = iv_url.
     ls_repo-branch_name  = iv_branch_name.
-    ls_repo-sha1         = iv_branch.
     ls_repo-package      = iv_package.
     ls_repo-offline      = iv_offline.
     ls_repo-created_by   = sy-uname.
@@ -422,31 +415,6 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_REPO IMPLEMENTATION.
                    iv_data  = ls_content-data_str ).
 
   ENDMETHOD.  "update_offline
-
-
-  METHOD update_sha1.
-
-    DATA: lt_content TYPE zif_abapgit_persistence=>tt_content,
-          ls_content LIKE LINE OF lt_content,
-          ls_repo    TYPE zif_abapgit_persistence=>ty_repo.
-
-
-    ASSERT NOT iv_key IS INITIAL.
-
-    TRY.
-        ls_repo = read( iv_key ).
-      CATCH zcx_abapgit_not_found.
-        zcx_abapgit_exception=>raise( 'key not found' ).
-    ENDTRY.
-
-    ls_repo-sha1 = iv_branch_sha1.
-    ls_content-data_str = to_xml( ls_repo ).
-
-    mo_db->update( iv_type  = zcl_abapgit_persistence_db=>c_type_repo
-                   iv_value = iv_key
-                   iv_data  = ls_content-data_str ).
-
-  ENDMETHOD.
 
 
   METHOD update_url.

--- a/src/persist/zif_abapgit_persistence.intf.abap
+++ b/src/persist/zif_abapgit_persistence.intf.abap
@@ -32,7 +32,6 @@ INTERFACE zif_abapgit_persistence PUBLIC.
   TYPES: BEGIN OF ty_repo_xml,
            url             TYPE string,
            branch_name     TYPE string,
-           sha1            TYPE zif_abapgit_definitions=>ty_sha1,
            package         TYPE devclass,
            created_by      TYPE xubname,
            created_at      TYPE timestampl,

--- a/src/ui/zcl_abapgit_gui_page_tag.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_tag.clas.abap
@@ -157,7 +157,7 @@ CLASS zcl_abapgit_gui_page_tag IMPLEMENTATION.
 
     ro_html->add( render_text_input( iv_name  = 'sha1'
                                      iv_label = 'SHA1'
-                                     iv_value = mo_repo_online->get_sha1_local( ) ) ).
+                                     iv_value = mo_repo_online->get_sha1_remote( ) ) ).
 
     ro_html->add( render_text_input( iv_name  = 'name'
                                      iv_label = 'tag name' ) ).

--- a/src/ui/zcl_abapgit_services_git.clas.abap
+++ b/src/ui/zcl_abapgit_services_git.clas.abap
@@ -145,7 +145,7 @@ CLASS zcl_abapgit_services_git IMPLEMENTATION.
     zcl_abapgit_git_porcelain=>create_branch(
       io_repo = lo_repo
       iv_name = lv_name
-      iv_from = lo_repo->get_sha1_local( ) ).
+      iv_from = lo_repo->get_sha1_remote( ) ).
 
     " automatically switch to new branch
     lo_repo->set_branch_name( lv_name ).

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -114,7 +114,6 @@ CLASS zcl_abapgit_repo DEFINITION
 
     METHODS set
       IMPORTING
-        !iv_sha1           TYPE zif_abapgit_definitions=>ty_sha1 OPTIONAL
         !it_checksums      TYPE zif_abapgit_persistence=>ty_local_checksum_tt OPTIONAL
         !iv_url            TYPE zif_abapgit_persistence=>ty_repo-url OPTIONAL
         !iv_branch_name    TYPE zif_abapgit_persistence=>ty_repo-branch_name OPTIONAL
@@ -457,8 +456,7 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
     DATA: lo_persistence TYPE REF TO zcl_abapgit_persistence_repo.
 
 
-    ASSERT iv_sha1 IS SUPPLIED
-      OR it_checksums IS SUPPLIED
+    ASSERT it_checksums IS SUPPLIED
       OR iv_url IS SUPPLIED
       OR iv_branch_name IS SUPPLIED
       OR iv_head_branch IS SUPPLIED
@@ -467,13 +465,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
       OR is_local_settings IS SUPPLIED.
 
     CREATE OBJECT lo_persistence.
-
-    IF iv_sha1 IS SUPPLIED.
-      lo_persistence->update_sha1(
-        iv_key         = ms_data-key
-        iv_branch_sha1 = iv_sha1 ).
-      ms_data-sha1 = iv_sha1.
-    ENDIF.
 
     IF it_checksums IS SUPPLIED.
       lo_persistence->update_local_checksums(

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -311,7 +311,13 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
                                      IMPORTING ev_branch        = lv_branch
                                                et_updated_files = lt_updated_files ).
 
-    refresh( ).
+    IF io_stage->get_branch_sha1( ) = get_sha1_remote( ).
+* pushing to the branch currently represented by this repository object      mv_branch = lv_branch.
+      mv_branch = lv_branch.
+    ELSE.
+      refresh( ).
+    ENDIF.
+
     update_local_checksums( lt_updated_files ).
 
     CLEAR: mv_code_inspector_successful.

--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -310,7 +310,6 @@ CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
       lo_repo->set(
         iv_url         = zcl_abapgit_url=>name( lo_repo->ms_data-url )
         iv_branch_name = ''
-        iv_sha1        = ''
         iv_head_branch = ''
         iv_offline     = abap_true ).
       CREATE OBJECT <lo_repo> TYPE zcl_abapgit_repo_offline

--- a/src/zcl_abapgit_transport_2_branch.clas.abap
+++ b/src/zcl_abapgit_transport_2_branch.clas.abap
@@ -33,7 +33,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_TRANSPORT_2_BRANCH IMPLEMENTATION.
+CLASS zcl_abapgit_transport_2_branch IMPLEMENTATION.
 
 
   METHOD create.
@@ -79,7 +79,7 @@ CLASS ZCL_ABAPGIT_TRANSPORT_2_BRANCH IMPLEMENTATION.
         zcl_abapgit_git_porcelain=>create_branch(
           io_repo = io_repository
           iv_name = iv_branch_name
-          iv_from = io_repository->get_sha1_local( ) ).
+          iv_from = io_repository->get_sha1_remote( ) ).
 
         io_repository->set_branch_name( iv_branch_name ).
       CATCH zcx_abapgit_exception.


### PR DESCRIPTION
In this commit we remove the local SHA1 and all its references from
ZCL_ABAPGIT_REPO_ONLINE. SHA1 is also removed from repo persistency.
SHA1 insn't needed anymore. All where-used places were either migrated to
remote_SHA1 or removed.

Needs further testing.

#1485 
#1509