### PR TITLE
New online repo: method refresh deleted #1678

### DIFF
--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -291,7 +291,6 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
 
     add( ro_repo ).
 
-    ro_repo->refresh( ).
     ro_repo->find_remote_dot_abapgit( ).
 
   ENDMETHOD.

--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -49,7 +49,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
+CLASS zcl_abapgit_repo_srv IMPLEMENTATION.
 
 
   METHOD add.
@@ -291,7 +291,13 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
 
     add( ro_repo ).
 
-    ro_repo->find_remote_dot_abapgit( ).
+    TRY.
+        ro_repo->refresh( ).
+        ro_repo->find_remote_dot_abapgit( ).
+      CATCH zcx_abapgit_exception.
+        "User gets later a error message
+    ENDTRY.
+
 
   ENDMETHOD.
 


### PR DESCRIPTION
https://github.com/larshp/abapGit/issues/1678
Avoids exception before the repo is created as favorite.
The refresh will be call later again.