### PR TITLE
Introduce customizable hotkeys #1728

### DIFF
--- a/src/ui/db/zcl_abapgit_gui_page_db.clas.abap
+++ b/src/ui/db/zcl_abapgit_gui_page_db.clas.abap
@@ -5,6 +5,7 @@ CLASS zcl_abapgit_gui_page_db DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
 
     METHODS constructor .
 
@@ -185,6 +186,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DB IMPLEMENTATION.
     ro_html->add( '</div>' ).
 
   ENDMETHOD.            "render_content
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
 
 
   METHOD zif_abapgit_gui_page~on_event.

--- a/src/ui/db/zcl_abapgit_gui_page_db_dis.clas.abap
+++ b/src/ui/db/zcl_abapgit_gui_page_db_dis.clas.abap
@@ -4,6 +4,8 @@ CLASS zcl_abapgit_gui_page_db_dis DEFINITION
   CREATE PUBLIC INHERITING FROM zcl_abapgit_gui_page.
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
+
     METHODS: constructor
       IMPORTING is_key TYPE zif_abapgit_persistence=>ty_content.
 
@@ -80,4 +82,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DB_DIS IMPLEMENTATION.
            && |<table class="tag"><tr><td class="label">Key:</td>|
            && |  <td>{ is_key-value }</td></tr></table>|.
   ENDMETHOD. "render_record_banner
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
 ENDCLASS.

--- a/src/ui/db/zcl_abapgit_gui_page_db_edit.clas.abap
+++ b/src/ui/db/zcl_abapgit_gui_page_db_edit.clas.abap
@@ -5,10 +5,11 @@ CLASS zcl_abapgit_gui_page_db_edit DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
 
     METHODS constructor
       IMPORTING
-        !is_key TYPE zif_abapgit_persistence=>ty_content .
+        is_key TYPE zif_abapgit_persistence=>ty_content .
 
     METHODS zif_abapgit_gui_page~on_event
         REDEFINITION .
@@ -134,6 +135,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DB_EDIT IMPLEMENTATION.
       iv_data  = is_content-data_str ).
 
     COMMIT WORK.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_bkg.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_bkg.clas.abap
@@ -5,10 +5,11 @@ CLASS zcl_abapgit_gui_page_bkg DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
 
     METHODS constructor
       IMPORTING
-        !iv_key TYPE zif_abapgit_persistence=>ty_repo-key .
+        iv_key TYPE zif_abapgit_persistence=>ty_repo-key .
 
     METHODS zif_abapgit_gui_page~on_event
         REDEFINITION .
@@ -303,6 +304,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_BKG IMPLEMENTATION.
     MESSAGE 'Saved' TYPE 'S' ##NO_TEXT.
 
     COMMIT WORK.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_bkg_run.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_bkg_run.clas.abap
@@ -5,6 +5,7 @@ CLASS zcl_abapgit_gui_page_bkg_run DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
 
     METHODS constructor .
 
@@ -69,6 +70,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_BKG_RUN IMPLEMENTATION.
       CATCH zcx_abapgit_exception INTO lx_error.
         APPEND lx_error->get_text( ) TO mt_text.
     ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
@@ -4,6 +4,8 @@ CLASS zcl_abapgit_gui_page_boverview DEFINITION
   CREATE PUBLIC INHERITING FROM zcl_abapgit_gui_page.
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
+
     METHODS:
       constructor
         IMPORTING io_repo TYPE REF TO zcl_abapgit_repo_online
@@ -59,7 +61,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_BOVERVIEW IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_boverview IMPLEMENTATION.
 
 
   METHOD body.
@@ -315,4 +317,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_BOVERVIEW IMPLEMENTATION.
     ENDCASE.
 
   ENDMETHOD.
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_code_insp.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_code_insp.clas.abap
@@ -2,6 +2,8 @@ CLASS zcl_abapgit_gui_page_code_insp DEFINITION PUBLIC FINAL CREATE PUBLIC
     INHERITING FROM zcl_abapgit_gui_page.
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
+
     METHODS:
       constructor
         IMPORTING
@@ -15,7 +17,6 @@ CLASS zcl_abapgit_gui_page_code_insp DEFINITION PUBLIC FINAL CREATE PUBLIC
 
       zif_abapgit_gui_page~render
         REDEFINITION.
-
 
   PROTECTED SECTION.
     DATA: mo_repo TYPE REF TO zcl_abapgit_repo.
