### PR TITLE
Introduce global hotkeys #1728

### DIFF
--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -1,7 +1,13 @@
 CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT CREATE PUBLIC.
 
   PUBLIC SECTION.
-    INTERFACES zif_abapgit_gui_page.
+    INTERFACES:
+      zif_abapgit_gui_page.
+
+    CLASS-METHODS:
+      get_hotkey_actions
+        RETURNING
+          VALUE(rt_hotkey_actions) TYPE zif_abapgit_gui_page_hotkey=>tty_hotkey_action.
 
   PROTECTED SECTION.
 
@@ -57,26 +63,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page IMPLEMENTATION.
-
-
-  METHOD footer.
-
-    CREATE OBJECT ro_html.
-
-    ro_html->add( '<div id="footer">' ).                    "#EC NOTEXT
-
-    ro_html->add( '<img src="img/logo" alt="logo">' ).      "#EC NOTEXT
-    ro_html->add( '<table class="w100"><tr>' ).             "#EC NOTEXT
-
-    ro_html->add( '<td class="w40"></td>' ).                "#EC NOTEXT
-    ro_html->add( |<td><span class="version">{ zif_abapgit_version=>gc_abap_version }</span></td>| ). "#EC NOTEXT
-    ro_html->add( '<td id="debug-output" class="w40"></td>' ). "#EC NOTEXT
-
-    ro_html->add( '</tr></table>' ).                        "#EC NOTEXT
-    ro_html->add( '</div>' ).                               "#EC NOTEXT
-
-  ENDMETHOD. "footer
+CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
 
 
   METHOD add_hotkeys.
@@ -103,6 +90,39 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
     lv_json = lv_json && `}`.
 
     io_html->add( |setKeyBindings({ lv_json });| ).
+
+  ENDMETHOD.
+
+
+  METHOD footer.
+
+    CREATE OBJECT ro_html.
+
+    ro_html->add( '<div id="footer">' ).                    "#EC NOTEXT
+
+    ro_html->add( '<img src="img/logo" alt="logo">' ).      "#EC NOTEXT
+    ro_html->add( '<table class="w100"><tr>' ).             "#EC NOTEXT
+
+    ro_html->add( '<td class="w40"></td>' ).                "#EC NOTEXT
+    ro_html->add( |<td><span class="version">{ zif_abapgit_version=>gc_abap_version }</span></td>| ). "#EC NOTEXT
+    ro_html->add( '<td id="debug-output" class="w40"></td>' ). "#EC NOTEXT
+
+    ro_html->add( '</tr></table>' ).                        "#EC NOTEXT
+    ro_html->add( '</div>' ).                               "#EC NOTEXT
+
+  ENDMETHOD. "footer
+
+
+  METHOD get_hotkey_actions.
+
+    " these are the global shortcuts active on all pages
+
+    DATA: ls_hotkey_action LIKE LINE OF rt_hotkey_actions.
+
+    ls_hotkey_action-name           = |Global: Show hotkeys|.
+    ls_hotkey_action-action         = |showHotkeys|.
+    ls_hotkey_action-default_hotkey = |?|.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_hotkeys.clas.abap
+++ b/src/ui/zcl_abapgit_hotkeys.clas.abap
@@ -53,6 +53,10 @@ CLASS zcl_abapgit_hotkeys IMPLEMENTATION.
 
     ENDLOOP.
 
+    " the global shortcuts are defined in the base class
+    lt_hotkey_actions = zcl_abapgit_gui_page=>get_hotkey_actions( ).
+    INSERT LINES OF lt_hotkey_actions INTO TABLE rt_hotkey_actions.
+
     SORT rt_hotkey_actions.
     DELETE ADJACENT DUPLICATES FROM rt_hotkey_actions.
 
@@ -64,7 +68,8 @@ CLASS zcl_abapgit_hotkeys IMPLEMENTATION.
     DATA: lo_settings                    TYPE REF TO zcl_abapgit_settings,
           lv_class_name                  TYPE abap_abstypename,
           lt_hotkey_actions_of_curr_page TYPE zif_abapgit_gui_page_hotkey=>tty_hotkey_action,
