### PR TITLE
refactor git length encoding #1741

### DIFF
--- a/src/git/zcl_abapgit_git_pack.clas.abap
+++ b/src/git/zcl_abapgit_git_pack.clas.abap
@@ -867,47 +867,25 @@ CLASS ZCL_ABAPGIT_GIT_PACK IMPLEMENTATION.
 
     lv_length = iv_length.
 
-    IF lv_length <= 15.
-      lv_hex = 0 + lv_type + lv_length MOD 16.
-      rv_xstring = lv_hex.
-      lv_length = lv_length DIV 16.
+* first byte
+    IF lv_length > 15.
+      lv_hex = 128.
+    ENDIF.
+    lv_hex = lv_hex + lv_type + lv_length MOD 16.
+    rv_xstring = lv_hex.
+    lv_length = lv_length DIV 16.
 
-    ELSEIF lv_length <= 2047.
-      lv_hex = 128 + lv_type + lv_length MOD 16.
-      rv_xstring = lv_hex.
-      lv_length = lv_length DIV 16.
-
-      lv_hex = lv_length.
-      CONCATENATE rv_xstring lv_hex INTO rv_xstring IN BYTE MODE.
-    ELSEIF lv_length <= 262143.
-      lv_hex = 128 + lv_type + lv_length MOD 16.
-      rv_xstring = lv_hex.
-      lv_length = lv_length DIV 16.
-
+* subsequent bytes
+    WHILE lv_length >= 128.
       lv_hex = 128 + lv_length MOD 128.
       CONCATENATE rv_xstring lv_hex INTO rv_xstring IN BYTE MODE.
       lv_length = lv_length DIV 128.
+    ENDWHILE.
 
+* last byte
+    IF lv_length > 0.
       lv_hex = lv_length.
       CONCATENATE rv_xstring lv_hex INTO rv_xstring IN BYTE MODE.
-    ELSEIF lv_length <= 33554431.
-      lv_hex = 128 + lv_type + lv_length MOD 16.
-      rv_xstring = lv_hex.
-      lv_length = lv_length DIV 16.
-
-      lv_hex = 128 + lv_length MOD 128.
-      CONCATENATE rv_xstring lv_hex INTO rv_xstring IN BYTE MODE.
-      lv_length = lv_length DIV 128.
-
-      lv_hex = 128 + lv_length MOD 128.
-      CONCATENATE rv_xstring lv_hex INTO rv_xstring IN BYTE MODE.
-      lv_length = lv_length DIV 128.
-
-      lv_hex = lv_length.
-      CONCATENATE rv_xstring lv_hex INTO rv_xstring IN BYTE MODE.
-    ELSE.
-* this IF can be refactored, use shifting?
-      zcx_abapgit_exception=>raise( 'Todo, encoding length' ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/git/zcl_abapgit_git_pack.clas.testclasses.abap
+++ b/src/git/zcl_abapgit_git_pack.clas.testclasses.abap
@@ -92,68 +92,126 @@ CLASS ltcl_type_and_length DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARM
 
   PRIVATE SECTION.
     METHODS:
-      type_and_length01 FOR TESTING RAISING zcx_abapgit_exception,
-      type_and_length02 FOR TESTING RAISING zcx_abapgit_exception,
-      type_and_length03 FOR TESTING RAISING zcx_abapgit_exception,
-      type_and_length04 FOR TESTING RAISING zcx_abapgit_exception.
+      test
+        IMPORTING
+          iv_length   TYPE i
+          iv_type     TYPE zif_abapgit_definitions=>ty_type DEFAULT zif_abapgit_definitions=>gc_type-commit
+          iv_expected TYPE xstring
+        RAISING
+          zcx_abapgit_exception,
+      type_and_length_0 FOR TESTING RAISING zcx_abapgit_exception,
+      type_and_length_1 FOR TESTING RAISING zcx_abapgit_exception,
+      type_and_length_10 FOR TESTING RAISING zcx_abapgit_exception,
+      type_and_length_15 FOR TESTING RAISING zcx_abapgit_exception,
+      type_and_length_16 FOR TESTING RAISING zcx_abapgit_exception,
+      type_and_length_17 FOR TESTING RAISING zcx_abapgit_exception,
+      type_and_length_100 FOR TESTING RAISING zcx_abapgit_exception,
+      type_and_length_128 FOR TESTING RAISING zcx_abapgit_exception,
+      type_and_length_2047 FOR TESTING RAISING zcx_abapgit_exception,
+      type_and_length_2048 FOR TESTING RAISING zcx_abapgit_exception,
+      type_and_length_90000 FOR TESTING RAISING zcx_abapgit_exception,
+      type_and_length_1000000 FOR TESTING RAISING zcx_abapgit_exception.
 
 ENDCLASS.
 
 CLASS ltcl_type_and_length IMPLEMENTATION.
 
-  METHOD type_and_length01.
+  METHOD test.
 
     DATA: lv_result TYPE xstring.
 
     lv_result = zcl_abapgit_git_pack=>type_and_length(
-      iv_type   = zif_abapgit_definitions=>gc_type-commit
-      iv_length = 100 ).
+      iv_type   = iv_type
+      iv_length = iv_length ).
 
     cl_abap_unit_assert=>assert_equals(
       act = lv_result
-      exp = '9406' ).
+      exp = iv_expected ).
 
   ENDMETHOD.
 
