### PR TITLE
Parse commit message in branch overview, fix for PGP signature #1387

### DIFF
--- a/src/zcl_abapgit_branch_overview.clas.abap
+++ b/src/zcl_abapgit_branch_overview.clas.abap
@@ -45,69 +45,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_branch_overview IMPLEMENTATION.
-
-
-  METHOD zif_abapgit_branch_overview~compress.
-
-    DEFINE _compress.
-      IF lines( lt_temp ) >= 10.
-        READ TABLE lt_temp ASSIGNING <ls_temp> INDEX 1.
-        ASSERT sy-subrc = 0.
-        APPEND INITIAL LINE TO rt_commits ASSIGNING <ls_new>.
-        <ls_new>-time       = <ls_temp>-time.
-        <ls_new>-message    = |Compressed, { lines( lt_temp ) } commits|.
-        <ls_new>-branch     = lv_name.
-        <ls_new>-compressed = abap_true.
-      ELSE.
-        APPEND LINES OF lt_temp TO rt_commits.
-      ENDIF.
-    END-OF-DEFINITION.
-
-    DATA: lv_previous TYPE i,
-          lv_index    TYPE i,
-          lv_name     TYPE string,
-          lt_temp     LIKE it_commits.
-
-    FIELD-SYMBOLS: <ls_branch> LIKE LINE OF mt_branches,
-                   <ls_new>    LIKE LINE OF rt_commits,
-                   <ls_temp>   LIKE LINE OF lt_temp,
-                   <ls_commit> LIKE LINE OF it_commits.
-
-
-    LOOP AT mt_branches ASSIGNING <ls_branch>.
-
-      CLEAR lt_temp.
-      lv_name = <ls_branch>-name+11.
-
-      LOOP AT it_commits ASSIGNING <ls_commit>
-          WHERE branch = lv_name.
-        lv_index = sy-tabix.
-
-        IF NOT <ls_commit>-merge IS INITIAL
-            OR NOT <ls_commit>-create IS INITIAL.
-* always show these vertices
-          lv_previous = -1.
-        ENDIF.
-
-        IF lv_previous + 1 <> sy-tabix.
-          _compress.
-          CLEAR lt_temp.
-        ENDIF.
-
-        lv_previous = lv_index.
-
-        APPEND <ls_commit> TO lt_temp.
-
-      ENDLOOP.
-
-      _compress.
-
-    ENDLOOP.
-
-    SORT rt_commits BY time ASCENDING.
-
-  ENDMETHOD.
+CLASS ZCL_ABAPGIT_BRANCH_OVERVIEW IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -258,16 +196,6 @@ CLASS zcl_abapgit_branch_overview IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_abapgit_branch_overview~get_branches.
-    rt_branches = mt_branches.
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_branch_overview~get_commits.
-    rt_commits = mt_commits.
-  ENDMETHOD.
-
-
   METHOD get_git_objects.
 
     DATA: lo_branch_list       TYPE REF TO zcl_abapgit_git_branch_list,
@@ -319,13 +247,6 @@ CLASS zcl_abapgit_branch_overview IMPLEMENTATION.
         et_objects     = rt_objects ).
 
     DELETE rt_objects WHERE type = zif_abapgit_definitions=>gc_type-blob.
-
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_branch_overview~get_tags.
-
-    rt_tags = mt_tags.
 
   ENDMETHOD.
 
@@ -396,4 +317,82 @@ CLASS zcl_abapgit_branch_overview IMPLEMENTATION.
 
   ENDMETHOD.
 
