### PR TITLE
New user exit create_http_client #1841 

### DIFF
--- a/src/zcl_abapgit_exit.clas.abap
+++ b/src/zcl_abapgit_exit.clas.abap
@@ -93,6 +93,16 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_exit~create_http_client.
+
+    TRY.
+        ri_client = gi_exit->create_http_client( iv_url ).
+      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method.
+    ENDTRY.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_exit~http_client.
 
     TRY.

--- a/src/zif_abapgit_exit.intf.abap
+++ b/src/zif_abapgit_exit.intf.abap
@@ -9,14 +9,21 @@ INTERFACE zif_abapgit_exit PUBLIC.
     allow_sap_objects
       RETURNING VALUE(rv_allowed) TYPE abap_bool,
     change_proxy_url
-      IMPORTING iv_repo_url TYPE csequence
+      IMPORTING iv_repo_url  TYPE csequence
       CHANGING  cv_proxy_url TYPE string,
     change_proxy_port
-      IMPORTING iv_repo_url  TYPE csequence
+      IMPORTING iv_repo_url   TYPE csequence
       CHANGING  cv_proxy_port TYPE string,
     change_proxy_authentication
-      IMPORTING iv_repo_url            TYPE csequence
+      IMPORTING iv_repo_url             TYPE csequence
       CHANGING  cv_proxy_authentication TYPE abap_bool,
+    create_http_client
+      IMPORTING
+        iv_url           TYPE string
+      RETURNING
+        VALUE(ri_client) TYPE REF TO if_http_client
+      RAISING
+        zcx_abapgit_exception,
     http_client
       IMPORTING
         ii_client TYPE REF TO if_http_client,


### PR DESCRIPTION
With this commit one can implement the new user exit method
create_http_client for custom http client instantiation.
E.g. to use RFC destinations.

#1841 