-          lv_save_tabix                  TYPE syst-tabix.
+          lv_save_tabix                  TYPE syst-tabix,
+          lt_hotkey_actions              TYPE zif_abapgit_gui_page_hotkey=>tty_hotkey_action.
 
     FIELD-SYMBOLS: <ls_hotkey>              TYPE zif_abapgit_definitions=>ty_hotkey.
 
@@ -83,6 +88,10 @@ CLASS zcl_abapgit_hotkeys IMPLEMENTATION.
         RETURN.
     ENDTRY.
 
+    " these are the global shortcuts
+    lt_hotkey_actions = zcl_abapgit_gui_page=>get_hotkey_actions( ).
+    INSERT LINES OF lt_hotkey_actions INTO TABLE lt_hotkey_actions_of_curr_page.
+
     LOOP AT rt_hotkeys ASSIGNING <ls_hotkey>.
 
       lv_save_tabix = sy-tabix.
@@ -91,7 +100,7 @@ CLASS zcl_abapgit_hotkeys IMPLEMENTATION.
                                                 WITH TABLE KEY action
                                                 COMPONENTS action = <ls_hotkey>-action.
       IF sy-subrc <> 0.
-        " We only offer hotkeys which are supported by the current page
+        " We only offer hotkeys which are supported by the current page or globally
         DELETE rt_hotkeys INDEX lv_save_tabix.
       ENDIF.
 

--- a/src/zabapgit_js_common.w3mi.data.js
+++ b/src/zabapgit_js_common.w3mi.data.js
@@ -827,7 +827,45 @@ function setLinkHints(sLinkHintKey, sColor) {
 }
 
 function Hotkeys(oKeyMap){
+
+  var that = this;  
   this.oKeyMap = oKeyMap || {};
+
+  // these are the hotkeys provided by the backend
+  Object.keys(this.oKeyMap).forEach(function(sKey){
+
+    var action = that.oKeyMap[sKey]; 
+    
+    // We replace the actions with callback functions to unify
+    // the hotkey execution
+    that.oKeyMap[sKey] = function(oEvent) {
+
+      // We have either a js function
+      if (that[action]) {
+        that[action].call(that);
+        return;
+      }
+      
+      // Or a SAP event
+      var sUiSapEvent = that.getSapEvent(action);
+      if (sUiSapEvent) {
+        submitSapeventForm({}, sUiSapEvent, "post");
+        oEvent.preventDefault();
+        return;
+      }
+
+    }
+
+  });
+
+}
+
+Hotkeys.prototype.showHotkeys = function() {
+  var elHotkeys = document.querySelector('#hotkeys');
+  
+  if (elHotkeys) {
+    elHotkeys.style.display = (elHotkeys.style.display) ? '' : 'none';
+  }
 }
 
 Hotkeys.prototype.getSapEvent = function(sSapEvent) {
@@ -860,20 +898,10 @@ Hotkeys.prototype.onkeydown = function(oEvent){
 
   var 
     sKey = oEvent.key || oEvent.keyCode,
-    oHotkey = this.oKeyMap[sKey];
+    fnHotkey = this.oKeyMap[sKey];
 
-  if (oHotkey) {
-    var sSapEvent = this.getSapEvent(oHotkey);
-    if (sSapEvent) {
-      submitSapeventForm({}, sSapEvent, "post");
-      oEvent.preventDefault();
-    }
-  } else if (sKey === "?" ) {
-    var elHotkeys = document.querySelector('#hotkeys');
-    
-    if (elHotkeys) {
-      elHotkeys.style.display = (elHotkeys.style.display) ? '' : 'none';
-    }
+  if (fnHotkey) {
+    fnHotkey.call(this, oEvent);
   }
 }
 


### PR DESCRIPTION
With this commit we are able to define global hotkeys. Which means
that the hotkey is active on all pages. The global hotkeys are
defined in ZCL_ABAPGIT_GUI_PAGE=>GET_HOTKEY_ACTIONS. The first
globally defined hotkey is the hotkey overview with the default
hotkey '?' assigned to it. This was previously hard coded in the js.

#1728 