### PR TITLE
LIST_SUBPACKAGES return duplicate package names in deep hierarchies

### DIFF
--- a/src/zcl_abapgit_sap_package.clas.abap
+++ b/src/zcl_abapgit_sap_package.clas.abap
@@ -274,7 +274,7 @@ CLASS ZCL_ABAPGIT_SAP_PACKAGE IMPLEMENTATION.
       WHERE parentcl = mv_package.      "#EC CI_GENBUFF "#EC CI_SUBRC
     lv_children = sy-dbcnt.
 
-    LOOP AT rt_list INTO lv_devclass FROM 1 TO children.
+    LOOP AT rt_list INTO lv_devclass FROM 1 TO lv_children.
       "Get Children of Child
       lt_list = zcl_abapgit_factory=>get_sap_package( lv_devclass )->list_subpackages( ).
       APPEND LINES OF lt_list TO rt_list.

--- a/src/zcl_abapgit_sap_package.clas.abap
+++ b/src/zcl_abapgit_sap_package.clas.abap
@@ -267,12 +267,12 @@ CLASS ZCL_ABAPGIT_SAP_PACKAGE IMPLEMENTATION.
 
     DATA: lt_list     LIKE rt_list,
           lv_devclass LIKE LINE OF rt_list.
-
+    DATA: lv_children TYPE i.
 
     SELECT devclass FROM tdevc
       INTO TABLE rt_list
       WHERE parentcl = mv_package.      "#EC CI_GENBUFF "#EC CI_SUBRC
-    children = sy-dbcnt.
+    lv_children = sy-dbcnt.
 
     LOOP AT rt_list INTO lv_devclass FROM 1 TO children.
       "Get Children of Child

--- a/src/zcl_abapgit_sap_package.clas.abap
+++ b/src/zcl_abapgit_sap_package.clas.abap
@@ -269,11 +269,13 @@ CLASS ZCL_ABAPGIT_SAP_PACKAGE IMPLEMENTATION.
           lv_devclass LIKE LINE OF rt_list.
 
 
-    SELECT devclass INTO TABLE rt_list
-      FROM tdevc WHERE parentcl = mv_package. "#EC CI_GENBUFF "#EC CI_SUBRC
+    SELECT devclass FROM tdevc
+      INTO TABLE rt_list
+      WHERE parentcl = mv_package.      "#EC CI_GENBUFF "#EC CI_SUBRC
+    children = sy-dbcnt.
 
-* note the recursion, since packages are added to the list
-    LOOP AT rt_list INTO lv_devclass.
+    LOOP AT rt_list INTO lv_devclass FROM 1 TO children.
+      "Get Children of Child
       lt_list = zcl_abapgit_factory=>get_sap_package( lv_devclass )->list_subpackages( ).
       APPEND LINES OF lt_list TO rt_list.
     ENDLOOP.


### PR DESCRIPTION
ZIF_ABAPGIT_SAP_PACKAGE~LIST_SUBPACKAGES in ZCL_ABAPGIT_SAP_PACKAGE returned duplicate entries for subpackages with more than 1 hierarchy level, because the recursion selected all subpackages of a given package and added them to the list and then parsed the added subpackages again, which would in turn again select the subpackages of the subpackage.