### PR TITLE
repo: skip missing packages in new repo validation

### DIFF
--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -138,6 +138,10 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
       lo_repo = get( ls_repo-key ).
 
       lo_package = zcl_abapgit_factory=>get_sap_package( ls_repo-package ).
+      IF lo_package->exists( ) eq ABAP_FALSE.
+        " Skip dangling repository
+        CONTINUE.
+      ENDIF.
 
       CLEAR lt_packages.
       IF lo_repo->get_local_settings( )-ignore_subpackages = abap_false.


### PR DESCRIPTION
When we try to add a new online repository and we have a repository
whose package does not exist in abapGit we get a short dump caused
by assert in the method zif_abapgit_sap_package~read_parent of
the class zcl_abapgit_sap_pacakge.

This commit makes sure we skip such repositories because we believe it
does not make sense to prevent us from cloning in these cases.

Thank you Petr Benes <petr.benes@sap.com>!