### PR TITLE
Remove superfluous spaces

### DIFF
--- a/src/objects/ecatt/zcl_abapgit_ecatt_script_downl.clas.abap
+++ b/src/objects/ecatt/zcl_abapgit_ecatt_script_downl.clas.abap
@@ -450,7 +450,7 @@ CLASS ZCL_ABAPGIT_ECATT_SCRIPT_DOWNL IMPLEMENTATION.
       me->raise_download_exception(
             textid        = cx_ecatt_apl_util=>download_processing
             previous      = ex_ecatt
-            called_method = 'CL_APL_ECATT_SCRIPT_DOWNLOAD->SET_SCRIPT_TO_TEMPLATE' ) .
+            called_method = 'CL_APL_ECATT_SCRIPT_DOWNLOAD->SET_SCRIPT_TO_TEMPLATE' ).
     ENDIF.
 
     CALL FUNCTION 'SDIXML_DATA_TO_DOM'

--- a/src/objects/ecatt/zcl_abapgit_ecatt_sp_upload.clas.abap
+++ b/src/objects/ecatt/zcl_abapgit_ecatt_sp_upload.clas.abap
@@ -49,7 +49,7 @@ CLASS ZCL_ABAPGIT_ECATT_SP_UPLOAD IMPLEMENTATION.
         li_section = template_over_all->find_from_name_ns( 'START_PROFILE' ).
 
         IF NOT li_section IS INITIAL.
-          CLASS cl_ixml DEFINITION LOAD .
+          CLASS cl_ixml DEFINITION LOAD.
           li_ixml = cl_ixml=>create( ).
           li_dom  = li_ixml->create_document( ).
           li_root ?= li_section->clone( ).
@@ -70,7 +70,7 @@ CLASS ZCL_ABAPGIT_ECATT_SP_UPLOAD IMPLEMENTATION.
               i_sp_xml = lv_start_profile.
 
         ENDIF.
-      CATCH cx_ecatt_apl .
+      CATCH cx_ecatt_apl.
         lv_exception_occurred = 'X'.
     ENDTRY.
 

--- a/src/objects/ecatt/zcl_abapgit_ecatt_val_obj_upl.clas.abap
+++ b/src/objects/ecatt/zcl_abapgit_ecatt_val_obj_upl.clas.abap
@@ -198,7 +198,7 @@ CLASS ZCL_ABAPGIT_ECATT_VAL_OBJ_UPL IMPLEMENTATION.
           illegal_object = 1
           OTHERS         = 2.
       IF sy-subrc <> 0.
-        CLEAR lv_invert_validation .
+        CLEAR lv_invert_validation.
       ENDIF.
     ENDIF.
 

--- a/src/objects/ecatt/zcl_abapgit_ecatt_val_obj_upl.clas.abap
+++ b/src/objects/ecatt/zcl_abapgit_ecatt_val_obj_upl.clas.abap
@@ -168,7 +168,7 @@ CLASS ZCL_ABAPGIT_ECATT_VAL_OBJ_UPL IMPLEMENTATION.
           illegal_object = 1
           OTHERS         = 2.
       IF sy-subrc <> 0.
-        CLEAR lv_invert_validation .
+        CLEAR lv_invert_validation.
       ENDIF.
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -547,7 +547,7 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
 
   METHOD is_function_group_locked.
 
-    DATA: lv_object TYPE eqegraarg .
+    DATA: lv_object TYPE eqegraarg.
 
     lv_object = |FG{ ms_item-obj_name }|.
     OVERLAY lv_object WITH '                                          '.

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -112,7 +112,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
 
 
   METHOD are_exceptions_class_based.
@@ -400,7 +400,7 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
       lo_xml->read( EXPORTING iv_name = 'PROGDIR'
                     CHANGING cg_data = ls_progdir ).
 
-      IF ls_progdir-uccheck IS INITIAL .
+      IF ls_progdir-uccheck IS INITIAL.
         CONTINUE.
       ELSEIF rv_abap_version IS INITIAL.
         rv_abap_version = ls_progdir-uccheck.
@@ -708,6 +708,20 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD update_func_group_short_text.
+
+    " We update the short text directly.
+    " SE80 does the same in
+    "   Program SAPLSEUF / LSEUFF07
+    "   FORM GROUP_CHANGE
+
+    UPDATE tlibt SET areat = iv_short_text
+                 WHERE spras = sy-langu
+                 AND   area  = iv_group.
+
+  ENDMETHOD.
+
+
   METHOD update_where_used.
 * make extra sure the where-used list is updated after deletion
 * Experienced some problems with the T00 include
@@ -998,18 +1012,4 @@ CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
     ENDIF.
 
   ENDMETHOD.
-
-  METHOD update_func_group_short_text.
-
-    " We update the short text directly.
-    " SE80 does the same in
-    "   Program SAPLSEUF / LSEUFF07
-    "   FORM GROUP_CHANGE
-
-    UPDATE tlibt SET areat = iv_short_text
-                 WHERE spras = sy-langu
-                 AND   area  = iv_group.
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_tran.clas.testclasses.abap
+++ b/src/objects/zcl_abapgit_object_tran.clas.testclasses.abap
@@ -20,7 +20,7 @@ CLASS ltcl_split_parameters DEFINITION FINAL FOR TESTING
 
       then_st_tcode_shd_be
         IMPORTING
-          iv_exp_st_tcode TYPE eusel_tcod ,
+          iv_exp_st_tcode TYPE eusel_tcod,
 
       then_st_skip_1_shd_be
         IMPORTING

--- a/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
@@ -52,7 +52,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_repo_sett IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -308,8 +308,8 @@ CLASS zcl_abapgit_gui_page_repo_sett IMPLEMENTATION.
       ls_settings-block_commit = abap_false.
     ENDIF.
 
-    IF  ls_settings-block_commit = abap_true
-    AND ls_settings-code_inspector_check_variant IS INITIAL.
+    IF ls_settings-block_commit = abap_true
+        AND ls_settings-code_inspector_check_variant IS INITIAL.
       zcx_abapgit_exception=>raise( |If block commit is active, a check variant has to be maintained.| ).
     ENDIF.
 

--- a/src/xml/zcl_abapgit_xml_output.clas.testclasses.abap
+++ b/src/xml/zcl_abapgit_xml_output.clas.testclasses.abap
@@ -87,7 +87,7 @@ CLASS ltcl_xml_output IMPLEMENTATION.
                        iv_string     = lv_value
                        iv_codepage   = lv_encoding
                        iv_add_bom    = 'X' ).
-      CATCH cx_bcs .
+      CATCH cx_bcs.
     ENDTRY.
 
     lo_conv_in_string = cl_abap_conv_in_ce=>create(

--- a/src/zcl_abapgit_repo_online.clas.testclasses.abap
+++ b/src/zcl_abapgit_repo_online.clas.testclasses.abap
@@ -71,7 +71,7 @@ CLASS ltcl_run_code_inspection DEFINITION FINAL FOR TESTING
       given_mock_code_inspector
         IMPORTING
           iv_package       TYPE devclass
-          iv_check_variant TYPE sci_chkv ,
+          iv_check_variant TYPE sci_chkv,
 
       given_block_commit
         IMPORTING


### PR DESCRIPTION
Eg space before .
`moo = boo .`

Or doulbe space after keyword,
`IF  foo = bar.`

Some files reorganized due to pretty printer/SE80