### PR TITLE
Added Buffering to ZCL_ABAPGIT_FOLDER_LOGIC

### DIFF
--- a/src/zcl_abapgit_file_status.clas.abap
+++ b/src/zcl_abapgit_file_status.clas.abap
@@ -298,7 +298,7 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
     " Try to get a unique package name for DEVC by using the path
     IF lv_type = 'DEVC'.
       ASSERT lv_name = 'PACKAGE'.
-      lv_name = zcl_abapgit_folder_logic=>path_to_package(
+      lv_name = zcl_abapgit_folder_logic=>get_instance( )->path_to_package(
         iv_top                  = iv_devclass
         io_dot                  = io_dot
         iv_create_if_not_exists = abap_false
@@ -320,6 +320,7 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
           ls_file     TYPE zif_abapgit_definitions=>ty_file_signature,
           lt_res_sort LIKE it_results,
           lt_item_idx LIKE it_results.
+    DATA: lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
 
     FIELD-SYMBOLS: <ls_res1> LIKE LINE OF it_results,
                    <ls_res2> LIKE LINE OF it_results.
@@ -360,9 +361,10 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
     ENDLOOP.
 
     " Check that objects are created in package corresponding to folder
+    lo_folder_logic = zcl_abapgit_folder_logic=>get_instance( ).
     LOOP AT it_results ASSIGNING <ls_res1>
         WHERE NOT package IS INITIAL AND NOT path IS INITIAL.
-      lv_path = zcl_abapgit_folder_logic=>package_to_path(
+      lv_path = lo_folder_logic->package_to_path(
         iv_top     = iv_top
         io_dot     = io_dot
         iv_package = <ls_res1>-package ).

--- a/src/zcl_abapgit_folder_logic.clas.abap
+++ b/src/zcl_abapgit_folder_logic.clas.abap
@@ -4,7 +4,7 @@ CLASS zcl_abapgit_folder_logic DEFINITION
 
   PUBLIC SECTION.
 
-    CLASS-METHODS package_to_path
+    METHODS package_to_path
       IMPORTING
         !iv_top        TYPE devclass
         !io_dot        TYPE REF TO zcl_abapgit_dot_abapgit
@@ -13,7 +13,7 @@ CLASS zcl_abapgit_folder_logic DEFINITION
         VALUE(rv_path) TYPE string
       RAISING
         zcx_abapgit_exception .
-    CLASS-METHODS path_to_package
+    METHODS path_to_package
       IMPORTING
         !iv_top                  TYPE devclass
         !io_dot                  TYPE REF TO zcl_abapgit_dot_abapgit
@@ -23,12 +23,52 @@ CLASS zcl_abapgit_folder_logic DEFINITION
         VALUE(rv_package)        TYPE devclass
       RAISING
         zcx_abapgit_exception .
+    CLASS-METHODS get_instance
+      RETURNING
+        VALUE(ro_instance) TYPE REF TO zcl_abapgit_folder_logic .
+  PROTECTED SECTION.
+    METHODS get_parent
+      IMPORTING
+        !iv_package     TYPE devclass
+      RETURNING
+        VALUE(r_parent) TYPE devclass.
+  PRIVATE SECTION.
+    TYPES:
+      BEGIN OF ty_devclass_info,
+        devclass  TYPE devclass,
+        namespace TYPE namespace,
+        parentcl  TYPE parentcl,
+      END OF ty_devclass_info .
+    TYPES:
+      ty_devclass_info_tt TYPE SORTED TABLE OF ty_devclass_info
+        WITH UNIQUE KEY devclass .
+    DATA mt_parent TYPE ty_devclass_info_tt .
 ENDCLASS.
 
 
 
 CLASS ZCL_ABAPGIT_FOLDER_LOGIC IMPLEMENTATION.
 
+
+  METHOD get_instance.
+    CREATE OBJECT ro_instance.
+  ENDMETHOD.
+
+  METHOD get_parent.
+    DATA: st_parent LIKE LINE OF mt_parent.
+
+    "Determine Parent Package
+    READ TABLE mt_parent INTO st_parent
+      WITH TABLE KEY devclass = iv_package.
+    IF sy-subrc <> 0.
+      r_parent = zcl_abapgit_factory=>get_sap_package( iv_package )->read_parent( ).
+      st_parent-devclass = iv_package.
+      st_parent-parentcl = r_parent.
+      INSERT st_parent INTO TABLE mt_parent.
+    ELSE.
+      r_parentcl = st_parent-parentcl.
+    ENDIF.
+  ENDMETHOD.
 
   METHOD package_to_path.
 

--- a/src/zcl_abapgit_folder_logic.clas.abap
+++ b/src/zcl_abapgit_folder_logic.clas.abap
@@ -66,7 +66,7 @@ CLASS ZCL_ABAPGIT_FOLDER_LOGIC IMPLEMENTATION.
       st_parent-parentcl = r_parent.
       INSERT st_parent INTO TABLE mt_parent.
     ELSE.
-      r_parentcl = st_parent-parentcl.
+      r_parent = st_parent-parentcl.
     ENDIF.
   ENDMETHOD.
 
@@ -81,7 +81,7 @@ CLASS ZCL_ABAPGIT_FOLDER_LOGIC IMPLEMENTATION.
     IF iv_top = iv_package.
       rv_path = io_dot->get_starting_folder( ).
     ELSE.
-      lv_parentcl = zcl_abapgit_factory=>get_sap_package( iv_package )->read_parent( ).
+      lv_parentcl = get_parent( iv_package ).
 
       IF lv_parentcl IS INITIAL.
         zcx_abapgit_exception=>raise( |error, expected parent package, { iv_package }| ).

--- a/src/zcl_abapgit_folder_logic.clas.testclasses.abap
+++ b/src/zcl_abapgit_folder_logic.clas.testclasses.abap
@@ -25,12 +25,12 @@ CLASS ltcl_folder_logic_helper IMPLEMENTATION.
     lo_dot->set_starting_folder( iv_starting ).
     lo_dot->set_folder_logic( iv_logic ).
 
-    lv_package = zcl_abapgit_folder_logic=>path_to_package(
+    lv_package = zcl_abapgit_folder_logic=>get_instance( )->path_to_package(
       iv_top  = iv_top
       io_dot  = lo_dot
       iv_path = iv_path ).
 
-    lv_path = zcl_abapgit_folder_logic=>package_to_path(
+    lv_path = zcl_abapgit_folder_logic=>get_instance( )->package_to_path(
       iv_top     = iv_top
       io_dot     = lo_dot
       iv_package = iv_package ).

--- a/src/zcl_abapgit_objects.clas.abap
+++ b/src/zcl_abapgit_objects.clas.abap
@@ -474,6 +474,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
           lo_progress TYPE REF TO zcl_abapgit_progress,
           lv_path     TYPE string,
           lt_items    TYPE zif_abapgit_definitions=>ty_items_tt.
+    DATA: lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
 
     FIELD-SYMBOLS: <ls_result> TYPE zif_abapgit_definitions=>ty_result,
                    <ls_deser>  LIKE LINE OF lt_late.
@@ -507,6 +508,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
     check_objects_locked( iv_language = io_repo->get_dot_abapgit( )->get_master_language( )
                           it_items    = lt_items ).
 
+    lo_folder_logic = zcl_abapgit_folder_logic=>get_instance( ).
     LOOP AT lt_results ASSIGNING <ls_result>.
       lo_progress->show( iv_current = sy-tabix
                          iv_text    = |Deserialize { <ls_result>-obj_name }| ) ##NO_TEXT.
@@ -515,7 +517,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
       ls_item-obj_type = <ls_result>-obj_type.
       ls_item-obj_name = <ls_result>-obj_name.
 
-      lv_package = zcl_abapgit_folder_logic=>path_to_package(
+      lv_package = lo_folder_logic->path_to_package(
         iv_top  = io_repo->get_package( )
         io_dot  = io_repo->get_dot_abapgit( )
         iv_path = <ls_result>-path ).
@@ -994,13 +996,14 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
                                   WITH UNIQUE KEY obj_type obj_name devclass,
           ls_overwrite       LIKE LINE OF rt_overwrite,
           ls_tadir           TYPE tadir.
+    DATA: lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
 
     FIELD-SYMBOLS: <ls_result> LIKE LINE OF it_results.
 
-
+    lo_folder_logic = zcl_abapgit_folder_logic=>get_instance( ).
     LOOP AT it_results ASSIGNING <ls_result>.
 
-      lv_package = zcl_abapgit_folder_logic=>path_to_package(
+      lv_package = lo_folder_logic->path_to_package(
         iv_top  = io_repo->get_package( )
         io_dot  = io_repo->get_dot_abapgit( )
         iv_path = <ls_result>-path ).

--- a/src/zcl_abapgit_tadir.clas.abap
+++ b/src/zcl_abapgit_tadir.clas.abap
@@ -29,7 +29,6 @@ CLASS zcl_abapgit_tadir DEFINITION
         !iv_ignore_subpackages TYPE abap_bool DEFAULT abap_false
         !iv_only_local_objects TYPE abap_bool
         !io_log                TYPE REF TO zcl_abapgit_log OPTIONAL
-        !io_folder_logic       TYPE REF TO zcl_abapgit_folder_logic OPTIONAL
       RETURNING
         VALUE(rt_tadir)        TYPE zif_abapgit_definitions=>ty_tadir_tt
       RAISING
@@ -101,7 +100,6 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
 
     IF NOT io_dot IS INITIAL.
       "Reuse given Folder Logic Instance
-      lo_folder_logic = io_folder_logic.
       IF lo_folder_logic IS NOT BOUND.
         "Get Folder Logic Instance
         lo_folder_logic = zcl_abapgit_folder_logic=>get_instance( ).

--- a/src/zcl_abapgit_tadir.clas.abap
+++ b/src/zcl_abapgit_tadir.clas.abap
@@ -29,6 +29,7 @@ CLASS zcl_abapgit_tadir DEFINITION
         !iv_ignore_subpackages TYPE abap_bool DEFAULT abap_false
         !iv_only_local_objects TYPE abap_bool
         !io_log                TYPE REF TO zcl_abapgit_log OPTIONAL
+        !io_folder_logic       TYPE REF TO zcl_abapgit_folder_logic OPTIONAL
       RETURNING
         VALUE(rt_tadir)        TYPE zif_abapgit_definitions=>ty_tadir_tt
       RAISING
@@ -50,6 +51,7 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
           lt_srcsystem    TYPE RANGE OF tadir-srcsystem,
           ls_srcsystem    LIKE LINE OF lt_srcsystem,
           ls_exclude      LIKE LINE OF lt_excludes.
+    DATA: lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
 
     FIELD-SYMBOLS: <ls_tdevc> LIKE LINE OF lt_tdevc,
                    <ls_tadir> LIKE LINE OF rt_tadir.
@@ -98,10 +100,18 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
     ENDIF.
 
     IF NOT io_dot IS INITIAL.
-      lv_path = zcl_abapgit_folder_logic=>package_to_path(
+      "Reuse given Folder Logic Instance
+      lo_folder_logic = io_folder_logic.
+      IF lo_folder_logic IS NOT BOUND.
+        "Get Folder Logic Instance
+        lo_folder_logic = zcl_abapgit_folder_logic=>get_instance( ).
+      ENDIF.
+
+      lv_path = lo_folder_logic->package_to_path(
         iv_top     = iv_top
         io_dot     = io_dot
-        iv_package = iv_package ).
+        iv_package = iv_package
+        io_folder_logic = lo_folder_logic ). "Hand down existing folder logic instance
     ENDIF.
 
     LOOP AT rt_tadir ASSIGNING <ls_tadir>.

--- a/src/zcl_abapgit_tadir.clas.abap
+++ b/src/zcl_abapgit_tadir.clas.abap
@@ -29,6 +29,7 @@ CLASS zcl_abapgit_tadir DEFINITION
         !iv_ignore_subpackages TYPE abap_bool DEFAULT abap_false
         !iv_only_local_objects TYPE abap_bool
         !io_log                TYPE REF TO zcl_abapgit_log OPTIONAL
+        !io_folder_logic       TYPE REF TO zcl_abapgit_folder_logic OPTIONAL
       RETURNING
         VALUE(rt_tadir)        TYPE zif_abapgit_definitions=>ty_tadir_tt
       RAISING
@@ -100,6 +101,7 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
 
     IF NOT io_dot IS INITIAL.
       "Reuse given Folder Logic Instance
+      lo_folder_logic = io_folder_logic.
       IF lo_folder_logic IS NOT BOUND.
         "Get Folder Logic Instance
         lo_folder_logic = zcl_abapgit_folder_logic=>get_instance( ).
@@ -133,7 +135,8 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
                         iv_only_local_objects = iv_only_local_objects
                         iv_top                = iv_top
                         io_dot                = io_dot
-                        io_log                = io_log ).
+                        io_log                = io_log
+                        io_folder_logic       = lo_folder_logic ). "Hand down existing folder logic instance
       APPEND LINES OF lt_tadir TO rt_tadir.
     ENDLOOP.
 

--- a/src/zcl_abapgit_tadir.clas.abap
+++ b/src/zcl_abapgit_tadir.clas.abap
@@ -110,8 +110,7 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
       lv_path = lo_folder_logic->package_to_path(
         iv_top     = iv_top
         io_dot     = io_dot
-        iv_package = iv_package
-        io_folder_logic = lo_folder_logic ). "Hand down existing folder logic instance
+        iv_package = iv_package ).
     ENDIF.
 
     LOOP AT rt_tadir ASSIGNING <ls_tadir>.


### PR DESCRIPTION
- Converted ZCL_ABAPGIT_FOLDER_LOGIC=>PACKAGE_TO_PATH and ZCL_ABAPGIT_FOLDER_LOGIC=>PATH_TO_PACKAGE to instance methods, so they can work with buffered data when constructiing path information. This gives a performance advantage in repos with a depp tree structure and multiple leaf packages
- Adapted all calling code to use an instance of ZCL_ABAPGIT_FOLDER_LOGIC instead of the previously available static methods
- Where applicaple PACKAGE_TO_PATH and PATH_TO_PACKAGE were called in an instance of ZCL_ABAPGIT_FOLDER_LOGIC, which was instanced outside of a processing loop and thus profited from the introduced buffering