### PR TITLE
Fix: hotkey overview close key dynamically #1728

### DIFF
--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -129,7 +129,12 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
                     iv_class = 'close-btn' )
                && '</div></div>' ).
 
-    ro_html->add( |<div class="paddings">Close window with ? or upper right corner X</div>| ).
+    READ TABLE lt_hotkeys ASSIGNING <ls_hotkey>
+                          WITH KEY action = zcl_abapgit_gui_page=>c_global_page_action-showhotkeys.
+    IF sy-subrc = 0.
+      ro_html->add( |<div class="paddings">Close window with '{ <ls_hotkey>-sequence }' |
+                 && |or upper right corner X</div>| ).
+    ENDIF.
 
     " Generate hotkeys
     ro_html->add( |<div class="newslist">| ).

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -4,6 +4,11 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT CREATE PUBLIC.
     INTERFACES:
       zif_abapgit_gui_page.
 
+    CONSTANTS:
+      BEGIN OF c_global_page_action,
+        showhotkeys TYPE string VALUE `showHotkeys` ##NO_TEXT,
+      END OF c_global_page_action.
+
     CLASS-METHODS:
       get_hotkey_actions
         RETURNING
@@ -28,7 +33,6 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT CREATE PUBLIC.
       RAISING   zcx_abapgit_exception.
 
   PRIVATE SECTION.
-
     METHODS html_head
       RETURNING VALUE(ro_html) TYPE REF TO zcl_abapgit_html.
 
@@ -63,7 +67,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page IMPLEMENTATION.
 
 
   METHOD add_hotkeys.
@@ -120,7 +124,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
     DATA: ls_hotkey_action LIKE LINE OF rt_hotkey_actions.
 
     ls_hotkey_action-name           = |Global: Show hotkeys|.
-    ls_hotkey_action-action         = |showHotkeys|.
+    ls_hotkey_action-action         = c_global_page_action-showhotkeys.
     ls_hotkey_action-default_hotkey = |?|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 


### PR DESCRIPTION
As we now can change the hotkey for hotkey overview, we need to take this into 
account when showing the message to close the window.
![image](https://user-images.githubusercontent.com/17437789/44296956-edb4ad00-a2c8-11e8-86c3-44e3ef60648f.png)

#1728 