### PR TITLE
Optimized ZCL_ABAPGIT_TADIR=>BUILD for better performance

### DIFF
--- a/src/zcl_abapgit_tadir.clas.abap
+++ b/src/zcl_abapgit_tadir.clas.abap
@@ -64,7 +64,7 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
     IF iv_ignore_subpackages = abap_false.
       lt_packages = zcl_abapgit_factory=>get_sap_package( iv_package )->list_subpackages( ).
     ENDIF.
-    INSERT iv_package INTO lt_packages INDEX 1.    
+    INSERT iv_package INTO lt_packages INDEX 1.
 
     ls_exclude-sign = 'I'.
     ls_exclude-option = 'EQ'.

--- a/src/zcl_abapgit_tadir.clas.abap
+++ b/src/zcl_abapgit_tadir.clas.abap
@@ -51,9 +51,20 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
           ls_srcsystem    LIKE LINE OF lt_srcsystem,
           ls_exclude      LIKE LINE OF lt_excludes.
 
+    DATA: last_package TYPE devclass VALUE cl_abap_char_utilities=>horizontal_tab.
+    DATA: lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
+
     FIELD-SYMBOLS: <ls_tdevc> LIKE LINE OF lt_tdevc,
                    <ls_tadir> LIKE LINE OF rt_tadir.
 
+    "Determine Packages to Read
+    DATA: lt_packages TYPE zif_abapgit_sap_package=>ty_devclass_tt.
+    IF iv_ignore_subpackages = abap_true.
+      INSERT iv_package INTO TABLE lt_packages.
+    ELSE.
+      lt_packages = zcl_abapgit_factory=>get_sap_package( iv_package )->list_subpackages( abap_true ).
+      INSERT iv_package INTO lt_packages INDEX 1.
+    ENDIF.
 
     ls_exclude-sign = 'I'.
     ls_exclude-option = 'EQ'.
@@ -74,37 +85,57 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
       APPEND ls_srcsystem TO lt_srcsystem.
     ENDIF.
 
-    SELECT * FROM tadir
-      INTO CORRESPONDING FIELDS OF TABLE rt_tadir
-      WHERE devclass = iv_package
-      AND pgmid = 'R3TR'
-      AND object NOT IN lt_excludes
-      AND delflag = abap_false
-      AND srcsystem IN lt_srcsystem
-      ORDER BY PRIMARY KEY.               "#EC CI_GENBUFF "#EC CI_SUBRC
+    IF lt_packages IS NOT INITIAL.
+      SELECT * FROM tadir
+        INTO CORRESPONDING FIELDS OF TABLE rt_tadir
+        FOR ALL ENTRIES IN lt_packages
+        WHERE devclass = lt_packages-table_line
+        AND pgmid = 'R3TR'
+        AND object NOT IN lt_excludes
+        AND delflag = abap_false
+        AND srcsystem IN lt_srcsystem
+        ORDER BY PRIMARY KEY.    "#EC CI_GENBUFF "#EC CI_SUBRC
+    ENDIF.
+
+    SORT rt_tadir BY devclass pgmid object obj_name.
 
     CREATE OBJECT lo_skip_objects.
     rt_tadir = lo_skip_objects->skip_sadl_generated_objects(
       it_tadir = rt_tadir
       io_log   = io_log ).
 
-    " Local packages are not in TADIR, only in TDEVC, act as if they were
-    IF iv_package CP '$*'. " OR iv_package CP 'T*' ).
-      APPEND INITIAL LINE TO rt_tadir ASSIGNING <ls_tadir>.
-      <ls_tadir>-pgmid    = 'R3TR'.
-      <ls_tadir>-object   = 'DEVC'.
-      <ls_tadir>-obj_name = iv_package.
-      <ls_tadir>-devclass = iv_package.
-    ENDIF.
+    LOOP AT lt_packages ASSIGNING FIELD-SYMBOL(<package>).
+      " Local packages are not in TADIR, only in TDEVC, act as if they were
+      IF <package> CP '$*'. " OR <package> CP 'T*' ).
+        APPEND INITIAL LINE TO rt_tadir ASSIGNING <ls_tadir>.
+        <ls_tadir>-pgmid    = 'R3TR'.
+        <ls_tadir>-object   = 'DEVC'.
+        <ls_tadir>-obj_name = <package>.
+        <ls_tadir>-devclass = <package>.
+      ENDIF.
+    ENDLOOP.
 
-    IF NOT io_dot IS INITIAL.
-      lv_path = zcl_abapgit_folder_logic=>package_to_path(
-        iv_top     = iv_top
-        io_dot     = io_dot
-        iv_package = iv_package ).
-    ENDIF.
-
+    lo_folder_logic = io_folder_logic.
     LOOP AT rt_tadir ASSIGNING <ls_tadir>.