@@ -316,4 +317,10 @@ CLASS zcl_abapgit_gui_page_code_insp IMPLEMENTATION.
     ro_html = super->zif_abapgit_gui_page~render( ).
 
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_commit.clas.abap
@@ -5,6 +5,7 @@ CLASS zcl_abapgit_gui_page_commit DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
 
     CONSTANTS:
       BEGIN OF c_action,
@@ -14,10 +15,10 @@ CLASS zcl_abapgit_gui_page_commit DEFINITION
 
     METHODS constructor
       IMPORTING
-        !io_repo  TYPE REF TO zcl_abapgit_repo_online
-        !io_stage TYPE REF TO zcl_abapgit_stage
+        io_repo  TYPE REF TO zcl_abapgit_repo_online
+        io_stage TYPE REF TO zcl_abapgit_stage
       RAISING
-        zcx_abapgit_exception .
+        zcx_abapgit_exception.
 
     METHODS zif_abapgit_gui_page~on_event
         REDEFINITION .
@@ -322,6 +323,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
     ro_html = super->scripts( ).
 
     ro_html->add( 'setInitialFocus("comment");' ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_debuginfo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_debuginfo.clas.abap
@@ -5,6 +5,7 @@ CLASS zcl_abapgit_gui_page_debuginfo DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
 
     METHODS constructor .
   PROTECTED SECTION.
@@ -100,4 +101,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DEBUGINFO IMPLEMENTATION.
       '"<br>Frontend time: " + new Date(), "debug_info");' ).
 
   ENDMETHOD.  "scripts
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_diff.clas.abap
@@ -4,6 +4,7 @@ CLASS zcl_abapgit_gui_page_diff DEFINITION
   CREATE PUBLIC INHERITING FROM zcl_abapgit_gui_page.
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
 
     CONSTANTS:
       BEGIN OF c_fstate,
@@ -26,9 +27,9 @@ CLASS zcl_abapgit_gui_page_diff DEFINITION
 
     METHODS:
       constructor
-        IMPORTING iv_key           TYPE zif_abapgit_persistence=>ty_repo-key
-                  is_file          TYPE zif_abapgit_definitions=>ty_file OPTIONAL
-                  is_object        TYPE zif_abapgit_definitions=>ty_item OPTIONAL
+        IMPORTING iv_key    TYPE zif_abapgit_persistence=>ty_repo-key
+                  is_file   TYPE zif_abapgit_definitions=>ty_file OPTIONAL
+                  is_object TYPE zif_abapgit_definitions=>ty_item OPTIONAL
         RAISING   zcx_abapgit_exception,
       zif_abapgit_gui_page~on_event REDEFINITION.
   PROTECTED SECTION.
@@ -75,7 +76,7 @@ CLASS zcl_abapgit_gui_page_diff DEFINITION
                 is_status TYPE zif_abapgit_definitions=>ty_result
       RAISING   zcx_abapgit_exception.
     METHODS build_menu
-      RETURNING VALUE(ro_menu)   TYPE REF TO zcl_abapgit_html_toolbar.
+      RETURNING VALUE(ro_menu) TYPE REF TO zcl_abapgit_html_toolbar.
     METHODS is_binary
       IMPORTING iv_d1         TYPE xstring
                 iv_d2         TYPE xstring
@@ -84,7 +85,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
 
 
   METHOD append_diff.
@@ -646,4 +647,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
     ENDCASE.
 
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_explore.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_explore.clas.abap
@@ -4,6 +4,7 @@ CLASS zcl_abapgit_gui_page_explore DEFINITION
   CREATE PUBLIC INHERITING FROM zcl_abapgit_gui_page.
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
 
     CONSTANTS c_explore_url TYPE string
       VALUE 'https://dotabap.github.io/explore.html'.
@@ -29,4 +30,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_EXPLORE IMPLEMENTATION.
   METHOD render_content.
     ASSERT 1 = 1. " Dummy
   ENDMETHOD. "render_content.
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -358,32 +358,39 @@ CLASS zcl_abapgit_gui_page_main IMPLEMENTATION.
 
     DATA: ls_hotkey_action TYPE zif_abapgit_gui_page_hotkey=>ty_hotkey_action.
 
