### PR TITLE
Unable to save variant, #1843

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-TEST
 [![Build Status](https://travis-ci.org/larshp/abapGit.svg?branch=master)](https://travis-ci.org/larshp/abapGit)
 [![abaplint](https://abaplint.org/badges/larshp/abapGit)](https://abaplint.org/project/larshp/abapGit)
 [![Slack](https://abapgit-slackinviter.herokuapp.com/badge.svg)](https://abapgit-slackinviter.herokuapp.com/)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+TEST
 [![Build Status](https://travis-ci.org/larshp/abapGit.svg?branch=master)](https://travis-ci.org/larshp/abapGit)
 [![abaplint](https://abaplint.org/badges/larshp/abapGit)](https://abaplint.org/project/larshp/abapGit)
 [![Slack](https://abapgit-slackinviter.herokuapp.com/badge.svg)](https://abapgit-slackinviter.herokuapp.com/)

--- a/src/ui/zcl_abapgit_gui.clas.abap
+++ b/src/ui/zcl_abapgit_gui.clas.abap
@@ -24,7 +24,7 @@ CLASS zcl_abapgit_gui DEFINITION
 
     CLASS-METHODS set_all_visible
       IMPORTING
-        !visible LIKE cl_gui_control=>visible_true DEFAULT cl_gui_control=>visible_true
+        !visible TYPE char1 DEFAULT cl_gui_control=>visible_true
       RAISING
         zcx_abapgit_exception .
 

--- a/src/ui/zcl_abapgit_gui.clas.abap
+++ b/src/ui/zcl_abapgit_gui.clas.abap
@@ -384,8 +384,7 @@ CLASS zcl_abapgit_gui IMPLEMENTATION.
         EXCEPTIONS
           cntl_error        = 1
           cntl_system_error = 2
-          OTHERS            = 3
-      ).
+          OTHERS            = 3 ).
       IF sy-subrc <> 0.
         zcx_abapgit_exception=>raise( 'Controls error' ).
       ENDIF.

--- a/src/zabapgit.prog.abap
+++ b/src/zabapgit.prog.abap
@@ -55,6 +55,7 @@ START-OF-SELECTION.
 
 * Hide Execute button from screen
 AT SELECTION-SCREEN OUTPUT.
+  zcl_abapgit_gui=>set_all_visible( cl_gui_control=>visible_true ).
   IF sy-dynnr = lcl_password_dialog=>c_dynnr.
     lcl_password_dialog=>on_screen_output( ).
   ELSE.
@@ -66,6 +67,10 @@ AT SELECTION-SCREEN ON EXIT-COMMAND.
   PERFORM exit.
 
 AT SELECTION-SCREEN.
+  IF sscrfields-ucomm = 'SPOS'. " save variant - it's for abapGit background mode
+    zcl_abapgit_gui=>set_all_visible( cl_gui_control=>visible_false ).
+    RETURN.
+  ENDIF.
   IF sy-dynnr = lcl_password_dialog=>c_dynnr.
     lcl_password_dialog=>on_screen_event( sscrfields-ucomm ).
   ENDIF.


### PR DESCRIPTION
Correction of #1843 :
When Save (SPOS) is pressed, make the controls invisible (abapGit HTML), before the system displays the program variant screen.
Before the selection screen is displayed (after leaving the program variant screen), make the controls visible again.