-  METHOD type_and_length02.
+  METHOD type_and_length_100.
 
-    DATA: lv_result TYPE xstring.
-
-    lv_result = zcl_abapgit_git_pack=>type_and_length(
-      iv_type   = zif_abapgit_definitions=>gc_type-blob
-      iv_length = 90000 ).
-
-    cl_abap_unit_assert=>assert_equals(
-      act = lv_result
-      exp = 'B0F92B' ).
+    test( iv_length   = 100
+          iv_expected = '9406' ).
 
   ENDMETHOD.
 
-  METHOD type_and_length03.
+  METHOD type_and_length_2047.
 
-    DATA: lv_result TYPE xstring.
-
-    lv_result = zcl_abapgit_git_pack=>type_and_length(
-      iv_type   = zif_abapgit_definitions=>gc_type-commit
-      iv_length = 10 ).
-
-    cl_abap_unit_assert=>assert_equals(
-      act = lv_result
-      exp = '1A' ).
+    test( iv_length   = 2047
+          iv_expected = '9F7F' ).
 
   ENDMETHOD.
 
-  METHOD type_and_length04.
+  METHOD type_and_length_2048.
 
-    DATA: lv_result TYPE xstring.
+    test( iv_length   = 2048
+          iv_expected = '908001' ).
 
-    lv_result = zcl_abapgit_git_pack=>type_and_length(
-      iv_type   = zif_abapgit_definitions=>gc_type-commit
-      iv_length = 1000000 ).
+  ENDMETHOD.
 
-    cl_abap_unit_assert=>assert_equals(
-      act = lv_result
-      exp = '90A4E803' ).
+  METHOD type_and_length_90000.
+
+    test( iv_length   = 90000
+          iv_type     = zif_abapgit_definitions=>gc_type-blob
+          iv_expected = 'B0F92B' ).
+
+  ENDMETHOD.
+
+  METHOD type_and_length_10.
+
+    test( iv_length   = 10
+          iv_expected = '1A' ).
+
+  ENDMETHOD.
+
+  METHOD type_and_length_1000000.
+
+    test( iv_length   = 1000000
+          iv_expected = '90A4E803' ).
+
+  ENDMETHOD.
+
+  METHOD type_and_length_0.
+
+    test( iv_length   = 0
+          iv_expected = '10' ).
+
+  ENDMETHOD.
+
+  METHOD type_and_length_128.
+
+    test( iv_length   = 128
+          iv_expected = '9008' ).
+
+  ENDMETHOD.
+
+  METHOD type_and_length_1.
+
+    test( iv_length   = 1
+          iv_expected = '11' ).
+
+  ENDMETHOD.
+
+  METHOD type_and_length_15.
+
+    test( iv_length   = 15
+          iv_expected = '1F' ).
+
+  ENDMETHOD.
+
+  METHOD type_and_length_16.
+
+    test( iv_length   = 16
+          iv_expected = '9001' ).
+
+  ENDMETHOD.
+
+  METHOD type_and_length_17.
+
+    test( iv_length   = 17
+          iv_expected = '9101' ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
refactor git length encoding #1741

can now handle larger numbers than 30mb, uses interation and less code

plus more unit tests