-    ls_hotkey_action-name   = |Main: Settings|.
-    ls_hotkey_action-action = zif_abapgit_definitions=>gc_action-go_settings.
+    ls_hotkey_action-name           = |Main: Settings|.
+    ls_hotkey_action-action         = zif_abapgit_definitions=>gc_action-go_settings.
+    ls_hotkey_action-default_hotkey = |s|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name   = |Main: Repo overview|.
-    ls_hotkey_action-action = zif_abapgit_definitions=>gc_action-go_repo_overview.
+    ls_hotkey_action-name           = |Main: Repo overview|.
+    ls_hotkey_action-action         = zif_abapgit_definitions=>gc_action-go_repo_overview.
+    ls_hotkey_action-default_hotkey = |o|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name   = |Main: Refresh|.
-    ls_hotkey_action-action = zif_abapgit_definitions=>gc_action-repo_refresh.
+    ls_hotkey_action-name           = |Main: Refresh|.
+    ls_hotkey_action-action         = zif_abapgit_definitions=>gc_action-repo_refresh.
+    ls_hotkey_action-default_hotkey = |r|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name   = |Main: Pull|.
-    ls_hotkey_action-action = zif_abapgit_definitions=>gc_action-git_pull.
+    ls_hotkey_action-name           = |Main: Pull|.
+    ls_hotkey_action-action         = zif_abapgit_definitions=>gc_action-git_pull.
+    ls_hotkey_action-default_hotkey = |p|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name   = |Main: + Online|.
-    ls_hotkey_action-action = zif_abapgit_definitions=>gc_action-repo_newonline.
+    ls_hotkey_action-name           = |Main: + Online|.
+    ls_hotkey_action-action         = zif_abapgit_definitions=>gc_action-repo_newonline.
+    ls_hotkey_action-default_hotkey = |n|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name   = |Main: Uninstall|.
-    ls_hotkey_action-action = zif_abapgit_definitions=>gc_action-repo_purge.
+    ls_hotkey_action-name           = |Main: Uninstall|.
+    ls_hotkey_action-action         = zif_abapgit_definitions=>gc_action-repo_purge.
+    ls_hotkey_action-default_hotkey = |u|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name   = |Main: Show diff|.
-    ls_hotkey_action-action = zif_abapgit_definitions=>gc_action-go_diff.
+    ls_hotkey_action-name           = |Main: Show diff|.
+    ls_hotkey_action-action         = zif_abapgit_definitions=>gc_action-go_diff.
+    ls_hotkey_action-default_hotkey = |d|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -4,6 +4,7 @@ CLASS zcl_abapgit_gui_page_main DEFINITION
   CREATE PUBLIC INHERITING FROM zcl_abapgit_gui_page.
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
     METHODS:
       constructor
         RAISING zcx_abapgit_exception,
@@ -43,7 +44,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_main IMPLEMENTATION.
 
 
   METHOD build_main_menu.
@@ -351,4 +352,40 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
     ENDCASE.
 
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+    DATA: ls_hotkey_action TYPE zif_abapgit_gui_page_hotkey=>ty_hotkey_action.
+
+    ls_hotkey_action-name   = |Main: Settings|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>gc_action-go_settings.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
+
+    ls_hotkey_action-name   = |Main: Repo overview|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>gc_action-go_repo_overview.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
+
+    ls_hotkey_action-name   = |Main: Refresh|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>gc_action-repo_refresh.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
+
+    ls_hotkey_action-name   = |Main: Pull|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>gc_action-git_pull.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
+
+    ls_hotkey_action-name   = |Main: + Online|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>gc_action-repo_newonline.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
+
+    ls_hotkey_action-name   = |Main: Uninstall|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>gc_action-repo_purge.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
+
+    ls_hotkey_action-name   = |Main: Show diff|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>gc_action-go_diff.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_merge.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_merge.clas.abap
@@ -5,12 +5,13 @@ CLASS zcl_abapgit_gui_page_merge DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
 
     METHODS constructor
       IMPORTING
-        !io_repo   TYPE REF TO zcl_abapgit_repo_online
-        !iv_source TYPE string
-        !iv_target TYPE string
+        io_repo   TYPE REF TO zcl_abapgit_repo_online
+        iv_source TYPE string
+        iv_target TYPE string
       RAISING
         zcx_abapgit_exception .
 
@@ -38,7 +39,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_MERGE IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_merge IMPLEMENTATION.
 
 
   METHOD build_menu.
@@ -215,4 +216,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MERGE IMPLEMENTATION.
     ENDCASE.
 
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_merge_res.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_merge_res.clas.abap
@@ -5,14 +5,15 @@ CLASS zcl_abapgit_gui_page_merge_res DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
 
     METHODS constructor
       IMPORTING
