### PR TITLE
Refactor: SET PARAMETER EUK #1690

### DIFF
--- a/src/objects/zcl_abapgit_object_sfbf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfbf.clas.abap
@@ -133,10 +133,8 @@ CLASS ZCL_ABAPGIT_OBJECT_SFBF IMPLEMENTATION.
         im_sfw_bfc_tc = ls_sfw_bfc_tc ).
     lo_bf->set_parent_bfs( lt_parent_bfs ).
 
-* magic, see function module RS_CORR_INSERT, FORM get_current_devclass
-    SET PARAMETER ID 'EUK' FIELD iv_package.
+    set_default_package( iv_package ).
     lo_bf->save_all( ).
-    SET PARAMETER ID 'EUK' FIELD ''.
 
     zcl_abapgit_objects_activation=>add_item( ms_item ).
 

--- a/src/objects/zcl_abapgit_object_sfbs.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfbs.clas.abap
@@ -119,10 +119,8 @@ CLASS ZCL_ABAPGIT_OBJECT_SFBS IMPLEMENTATION.
     lo_bfs->set_assigned_bfs( lt_nested_bfs ).
     lo_bfs->set_nested_parent( lt_parent_bfs ).
 
-* magic, see function module RS_CORR_INSERT, FORM get_current_devclass
-    SET PARAMETER ID 'EUK' FIELD iv_package.
+    set_default_package( iv_package ).
     lo_bfs->save_all( ).
-    SET PARAMETER ID 'EUK' FIELD ''.
 
     zcl_abapgit_objects_activation=>add_item( ms_item ).
 

--- a/src/objects/zcl_abapgit_object_sfsw.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfsw.clas.abap
@@ -109,13 +109,12 @@ CLASS ZCL_ABAPGIT_OBJECT_SFSW IMPLEMENTATION.
     lo_switch->set_parent_bf( lt_parent_bf ).
     lo_switch->set_conflicts( lt_conflicts ).
 
-* magic, see function module RS_CORR_INSERT, FORM get_current_devclass
-    SET PARAMETER ID 'EUK' FIELD iv_package.
+    set_default_package( iv_package ).
     lo_switch->save_all(
       EXCEPTIONS
         not_saved = 1
         OTHERS    = 2 ).
-    SET PARAMETER ID 'EUK' FIELD ''.
+
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( 'error in CL_SFW_SW->SAVE_ALL' ).
     ENDIF.

--- a/src/objects/zcl_abapgit_object_ssst.clas.abap
+++ b/src/objects/zcl_abapgit_object_ssst.clas.abap
@@ -104,7 +104,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SSST IMPLEMENTATION.
       EXCEPTIONS
         OTHERS              = 0.
 
-    SET PARAMETER ID 'EUK' FIELD iv_package.
+    set_default_package( iv_package ).
     ASSIGN ('(SAPLSTXBS)MASTER_LANGUAGE') TO <lv_spras>.
     IF sy-subrc = 0.
       <lv_spras> = ls_header-masterlang.


### PR DESCRIPTION
After this commit is applied all calls of "SET PARAMETER 'EUK'"
are replaced with the call of objects_super->set_default_package.
The method uses the ABAP memory which is in this case more reliable.

#1690