+
+      IF last_package <> <ls_tadir>-devclass.
+        "Change in Package
+        last_package = <ls_tadir>-devclass.
+
+        IF NOT io_dot IS INITIAL.
+          "Reuse given Folder Logic Instance
+          IF lo_folder_logic IS NOT BOUND.
+            "Get Folder Logic Instance
+            lo_folder_logic = zcl_abapgit_folder_logic=>get_instance( ).
+          ENDIF.
+
+          lv_path = lo_folder_logic->package_to_path(
+            iv_top     = iv_top
+            io_dot     = io_dot
+            iv_package = <ls_tadir>-devclass ).
+        ENDIF.
+      ENDIF.
+
       <ls_tadir>-path = lv_path.
 
       CASE <ls_tadir>-object.
@@ -112,22 +143,6 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
 * replace the internal GUID with a hash of the path
           <ls_tadir>-obj_name+15 = zcl_abapgit_object_sicf=>read_sicf_url( <ls_tadir>-obj_name ).
       ENDCASE.
-    ENDLOOP.
-
-* look for subpackages
-    IF iv_ignore_subpackages = abap_false.
-      SELECT * FROM tdevc INTO TABLE lt_tdevc
-        WHERE parentcl = iv_package
-        ORDER BY PRIMARY KEY.             "#EC CI_SUBRC "#EC CI_GENBUFF
-    ENDIF.
-
-    LOOP AT lt_tdevc ASSIGNING <ls_tdevc>.
-      lt_tadir = build( iv_package            = <ls_tdevc>-devclass
-                        iv_only_local_objects = iv_only_local_objects
-                        iv_top                = iv_top
-                        io_dot                = io_dot
-                        io_log                = io_log ).
-      APPEND LINES OF lt_tadir TO rt_tadir.
     ENDLOOP.
 
   ENDMETHOD.                    "build

--- a/src/zcl_abapgit_tadir.clas.abap
+++ b/src/zcl_abapgit_tadir.clas.abap
@@ -115,7 +115,6 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
       ENDIF.
     ENDLOOP.
 
-    lo_folder_logic = io_folder_logic.
     LOOP AT rt_tadir ASSIGNING <ls_tadir>.
 
       IF last_package <> <ls_tadir>-devclass.

--- a/src/zcl_abapgit_tadir.clas.abap
+++ b/src/zcl_abapgit_tadir.clas.abap
@@ -62,7 +62,7 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
     IF iv_ignore_subpackages = abap_true.
       INSERT iv_package INTO TABLE lt_packages.
     ELSE.
-      lt_packages = zcl_abapgit_factory=>get_sap_package( iv_package )->list_subpackages( abap_true ).
+      lt_packages = zcl_abapgit_factory=>get_sap_package( iv_package )->list_subpackages( ).
       INSERT iv_package INTO lt_packages INDEX 1.
     ENDIF.
 

--- a/src/zcl_abapgit_tadir.clas.abap
+++ b/src/zcl_abapgit_tadir.clas.abap
@@ -52,9 +52,7 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
           ls_srcsystem    LIKE LINE OF lt_srcsystem,
           ls_exclude      LIKE LINE OF lt_excludes.
     DATA: lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
-
-    DATA: last_package TYPE devclass VALUE cl_abap_char_utilities=>horizontal_tab.
-    DATA: lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
+    DATA: last_package    TYPE devclass VALUE cl_abap_char_utilities=>horizontal_tab.
 
     FIELD-SYMBOLS: <ls_tdevc> LIKE LINE OF lt_tdevc,
                    <ls_tadir> LIKE LINE OF rt_tadir.

--- a/src/zcl_abapgit_tadir.clas.abap
+++ b/src/zcl_abapgit_tadir.clas.abap
@@ -61,12 +61,10 @@ CLASS zcl_abapgit_tadir IMPLEMENTATION.
 
     "Determine Packages to Read
     DATA: lt_packages TYPE zif_abapgit_sap_package=>ty_devclass_tt.
-    IF iv_ignore_subpackages = abap_true.
-      INSERT iv_package INTO TABLE lt_packages.
-    ELSE.
+    IF iv_ignore_subpackages = abap_false.
       lt_packages = zcl_abapgit_factory=>get_sap_package( iv_package )->list_subpackages( ).
-      INSERT iv_package INTO lt_packages INDEX 1.
     ENDIF.
+    INSERT iv_package INTO lt_packages INDEX 1.    
 
     ls_exclude-sign = 'I'.
     ls_exclude-option = 'EQ'.


### PR DESCRIPTION
- Using the optimizations in ZCL_ABAPGIT_FOLDER_LOGIC (PR #1723) and ZCL_ABAPGIT_SAP_PACKAGE (PR #1724) to optimize the TADIR build method, by first determining all relevant subpackages and then processing them in one go instead of having to recurse and read information from the DB separately.
- Note that the optimization can also be used without the changes in #1723 and #1724, but the effect will be less or worse and the coding requires adaptations. Thus **I would recommend to merge this request after #1723 and #1724 have been merged!**