+
+  METHOD zif_abapgit_branch_overview~compress.
+
+    DEFINE _compress.
+      IF lines( lt_temp ) >= 10.
+        READ TABLE lt_temp ASSIGNING <ls_temp> INDEX 1.
+        ASSERT sy-subrc = 0.
+        APPEND INITIAL LINE TO rt_commits ASSIGNING <ls_new>.
+        <ls_new>-time       = <ls_temp>-time.
+        <ls_new>-message    = |Compressed, { lines( lt_temp ) } commits|.
+        <ls_new>-branch     = lv_name.
+        <ls_new>-compressed = abap_true.
+      ELSE.
+        APPEND LINES OF lt_temp TO rt_commits.
+      ENDIF.
+    END-OF-DEFINITION.
+
+    DATA: lv_previous TYPE i,
+          lv_index    TYPE i,
+          lv_name     TYPE string,
+          lt_temp     LIKE it_commits.
+
+    FIELD-SYMBOLS: <ls_branch> LIKE LINE OF mt_branches,
+                   <ls_new>    LIKE LINE OF rt_commits,
+                   <ls_temp>   LIKE LINE OF lt_temp,
+                   <ls_commit> LIKE LINE OF it_commits.
+
+
+    LOOP AT mt_branches ASSIGNING <ls_branch>.
+
+      CLEAR lt_temp.
+      lv_name = <ls_branch>-name+11.
+
+      LOOP AT it_commits ASSIGNING <ls_commit>
+          WHERE branch = lv_name.
+        lv_index = sy-tabix.
+
+        IF NOT <ls_commit>-merge IS INITIAL
+            OR NOT <ls_commit>-create IS INITIAL.
+* always show these vertices
+          lv_previous = -1.
+        ENDIF.
+
+        IF lv_previous + 1 <> sy-tabix.
+          _compress.
+          CLEAR lt_temp.
+        ENDIF.
+
+        lv_previous = lv_index.
+
+        APPEND <ls_commit> TO lt_temp.
+
+      ENDLOOP.
+
+      _compress.
+
+    ENDLOOP.
+
+    SORT rt_commits BY time ASCENDING.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_branch_overview~get_branches.
+    rt_branches = mt_branches.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_branch_overview~get_commits.
+    rt_commits = mt_commits.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_branch_overview~get_tags.
+
+    rt_tags = mt_tags.
+
+  ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_abapgit_branch_overview.clas.abap
+++ b/src/zcl_abapgit_branch_overview.clas.abap
@@ -288,7 +288,7 @@ CLASS ZCL_ABAPGIT_BRANCH_OVERVIEW IMPLEMENTATION.
   METHOD parse_commits.
 
     DATA: ls_commit LIKE LINE OF mt_commits,
-          lv_trash  TYPE string ##NEEDED,
+          lt_body   TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
           ls_raw    TYPE zcl_abapgit_git_pack=>ty_commit.
 
     FIELD-SYMBOLS: <ls_object> LIKE LINE OF it_objects.
@@ -302,7 +302,15 @@ CLASS ZCL_ABAPGIT_BRANCH_OVERVIEW IMPLEMENTATION.
       ls_commit-parent1 = ls_raw-parent.
       ls_commit-parent2 = ls_raw-parent2.
 
-      SPLIT ls_raw-body AT zif_abapgit_definitions=>gc_newline INTO ls_commit-message lv_trash.
+      SPLIT ls_raw-body AT zif_abapgit_definitions=>gc_newline INTO TABLE lt_body.
+
+      READ TABLE lt_body WITH KEY table_line = ' -----END PGP SIGNATURE-----' TRANSPORTING NO FIELDS.
+      IF sy-subrc = 0.
+        DELETE lt_body TO sy-tabix.
+        DELETE lt_body TO 2.
+      ENDIF.
+
+      READ TABLE lt_body INDEX 1 INTO ls_commit-message.
 
 * unix time stamps are in same time zone, so ignore the zone,
       FIND REGEX zif_abapgit_definitions=>gc_author_regex IN ls_raw-author

--- a/src/zcl_abapgit_branch_overview.clas.abap
+++ b/src/zcl_abapgit_branch_overview.clas.abap
@@ -2,45 +2,59 @@ CLASS zcl_abapgit_branch_overview DEFINITION
   PUBLIC
   FINAL
   CREATE PRIVATE
