### PR TITLE
Removed unnecessary default comments from testclasses

### DIFF
--- a/src/objects/zcl_abapgit_object_ecatt_super.clas.testclasses.abap
+++ b/src/objects/zcl_abapgit_object_ecatt_super.clas.testclasses.abap
@@ -1,5 +1,3 @@
-*"* use this source file for your ABAP unit test classes
-
 CLASS ltcl_changed_by DEFINITION DEFERRED.
 
 CLASS zcl_abapgit_object_ecatt_super DEFINITION LOCAL FRIENDS ltcl_changed_by.

--- a/src/objects/zcl_abapgit_object_tran.clas.testclasses.abap
+++ b/src/objects/zcl_abapgit_object_tran.clas.testclasses.abap
@@ -1,5 +1,3 @@
-*"* use this source file for your ABAP unit test classes
-
 CLASS ltcl_split_parameters DEFINITION FINAL FOR TESTING
   DURATION SHORT
   RISK LEVEL HARMLESS.

--- a/src/persist/zcl_abapgit_persist_settings.clas.testclasses.abap
+++ b/src/persist/zcl_abapgit_persist_settings.clas.testclasses.abap
@@ -1,5 +1,3 @@
-*"* use this source file for your ABAP unit test classes
-
 CLASS ltcl_persistence_settings DEFINITION FINAL FOR TESTING
   DURATION SHORT
   RISK LEVEL DANGEROUS.

--- a/src/syntax/zcl_abapgit_syntax_xml.clas.testclasses.abap
+++ b/src/syntax/zcl_abapgit_syntax_xml.clas.testclasses.abap
@@ -1,5 +1,3 @@
-*"* use this source file for your ABAP unit test classes
-
 CLASS abapgit_syntax_xml DEFINITION FINAL FOR TESTING
   DURATION SHORT
   RISK LEVEL HARMLESS.

--- a/src/ui/zcl_abapgit_ui_injector.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_ui_injector.clas.testclasses.abap
@@ -1,5 +1,3 @@
-*"* use this source file for your ABAP unit test classes
-
 CLASS ltd_abapgit_popups_mock DEFINITION.
 
   PUBLIC SECTION.

--- a/src/xml/zcl_abapgit_xml_output.clas.testclasses.abap
+++ b/src/xml/zcl_abapgit_xml_output.clas.testclasses.abap
@@ -1,4 +1,3 @@
-*"* use this source file for your ABAP unit test classes
 CLASS ltcl_xml_output DEFINITION DEFERRED.
 CLASS zcl_abapgit_xml_output DEFINITION LOCAL FRIENDS ltcl_xml_output.
 

--- a/src/zcl_abapgit_dependencies.clas.testclasses.abap
+++ b/src/zcl_abapgit_dependencies.clas.testclasses.abap
@@ -1,4 +1,3 @@
-*"* use this source file for your ABAP unit test classes
 CLASS ltd_sap_package DEFINITION FOR TESTING.
 
   PUBLIC SECTION.

--- a/src/zcl_abapgit_injector.clas.testclasses.abap
+++ b/src/zcl_abapgit_injector.clas.testclasses.abap
@@ -1,5 +1,3 @@
-*"* use this source file for your ABAP unit test classes
-
 CLASS ltd_abapgit_tadir_mock DEFINITION.
 
   PUBLIC SECTION.

--- a/src/zcl_abapgit_news.clas.testclasses.abap
+++ b/src/zcl_abapgit_news.clas.testclasses.abap
@@ -1,5 +1,3 @@
-*"* use this source file for your ABAP unit test classes
-
 CLASS ltcl_relevant DEFINITION DEFERRED.
 CLASS zcl_abapgit_news DEFINITION LOCAL FRIENDS ltcl_relevant.
 

--- a/src/zcl_abapgit_objects.clas.testclasses.abap
+++ b/src/zcl_abapgit_objects.clas.testclasses.abap
@@ -1,5 +1,3 @@
-*"* use this source file for your ABAP unit test classes
-
 *----------------------------------------------------------------------*
 *       CLASS ltcl_dangerous DEFINITION
 *----------------------------------------------------------------------*

--- a/src/zcl_abapgit_repo_online.clas.testclasses.abap
+++ b/src/zcl_abapgit_repo_online.clas.testclasses.abap
@@ -1,4 +1,3 @@
-*"* use this source file for your ABAP unit test classes
 CLASS ltd_code_inspector DEFINITION FOR TESTING.
 
   PUBLIC SECTION.


### PR DESCRIPTION
Removed occurrences of _*"* use this source file for your ABAP unit test classes_ comment.