-        !io_repo       TYPE REF TO zcl_abapgit_repo_online
-        !io_merge_page TYPE REF TO zcl_abapgit_gui_page_merge
-        !io_merge      TYPE REF TO zcl_abapgit_merge
+        io_repo       TYPE REF TO zcl_abapgit_repo_online
+        io_merge_page TYPE REF TO zcl_abapgit_gui_page_merge
+        io_merge      TYPE REF TO zcl_abapgit_merge
       RAISING
-        zcx_abapgit_exception .
+        zcx_abapgit_exception.
 
     METHODS zif_abapgit_gui_page~on_event
         REDEFINITION .
@@ -110,7 +111,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_MERGE_RES IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_merge_res IMPLEMENTATION.
 
 
   METHOD apply_merged_content.
@@ -126,7 +127,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MERGE_RES IMPLEMENTATION.
           lv_new_file_content TYPE xstring.
 
     FIELD-SYMBOLS: <lv_postdata_line> LIKE LINE OF it_postdata,
-                   <ls_conflict>   TYPE zif_abapgit_definitions=>ty_merge_conflict.
+                   <ls_conflict>      TYPE zif_abapgit_definitions=>ty_merge_conflict.
 
     LOOP AT it_postdata ASSIGNING <lv_postdata_line>.
       lv_string = |{ lv_string }{ <lv_postdata_line> }|.
@@ -401,10 +402,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MERGE_RES IMPLEMENTATION.
 
   METHOD render_line_split.
 
-    DATA: lv_new   TYPE string,
-          lv_old   TYPE string,
-          lv_mark  TYPE string,
-          lv_bg    TYPE string.
+    DATA: lv_new  TYPE string,
+          lv_old  TYPE string,
+          lv_mark TYPE string,
+          lv_bg   TYPE string.
 
     CREATE OBJECT ro_html.
 
@@ -577,4 +578,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MERGE_RES IMPLEMENTATION.
     ENDCASE.
 
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -5,6 +5,7 @@ CLASS zcl_abapgit_gui_page_repo_over DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
 
     METHODS constructor .
 
@@ -584,4 +585,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
     ENDCASE.
 
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
@@ -3,6 +3,8 @@ CLASS zcl_abapgit_gui_page_repo_sett DEFINITION
     CREATE PUBLIC INHERITING FROM zcl_abapgit_gui_page.
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
+
     METHODS:
       constructor
         IMPORTING io_repo TYPE REF TO zcl_abapgit_repo,
