### PR TITLE
Refresh online repo: call BRANCH_LIST just once #1679

### DIFF
--- a/src/git/zcl_abapgit_git_porcelain.clas.abap
+++ b/src/git/zcl_abapgit_git_porcelain.clas.abap
@@ -6,11 +6,12 @@ CLASS zcl_abapgit_git_porcelain DEFINITION
   PUBLIC SECTION.
     CLASS-METHODS pull
       IMPORTING
-        !io_repo    TYPE REF TO zcl_abapgit_repo_online
+        !io_repo        TYPE REF TO zcl_abapgit_repo_online
       EXPORTING
-        !et_files   TYPE zif_abapgit_definitions=>ty_files_tt
-        !et_objects TYPE zif_abapgit_definitions=>ty_objects_tt
-        !ev_branch  TYPE zif_abapgit_definitions=>ty_sha1
+        !et_files       TYPE zif_abapgit_definitions=>ty_files_tt
+        !et_objects     TYPE zif_abapgit_definitions=>ty_objects_tt
+        !ev_branch      TYPE zif_abapgit_definitions=>ty_sha1
+        !eo_branch_list TYPE REF TO zcl_abapgit_git_branch_list
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS push
@@ -351,6 +352,7 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
     CLEAR et_files.
     CLEAR et_objects.
     CLEAR ev_branch.
+    CLEAR eo_branch_list.
 
     zcl_abapgit_git_transport=>upload_pack(
       EXPORTING
@@ -358,7 +360,8 @@ CLASS zcl_abapgit_git_porcelain IMPLEMENTATION.
         iv_branch_name = io_repo->get_branch_name( )
       IMPORTING
         et_objects     = et_objects
-        ev_branch      = ev_branch ).
+        ev_branch      = ev_branch
+        eo_branch_list = eo_branch_list ).
 
     READ TABLE et_objects INTO ls_object WITH KEY sha1 = ev_branch type = zif_abapgit_definitions=>gc_type-commit.
     IF sy-subrc <> 0.

--- a/src/git/zcl_abapgit_git_transport.clas.abap
+++ b/src/git/zcl_abapgit_git_transport.clas.abap
@@ -12,6 +12,7 @@ CLASS zcl_abapgit_git_transport DEFINITION
                 it_branches    TYPE zif_abapgit_definitions=>ty_git_branch_list_tt OPTIONAL
       EXPORTING et_objects     TYPE zif_abapgit_definitions=>ty_objects_tt
                 ev_branch      TYPE zif_abapgit_definitions=>ty_sha1
+                eo_branch_list TYPE REF TO zcl_abapgit_git_branch_list
       RAISING   zcx_abapgit_exception.
 
 * local to remote
@@ -46,6 +47,7 @@ CLASS zcl_abapgit_git_transport DEFINITION
                 iv_branch_name TYPE string
       EXPORTING eo_client      TYPE REF TO zcl_abapgit_http_client
                 ev_branch      TYPE zif_abapgit_definitions=>ty_sha1
+                eo_branch_list TYPE REF TO zcl_abapgit_git_branch_list
       RAISING   zcx_abapgit_exception.
 
     CLASS-METHODS parse
@@ -98,18 +100,16 @@ CLASS zcl_abapgit_git_transport IMPLEMENTATION.
 
   METHOD find_branch.
 
-    DATA: lo_branch_list TYPE REF TO zcl_abapgit_git_branch_list.
-
     branch_list(
       EXPORTING
         iv_url          = iv_url
         iv_service      = iv_service
       IMPORTING
         eo_client       = eo_client
-        eo_branch_list  = lo_branch_list ).
+        eo_branch_list  = eo_branch_list ).
 
     IF ev_branch IS SUPPLIED.
-      ev_branch = lo_branch_list->find_by_name( iv_branch_name )-sha1.
+      ev_branch = eo_branch_list->find_by_name( iv_branch_name )-sha1.
     ENDIF.
 
   ENDMETHOD.                    "find_branch
@@ -229,7 +229,9 @@ CLASS zcl_abapgit_git_transport IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_branch> LIKE LINE OF lt_branches.
 
 
-    CLEAR et_objects.
+    CLEAR: et_objects,
+           ev_branch,
+           eo_branch_list.
 
     find_branch(
       EXPORTING
@@ -238,6 +240,7 @@ CLASS zcl_abapgit_git_transport IMPLEMENTATION.
         iv_branch_name = iv_branch_name
       IMPORTING
         eo_client      = lo_client
+        eo_branch_list = eo_branch_list
         ev_branch      = ev_branch ).
 
     IF it_branches IS INITIAL.


### PR DESCRIPTION
Before this commit is applied BRANCH_LIST is called twice while
refreshing an online repo. This leads to two identical HTTP calls.
After this commit is applied BRANCH_LIST is only called once and
therefore only one HTTP request is sent.

#1679