-  GLOBAL FRIENDS zcl_abapgit_factory .
 
+  GLOBAL FRIENDS zcl_abapgit_factory .
 
   PUBLIC SECTION.
 
-    INTERFACES zif_abapgit_branch_overview.
+    INTERFACES zif_abapgit_branch_overview .
 
-    METHODS:
-      constructor
-        IMPORTING io_repo TYPE REF TO zcl_abapgit_repo_online
-        RAISING   zcx_abapgit_exception.
-
+    METHODS constructor
+      IMPORTING
+        !io_repo TYPE REF TO zcl_abapgit_repo_online
+      RAISING
+        zcx_abapgit_exception .
   PRIVATE SECTION.
-    METHODS:
-      parse_commits
-        IMPORTING it_objects TYPE zif_abapgit_definitions=>ty_objects_tt
-        RAISING   zcx_abapgit_exception,
-      parse_annotated_tags
-        IMPORTING it_objects TYPE zif_abapgit_definitions=>ty_objects_tt
-        RAISING   zcx_abapgit_exception,
-      determine_branch
-        RAISING zcx_abapgit_exception,
-      determine_merges
-        RAISING zcx_abapgit_exception,
-      fixes
-        RAISING zcx_abapgit_exception,
-      get_git_objects
-        IMPORTING io_repo           TYPE REF TO zcl_abapgit_repo_online
-        RETURNING VALUE(rt_objects) TYPE zif_abapgit_definitions=>ty_objects_tt
-        RAISING   zcx_abapgit_exception,
-      determine_tags
-        RAISING zcx_abapgit_exception.
 
-    DATA:
-      mo_repo     TYPE REF TO zcl_abapgit_repo_online,
-      mt_branches TYPE zif_abapgit_definitions=>ty_git_branch_list_tt,
-      mt_commits  TYPE TABLE OF zif_abapgit_definitions=>ty_commit,
-      mt_tags     TYPE zif_abapgit_definitions=>ty_git_tag_list_tt.
+    TYPES:
+      ty_commits TYPE TABLE OF zif_abapgit_definitions=>ty_commit WITH DEFAULT KEY .
 
+    DATA mo_repo TYPE REF TO zcl_abapgit_repo_online .
+    DATA mt_branches TYPE zif_abapgit_definitions=>ty_git_branch_list_tt .
+    DATA mt_commits TYPE ty_commits .
+    DATA mt_tags TYPE zif_abapgit_definitions=>ty_git_tag_list_tt .
+
+    CLASS-METHODS parse_commits
+      IMPORTING
+        !it_objects       TYPE zif_abapgit_definitions=>ty_objects_tt
+      RETURNING
+        VALUE(rt_commits) TYPE ty_commits
+      RAISING
+        zcx_abapgit_exception .
+    METHODS parse_annotated_tags
+      IMPORTING
+        !it_objects TYPE zif_abapgit_definitions=>ty_objects_tt
+      RAISING
+        zcx_abapgit_exception .
+    METHODS determine_branch
+      RAISING
+        zcx_abapgit_exception .
+    METHODS determine_merges
+      RAISING
+        zcx_abapgit_exception .
+    METHODS fixes
+      RAISING
+        zcx_abapgit_exception .
+    METHODS get_git_objects
+      IMPORTING
+        !io_repo          TYPE REF TO zcl_abapgit_repo_online
+      RETURNING
+        VALUE(rt_objects) TYPE zif_abapgit_definitions=>ty_objects_tt
+      RAISING
+        zcx_abapgit_exception .
+    METHODS determine_tags
+      RAISING
+        zcx_abapgit_exception .
 ENDCLASS.
 
 
@@ -55,10 +69,9 @@ CLASS ZCL_ABAPGIT_BRANCH_OVERVIEW IMPLEMENTATION.
     mo_repo = io_repo.
 
     CLEAR mt_branches.
-    CLEAR mt_commits.
 
     lt_objects = get_git_objects( io_repo ).