@@ -314,6 +316,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
     ENDIF.
 
     mo_repo->set_local_settings( ls_settings ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -4,6 +4,8 @@ CLASS zcl_abapgit_gui_page_stage DEFINITION
   CREATE PUBLIC INHERITING FROM zcl_abapgit_gui_page.
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
+
     CONSTANTS: BEGIN OF c_action,
                  stage_all    TYPE string VALUE 'stage_all',
                  stage_commit TYPE string VALUE 'stage_commit',
@@ -361,6 +363,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
     ro_html->add( 'var gHelper = new StageHelper(gStageParams);' ).
 
   ENDMETHOD.  "scripts
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
 
 
   METHOD zif_abapgit_gui_page~on_event.

--- a/src/ui/zcl_abapgit_gui_page_syntax.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_syntax.clas.abap
@@ -2,6 +2,8 @@ CLASS zcl_abapgit_gui_page_syntax DEFINITION PUBLIC FINAL CREATE PUBLIC
     INHERITING FROM zcl_abapgit_gui_page.
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
+
     METHODS:
       constructor
         IMPORTING io_repo TYPE REF TO zcl_abapgit_repo.
@@ -16,7 +18,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_syntax IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_SYNTAX IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -50,4 +52,9 @@ CLASS zcl_abapgit_gui_page_syntax IMPLEMENTATION.
     ro_html->add( '</div>' ).
 
   ENDMETHOD.  "render_content
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_tag.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_tag.clas.abap
@@ -2,6 +2,7 @@ CLASS zcl_abapgit_gui_page_tag DEFINITION PUBLIC FINAL
     CREATE PUBLIC INHERITING FROM zcl_abapgit_gui_page.
 
   PUBLIC SECTION.
+    INTERFACES: zif_abapgit_gui_page_hotkey.
 
     CONSTANTS: BEGIN OF c_action,
                  commit_post     TYPE string VALUE 'commit_post',
@@ -60,7 +61,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_TAG IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_tag IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -388,4 +389,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_TAG IMPLEMENTATION.
     ENDCASE.
 
   ENDMETHOD.
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_view_repo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_view_repo.clas.abap
@@ -6,6 +6,7 @@ CLASS zcl_abapgit_gui_view_repo DEFINITION
   PUBLIC SECTION.
 
     INTERFACES zif_abapgit_gui_page .
+    INTERFACES zif_abapgit_gui_page_hotkey.
 
     ALIASES render
       FOR zif_abapgit_gui_page~render .
@@ -633,4 +634,10 @@ CLASS zcl_abapgit_gui_view_repo IMPLEMENTATION.
     ENDTRY.
 
   ENDMETHOD.  "lif_gui_page~render
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_view_tutorial.clas.abap
+++ b/src/ui/zcl_abapgit_gui_view_tutorial.clas.abap
@@ -2,6 +2,7 @@ CLASS zcl_abapgit_gui_view_tutorial DEFINITION PUBLIC FINAL CREATE PUBLIC.
 
   PUBLIC SECTION.
     INTERFACES zif_abapgit_gui_page.
+    INTERFACES zif_abapgit_gui_page_hotkey.
     ALIASES render FOR zif_abapgit_gui_page~render.
 
   PRIVATE SECTION.
@@ -62,6 +63,11 @@ CLASS ZCL_ABAPGIT_GUI_VIEW_TUTORIAL IMPLEMENTATION.
     ENDIF.
     ro_html->add( '</li>' ).
     ro_html->add( '</ul></p>' ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
 
   ENDMETHOD.
 

--- a/src/zabapgit_js_common.w3mi.data.js
+++ b/src/zabapgit_js_common.w3mi.data.js
@@ -820,4 +820,55 @@ function setLinkHints(sLinkHintKey, sColor) {
 
 }
 
+function Hotkeys(oKeyMap){
+  this.oKeyMap = oKeyMap;
+}
 
+Hotkeys.prototype.getSapEvent = function(sSapEvent) {
+
+  var result = "";
+  var aSapEvents = document.querySelectorAll('a[href^="sapevent:' + sSapEvent + '"]');
+
+  [].forEach.call(aSapEvents, function(sapEvent){
+      if (new RegExp(sSapEvent + "$" ).test(sapEvent.href)
+      || (new RegExp(sSapEvent + "\\?" ).test(sapEvent.href))) {
+        result = sapEvent.href.replace("sapevent:","");
+      }
+    });
+
+  return result;
+
+}
+
+Hotkeys.prototype.onkeydown = function(oEvent){
+
+  if (oEvent.defaultPrevented) {
+      return;
+  }
+
+  var activeElementType = ((document.activeElement && document.activeElement.nodeName) || "");
+
+  if (activeElementType === "INPUT" || activeElementType === "TEXTAREA") {
+    return
+  }
+
+  var 
+    sKey = oEvent.key || oEvent.keyCode,
+    oHotkey = this.oKeyMap[sKey];
+
+  if (oHotkey) {
+    var sSapEvent = this.getSapEvent(oHotkey);
+    if (sSapEvent) {
+      submitSapeventForm({}, sSapEvent, "post");
+      oEvent.preventDefault();
+    }
+  }
+}
+
+function setKeyBindings(oKeyMap){
+
+  var oHotkeys = new Hotkeys(oKeyMap);
+
+  document.addEventListener('keydown', oHotkeys.onkeydown.bind(oHotkeys));
+
+}

--- a/src/zcl_abapgit_settings.clas.abap
+++ b/src/zcl_abapgit_settings.clas.abap
@@ -96,15 +96,19 @@ CLASS zcl_abapgit_settings DEFINITION PUBLIC CREATE PUBLIC.
           iv_link_hint_key TYPE char01,
       get_link_hint_key
         RETURNING
-          VALUE(rv_link_hint_key) TYPE char01
-        RAISING
-          zcx_abapgit_exception,
+          VALUE(rv_link_hint_key) TYPE char01,
       get_link_hint_background_color
         RETURNING
           VALUE(rv_background_color) TYPE string,
       set_link_hint_background_color
         IMPORTING
-          iv_background_color TYPE string.
+          iv_background_color TYPE string,
+      set_hotkeys
+        IMPORTING
+          it_hotkeys TYPE zif_abapgit_definitions=>tty_hotkey,
+      get_hotkeys
+        RETURNING
+          VALUE(rt_hotkeys) TYPE zif_abapgit_definitions=>tty_hotkey.
 
   PRIVATE SECTION.
     TYPES: BEGIN OF ty_s_settings,
@@ -336,6 +340,15 @@ CLASS zcl_abapgit_settings IMPLEMENTATION.
 
   METHOD set_link_hint_background_color.
     ms_user_settings-link_hint_background_color = iv_background_color.
+  ENDMETHOD.
+
+
+  METHOD set_hotkeys.
+    ms_user_settings-hotkeys = it_hotkeys.
+  ENDMETHOD.
+
+  METHOD get_hotkeys.
+    rt_hotkeys = ms_user_settings-hotkeys.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -58,6 +58,13 @@ INTERFACE zif_abapgit_definitions PUBLIC.
   TYPES:
     ty_git_tag_list_tt TYPE STANDARD TABLE OF ty_git_tag WITH DEFAULT KEY .
 
+  TYPES:
+    BEGIN OF ty_hotkey,
+      sequence TYPE string,
+      action   TYPE string,
+    END OF ty_hotkey,
+    tty_hotkey TYPE STANDARD TABLE OF ty_hotkey
+                    WITH NON-UNIQUE DEFAULT KEY.
 
   CONSTANTS:
     BEGIN OF c_git_branch_type,
@@ -334,6 +341,7 @@ INTERFACE zif_abapgit_definitions PUBLIC.
            link_hints_enabled         TYPE abap_bool,
            link_hint_key              TYPE char01,
            link_hint_background_color TYPE string,
+           hotkeys                    TYPE tty_hotkey,
          END OF ty_s_user_settings.
 
   CONSTANTS:

--- a/src/zif_abapgit_gui_page_hotkey.intf.abap
+++ b/src/zif_abapgit_gui_page_hotkey.intf.abap
@@ -3,8 +3,9 @@ INTERFACE zif_abapgit_gui_page_hotkey
 
   TYPES:
     BEGIN OF ty_hotkey_action,
-      name   TYPE string,
-      action TYPE string,
+      name           TYPE string,
+      action         TYPE string,
+      default_hotkey TYPE string,
     END OF ty_hotkey_action,
     tty_hotkey_action TYPE STANDARD TABLE OF ty_hotkey_action
                            WITH NON-UNIQUE DEFAULT KEY.

--- a/src/zif_abapgit_gui_page_hotkey.intf.abap
+++ b/src/zif_abapgit_gui_page_hotkey.intf.abap
@@ -1,0 +1,17 @@
+INTERFACE zif_abapgit_gui_page_hotkey
+  PUBLIC.
+
+  TYPES:
+    BEGIN OF ty_hotkey_action,
+      name   TYPE string,
+      action TYPE string,
+    END OF ty_hotkey_action,
+    tty_hotkey_action TYPE STANDARD TABLE OF ty_hotkey_action
+                           WITH NON-UNIQUE DEFAULT KEY.
+
+  CLASS-METHODS
+    get_hotkey_actions
+      RETURNING
+        VALUE(rt_hotkey_actions) TYPE tty_hotkey_action.
+
+ENDINTERFACE.

--- a/src/zif_abapgit_gui_page_hotkey.intf.xml
+++ b/src/zif_abapgit_gui_page_hotkey.intf.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_ABAPGIT_GUI_PAGE_HOTKEY</CLSNAME>
+    <VERSION>1</VERSION>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit page hotkey definitions</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
With this commit customizable hotkeys are introduced. They can
be defined in the user specific settings. Currently we support
only one letter keybindigs e.g. 's', 't' or 'x' and no modifiers.

Every page in the UI can decide which actions it offers for the
hotkeys. Therefore we introduce the interface ZIF_ABAPGIT_GUI_PAGE_HOTKEY
with the method GET_HOTKEY_ACTIONS. At this point in time only
the main page offers actions for hotkeys, but the mechanism works
already for all pages. New actions for hotkeys can be defined
easily.

Hotkeys are only available for installed abapGit repositories.
Because we need to detect the classes which implement the above
mentioned interface and it seems that there is no easy way to do
that for local classes. Maybe we can add it later when we know more.

We don't supply default key bindings. So it is totally up to the
user to define them.

![image](https://user-images.githubusercontent.com/17437789/44053778-f7827938-9f40-11e8-943d-09216620012f.png)

#1728