### PR TITLE
CHAR: fix copy and paste error #1694

### DIFF
--- a/src/objects/zcl_abapgit_object_char.clas.abap
+++ b/src/objects/zcl_abapgit_object_char.clas.abap
@@ -132,7 +132,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CHAR IMPLEMENTATION.
           lv_text        TYPE string.
 
     FIELD-SYMBOLS: <ls_value>  LIKE LINE OF ls_char-cls_attr_value,
-                   <ls_valuet> LIKE LINE OF ls_char-cls_attr_value.
+                   <ls_valuet> LIKE LINE OF ls_char-cls_attr_valuet.
 
 
     io_xml->read( EXPORTING iv_name = 'CHAR'
@@ -179,8 +179,8 @@ CLASS ZCL_ABAPGIT_OBJECT_CHAR IMPLEMENTATION.
         LOOP AT ls_char-cls_attr_value ASSIGNING <ls_value>.
           <ls_value>-activation_state = 'I'.
         ENDLOOP.
-        LOOP AT ls_char-cls_attr_value ASSIGNING <ls_valuet>.
-          <ls_value>-activation_state = 'I'.
+        LOOP AT ls_char-cls_attr_valuet ASSIGNING <ls_valuet>.
+          <ls_valuet>-activation_state = 'I'.
         ENDLOOP.
 
         lo_char->if_cls_attribute~set_values(


### PR DESCRIPTION
Before this commit is applied we get DBSQL_DUPLICATE_KEY_ERROR
dumps while 'reset local'.