-    parse_commits( lt_objects ).
+    mt_commits = parse_commits( lt_objects ).
     parse_annotated_tags( lt_objects ).
 
     CLEAR lt_objects.
@@ -319,7 +332,7 @@ CLASS ZCL_ABAPGIT_BRANCH_OVERVIEW IMPLEMENTATION.
         ls_commit-email
         ls_commit-time ##NO_TEXT.
       ASSERT sy-subrc = 0.
-      APPEND ls_commit TO mt_commits.
+      APPEND ls_commit TO rt_commits.
 
     ENDLOOP.
 

--- a/src/zcl_abapgit_branch_overview.clas.testclasses.abap
+++ b/src/zcl_abapgit_branch_overview.clas.testclasses.abap
@@ -1,0 +1,23 @@
+
+CLASS ltcl_test DEFINITION FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS FINAL.
+
+  PRIVATE SECTION.
+    DATA:
+      mo_cut TYPE REF TO zcl_abapgit_branch_overview.
+
+    METHODS: parse_commits FOR TESTING.
+
+ENDCLASS.
+
+
+CLASS ltcl_test IMPLEMENTATION.
+
+  METHOD parse_commits.
+
+* todo
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/zcl_abapgit_branch_overview.clas.testclasses.abap
+++ b/src/zcl_abapgit_branch_overview.clas.testclasses.abap
@@ -1,13 +1,16 @@
 
+CLASS ltcl_test DEFINITION DEFERRED.
+CLASS zcl_abapgit_branch_overview DEFINITION LOCAL FRIENDS ltcl_test.
+
+
 CLASS ltcl_test DEFINITION FOR TESTING
   DURATION SHORT
   RISK LEVEL HARMLESS FINAL.
 
   PRIVATE SECTION.
-    DATA:
-      mo_cut TYPE REF TO zcl_abapgit_branch_overview.
 
-    METHODS: parse_commits FOR TESTING.
+    METHODS:
+      parse_commits FOR TESTING RAISING zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -16,7 +19,38 @@ CLASS ltcl_test IMPLEMENTATION.
 
   METHOD parse_commits.
 
-* todo
+    DATA: lt_objects TYPE zif_abapgit_definitions=>ty_objects_tt,
+          lt_commits TYPE zcl_abapgit_branch_overview=>ty_commits,
+          ls_commit  LIKE LINE OF lt_commits,
+          ls_object  LIKE LINE OF lt_objects.
+
+
+    ls_object-type = zif_abapgit_definitions=>gc_type-commit.
+    ls_object-data = '7472656520396335376238613931336465306539' &&
+      '3735333630633261306330643638363037306162' &&
+      '61343965650A706172656E742036393532346462' &&
+      '3139363263383839366566343364323861616131' &&
+      '396536366533373263653364620A617574686F72' &&
+      '206C6172736870203C6C617273687040686F746D' &&
+      '61696C2E636F6D3E203135333236313133353020' &&
+      '2B303030300A636F6D6D6974746572206C617273' &&
+      '6870203C6C617273687040686F746D61696C2E63' &&
+      '6F6D3E2031353332363131333530202B30303030' &&
+      '0A0A56494557'.
+    APPEND ls_object TO lt_objects.
+
+    lt_commits = zcl_abapgit_branch_overview=>parse_commits( lt_objects ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lines( lt_commits )
+      exp = 1 ).
+
+    READ TABLE lt_commits INTO ls_commit INDEX 1.
+    cl_abap_unit_assert=>assert_subrc( ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = ls_commit-message
+      exp = 'VIEW' ).
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_branch_overview.clas.xml
+++ b/src/zcl_abapgit_branch_overview.clas.xml
@@ -12,6 +12,7 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>


### PR DESCRIPTION
Parse commit message in branch overview, fix for PGP signature #1387 

Split into commits which can be reviewed individually

Tested with https://github.com/abapGit-tests/VIEW