### PR TITLE
Longtext serialization for DTEL, DOMA and TABL #1862 

### DIFF
--- a/src/objects/zcl_abapgit_object_doma.clas.abap
+++ b/src/objects/zcl_abapgit_object_doma.clas.abap
@@ -21,6 +21,7 @@ CLASS zcl_abapgit_object_doma DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
            END OF ty_dd07_texts,
            tt_dd01_texts TYPE STANDARD TABLE OF ty_dd01_texts,
            tt_dd07_texts TYPE STANDARD TABLE OF ty_dd07_texts.
+    CONSTANTS: c_longtext_id_doma TYPE dokil-id VALUE 'DO'.
 
     METHODS:
       serialize_texts
@@ -240,6 +241,8 @@ CLASS zcl_abapgit_object_doma IMPLEMENTATION.
 
     ENDTRY.
 
+    delete_longtexts( c_longtext_id_doma ).
+
   ENDMETHOD.
 
 
@@ -285,6 +288,8 @@ CLASS zcl_abapgit_object_doma IMPLEMENTATION.
     deserialize_texts( io_xml   = io_xml
                        is_dd01v = ls_dd01v
                        it_dd07v = lt_dd07v ).
+
+    deserialize_longtexts( io_xml ).
 
     zcl_abapgit_objects_activation=>add_item( ms_item ).
 
@@ -387,6 +392,9 @@ CLASS zcl_abapgit_object_doma IMPLEMENTATION.
                  ig_data = lt_dd07v ).
 
     serialize_texts( io_xml ).
+
+    serialize_longtexts( io_xml         = io_xml
+                         iv_longtext_id = c_longtext_id_doma ).
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -15,6 +15,7 @@ CLASS zcl_abapgit_object_dtel DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
              scrtext_l  TYPE dd04t-scrtext_l,
            END OF ty_dd04_texts,
            tt_dd04_texts TYPE STANDARD TABLE OF ty_dd04_texts.
+    CONSTANTS: c_longtext_id_dtel TYPE dokil-id VALUE 'DE'.
 
     METHODS:
       serialize_texts
@@ -176,6 +177,8 @@ CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'error from RS_DD_DELETE_OBJ, DTEL' ).
     ENDIF.
 
+    delete_longtexts( c_longtext_id_dtel ).
+
   ENDMETHOD.
 
 
@@ -212,6 +215,8 @@ CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
 
     deserialize_texts( io_xml   = io_xml
                        is_dd04v = ls_dd04v ).
+
+    deserialize_longtexts( io_xml ).
 
     zcl_abapgit_objects_activation=>add_item( ms_item ).
 
@@ -332,6 +337,9 @@ CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
                  ig_data = ls_tpara ).
 
     serialize_texts( io_xml ).
+
+    serialize_longtexts( io_xml         = io_xml
+                         iv_longtext_id = c_longtext_id_dtel ).
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -28,12 +28,9 @@ CLASS zcl_abapgit_object_msag DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
       deserialize_texts
         IMPORTING io_xml TYPE REF TO zcl_abapgit_xml_input
         RAISING   zcx_abapgit_exception,
-      serialize_longtexts
+      serialize_longtexts_msag
         IMPORTING it_t100 TYPE zcl_abapgit_object_msag=>tty_t100
                   io_xml  TYPE REF TO zcl_abapgit_xml_output
-        RAISING   zcx_abapgit_exception,
-      deserialize_longtexts
-        IMPORTING io_xml TYPE REF TO zcl_abapgit_xml_input
         RAISING   zcx_abapgit_exception.
 
 ENDCLASS.
@@ -211,8 +208,8 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
     io_xml->add( ig_data = lt_source
                  iv_name = 'T100' ).
 
-    serialize_longtexts( it_t100 = lt_source
-                         io_xml  = io_xml ).
+    serialize_longtexts_msag( it_t100 = lt_source
+                              io_xml  = io_xml ).
 
     serialize_texts( io_xml ).
 
@@ -322,18 +319,14 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD serialize_longtexts.
+  METHOD serialize_longtexts_msag.
 
-    DATA: lv_object    TYPE dokhl-object,
-          lt_objects   TYPE STANDARD TABLE OF dokhl-object
-                            WITH NON-UNIQUE DEFAULT KEY,
-          lt_dokil     TYPE STANDARD TABLE OF dokil
-                            WITH NON-UNIQUE DEFAULT KEY,
-          ls_longtext  TYPE ty_longtext,
-          lt_longtexts TYPE tty_longtexts.
+    DATA: lv_object  TYPE dokhl-object,
+          lt_objects TYPE STANDARD TABLE OF dokhl-object
+                          WITH NON-UNIQUE DEFAULT KEY,
+          lt_dokil   TYPE zif_abapgit_definitions=>tty_dokil.
 
-    FIELD-SYMBOLS: <ls_t100>  TYPE t100,
-                   <ls_dokil> LIKE LINE OF lt_dokil.
+    FIELD-SYMBOLS: <ls_t100>  TYPE t100.
 
     IF lines( it_t100 ) = 0.
       RETURN.
@@ -352,69 +345,9 @@ CLASS zcl_abapgit_object_msag IMPLEMENTATION.
              WHERE id     = 'NA'
              AND   object = lt_objects-table_line.
 
-    LOOP AT lt_dokil ASSIGNING <ls_dokil>
-                     WHERE txtlines > 0.
-
-      CLEAR: ls_longtext.
-
-      ls_longtext-dokil = <ls_dokil>.
-
-      CALL FUNCTION 'DOCU_READ'
-        EXPORTING
-          id      = <ls_dokil>-id
-          langu   = <ls_dokil>-langu
-          object  = <ls_dokil>-object
-          typ     = <ls_dokil>-typ
-          version = <ls_dokil>-version
-        IMPORTING
-          head    = ls_longtext-head
-        TABLES
-          line    = ls_longtext-lines.
-
-      CLEAR: ls_longtext-head-tdfuser,
-             ls_longtext-head-tdfreles,
-             ls_longtext-head-tdfdate,
-             ls_longtext-head-tdftime,
-             ls_longtext-head-tdluser,
-             ls_longtext-head-tdlreles,
-             ls_longtext-head-tdldate,
-             ls_longtext-head-tdltime.
-
-      INSERT ls_longtext INTO TABLE lt_longtexts.
-
-    ENDLOOP.
-
-    io_xml->add( iv_name = 'LONGTEXTS'
-                 ig_data = lt_longtexts ).
+    serialize_longtexts( io_xml   = io_xml
+                         it_dokil = lt_dokil ).
 
   ENDMETHOD.
-
-
-  METHOD deserialize_longtexts.
-
-    DATA: lt_longtexts TYPE tty_longtexts.
-    FIELD-SYMBOLS: <ls_longtext> TYPE zcl_abapgit_object_msag=>ty_longtext.
-
-    io_xml->read(
-      EXPORTING
-        iv_name = 'LONGTEXTS'
-      CHANGING
-        cg_data = lt_longtexts ).
-
-    LOOP AT lt_longtexts ASSIGNING <ls_longtext>.
-
-      CALL FUNCTION 'DOCU_UPDATE'
-        EXPORTING
-          head    = <ls_longtext>-head
-          state   = 'A'
-          typ     = <ls_longtext>-dokil-typ
-          version = <ls_longtext>-dokil-version
-        TABLES
-          line    = <ls_longtext>-lines.
-
-    ENDLOOP.
-
-  ENDMETHOD.
-
 
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_prog.clas.abap
+++ b/src/objects/zcl_abapgit_object_prog.clas.abap
@@ -10,6 +10,7 @@ CLASS zcl_abapgit_object_prog DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
              textpool TYPE zif_abapgit_definitions=>ty_tpool_tt,
            END OF ty_tpool_i18n,
            tt_tpool_i18n TYPE STANDARD TABLE OF ty_tpool_i18n.
+    CONSTANTS: c_longtext_id_prog TYPE dokil-id VALUE 'RE'.
 
     METHODS:
       serialize_texts
@@ -28,7 +29,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_PROG IMPLEMENTATION.
+CLASS zcl_abapgit_object_prog IMPLEMENTATION.
 
 
   METHOD deserialize_texts.
@@ -131,6 +132,8 @@ CLASS ZCL_ABAPGIT_OBJECT_PROG IMPLEMENTATION.
       zcx_abapgit_exception=>raise( |Error from RS_DELETE_PROGRAM: { sy-subrc }| ).
     ENDIF.
 
+    delete_longtexts( c_longtext_id_prog ).
+
   ENDMETHOD.
 
 
@@ -174,6 +177,8 @@ CLASS ZCL_ABAPGIT_OBJECT_PROG IMPLEMENTATION.
 
     " Texts deserializing (translations)
     deserialize_texts( io_xml ).
+
+    deserialize_longtexts( io_xml ).
 
   ENDMETHOD.
 
@@ -241,6 +246,9 @@ CLASS ZCL_ABAPGIT_OBJECT_PROG IMPLEMENTATION.
 
     " Texts serializing (translations)
     serialize_texts( io_xml ).
+
+    serialize_longtexts( io_xml         = io_xml
+                         iv_longtext_id = c_longtext_id_prog ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -3,6 +3,8 @@ CLASS zcl_abapgit_object_tabl DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
   PUBLIC SECTION.
     INTERFACES zif_abapgit_object.
     ALIASES mo_files FOR zif_abapgit_object~mo_files.
+  PRIVATE SECTION.
+    CONSTANTS: c_longtext_id_tabl TYPE dokil-id VALUE 'TB'.
 
 ENDCLASS.
 
@@ -135,6 +137,8 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'error from RS_DD_DELETE_OBJ, TABL' ).
     ENDIF.
 
+    delete_longtexts( c_longtext_id_tabl ).
+
   ENDMETHOD.
 
 
@@ -244,6 +248,8 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
                                            iv_name = lv_tname ).
 
     ENDLOOP.
+
+    deserialize_longtexts( io_xml ).
 
   ENDMETHOD.
 
@@ -521,6 +527,9 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
                  iv_name = 'DD35V_TALE' ).
     io_xml->add( iv_name = 'DD36M'
                  ig_data = lt_dd36m ).
+
+    serialize_longtexts( io_xml         = io_xml
+                         iv_longtext_id = c_longtext_id_tabl ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -47,8 +47,18 @@ CLASS zcl_abapgit_objects_super DEFINITION PUBLIC ABSTRACT.
         RETURNING VALUE(rv_exists_a_lock_entry) TYPE abap_bool
         RAISING   zcx_abapgit_exception,
       set_default_package
-        IMPORTING
-          iv_package TYPE devclass.
+        IMPORTING iv_package TYPE devclass,
+      serialize_longtexts
+        IMPORTING io_xml         TYPE REF TO zcl_abapgit_xml_output
+                  iv_longtext_id TYPE dokil-id OPTIONAL
+                  it_dokil       TYPE zif_abapgit_definitions=>tty_dokil OPTIONAL
+        RAISING   zcx_abapgit_exception,
+      deserialize_longtexts
+        IMPORTING io_xml TYPE REF TO zcl_abapgit_xml_input
+        RAISING   zcx_abapgit_exception,
+      delete_longtexts
+        IMPORTING iv_longtext_id TYPE dokil-id
+        RAISING   zcx_abapgit_exception.
 
   PRIVATE SECTION.
 
@@ -64,6 +74,7 @@ ENDCLASS.
 
 
 CLASS zcl_abapgit_objects_super IMPLEMENTATION.
+
 
   METHOD set_default_package.
 
@@ -136,6 +147,22 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
     ELSEIF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( 'error from RS_CORR_INSERT' ).
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD delete_longtexts.
+
+    zcl_abapgit_longtexts=>delete( iv_longtext_id = iv_longtext_id
+                                   iv_object_name = ms_item-obj_name
+                                   iv_language    = mv_language ).
+
+  ENDMETHOD.
+
+
+  METHOD deserialize_longtexts.
+
+    zcl_abapgit_longtexts=>deserialize( io_xml ).
 
   ENDMETHOD.
 
@@ -330,6 +357,17 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
         resource_failure      = 3
         OTHERS                = 4
         ##fm_subrc_ok.                                                   "#EC CI_SUBRC
+
+  ENDMETHOD.
+
+
+  METHOD serialize_longtexts.
+
+    zcl_abapgit_longtexts=>serialize( iv_object_name = ms_item-obj_name
+                                      iv_longtext_id = iv_longtext_id
+                                      iv_language    = mv_language
+                                      it_dokil       = it_dokil
+                                      io_xml         = io_xml ).
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_longtexts.clas.abap
+++ b/src/zcl_abapgit_longtexts.clas.abap
@@ -1,0 +1,175 @@
+CLASS zcl_abapgit_longtexts DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+    CLASS-METHODS:
+      serialize
+        IMPORTING
+          iv_object_name TYPE sobj_name
+          iv_longtext_id TYPE dokil-id
+          iv_language    TYPE sy-langu
+          it_dokil       TYPE zif_abapgit_definitions=>tty_dokil
+          io_xml         TYPE REF TO zcl_abapgit_xml_output
+        RAISING
+          zcx_abapgit_exception,
+
+      deserialize
+        IMPORTING
+          io_xml TYPE REF TO zcl_abapgit_xml_input
+        RAISING
+          zcx_abapgit_exception,
+
+      delete
+        IMPORTING
+          iv_object_name TYPE sobj_name
+          iv_longtext_id TYPE dokil-id
+          iv_language    TYPE sy-langu
+        RAISING
+          zcx_abapgit_exception.
+
+  PRIVATE SECTION.
+    TYPES:
+      BEGIN OF ty_longtext,
+        dokil TYPE dokil,
+        head  TYPE thead,
+        lines TYPE tline_tab,
+      END OF ty_longtext,
+      tty_longtexts TYPE STANDARD TABLE OF ty_longtext
+                         WITH NON-UNIQUE DEFAULT KEY.
+    CONSTANTS:
+      c_longtexts_name    TYPE string   VALUE 'LONGTEXTS' ##NO_TEXT,
+      c_docu_state_active TYPE dokstate VALUE 'A' ##NO_TEXT.
+
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_longtexts IMPLEMENTATION.
+
+
+  METHOD delete.
+
+    DATA: lt_dokil TYPE zif_abapgit_definitions=>tty_dokil.
+    FIELD-SYMBOLS: <ls_dokil> TYPE dokil.
+
+    SELECT * FROM dokil
+             INTO TABLE lt_dokil
+             WHERE id     = iv_longtext_id
+             AND   object = iv_longtext_id
+             AND   langu  = iv_language.
+
+    LOOP AT lt_dokil ASSIGNING <ls_dokil>.
+
+      CALL FUNCTION 'DOCU_DEL'
+        EXPORTING
+          id       = <ls_dokil>-id
+          langu    = <ls_dokil>-langu
+          object   = <ls_dokil>-object
+          typ      = <ls_dokil>-typ
+        EXCEPTIONS
+          ret_code = 1
+          OTHERS   = 2.
+
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise_t100( ).
+      ENDIF.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD deserialize.
+
+    DATA: lt_longtexts TYPE tty_longtexts.
+    FIELD-SYMBOLS: <ls_longtext> TYPE ty_longtext.
+
+    io_xml->read(
+      EXPORTING
+        iv_name = c_longtexts_name
+      CHANGING
+        cg_data = lt_longtexts ).
+
+    LOOP AT lt_longtexts ASSIGNING <ls_longtext>.
+
+      CALL FUNCTION 'DOCU_UPDATE'
+        EXPORTING
+          head    = <ls_longtext>-head
+          state   = c_docu_state_active
+          typ     = <ls_longtext>-dokil-typ
+          version = <ls_longtext>-dokil-version
+        TABLES
+          line    = <ls_longtext>-lines.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD serialize.
+
+    DATA: ls_longtext  TYPE ty_longtext,
+          lt_longtexts TYPE tty_longtexts.
+    DATA: lt_dokil       TYPE zif_abapgit_definitions=>tty_dokil,
+          lv_longtext_id TYPE dokil-id.
+
+    FIELD-SYMBOLS: <ls_dokil> LIKE LINE OF lt_dokil.
+
+
+    IF lines( it_dokil ) > 0.
+
+      lt_dokil = it_dokil.
+
+    ELSEIF iv_longtext_id IS NOT INITIAL.
+
+      SELECT * FROM dokil
+              INTO TABLE lt_dokil
+              WHERE id     = iv_longtext_id
+              AND   object = iv_object_name
+              AND   langu  = iv_language.
+
+    ELSE.
+
+      zcx_abapgit_exception=>raise( |serialize_longtexts parameter error| ).
+
+    ENDIF.
+
+    LOOP AT lt_dokil ASSIGNING <ls_dokil>
+                     WHERE txtlines > 0.
+
+      CLEAR: ls_longtext.
+
+      ls_longtext-dokil = <ls_dokil>.
+
+      CALL FUNCTION 'DOCU_READ'
+        EXPORTING
+          id      = <ls_dokil>-id
+          langu   = <ls_dokil>-langu
+          object  = <ls_dokil>-object
+          typ     = <ls_dokil>-typ
+          version = <ls_dokil>-version
+        IMPORTING
+          head    = ls_longtext-head
+        TABLES
+          line    = ls_longtext-lines.
+
+      CLEAR: ls_longtext-head-tdfuser,
+             ls_longtext-head-tdfreles,
+             ls_longtext-head-tdfdate,
+             ls_longtext-head-tdftime,
+             ls_longtext-head-tdluser,
+             ls_longtext-head-tdlreles,
+             ls_longtext-head-tdldate,
+             ls_longtext-head-tdltime.
+
+      INSERT ls_longtext INTO TABLE lt_longtexts.
+
+    ENDLOOP.
+
+    io_xml->add( iv_name = c_longtexts_name
+                 ig_data = lt_longtexts ).
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zcl_abapgit_longtexts.clas.xml
+++ b/src/zcl_abapgit_longtexts.clas.xml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_LONGTEXTS</CLSNAME>
+    <VERSION>1</VERSION>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit long text serialization/deserialization</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <CLSFINAL>X</CLSFINAL>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -344,6 +344,10 @@ INTERFACE zif_abapgit_definitions PUBLIC.
            hotkeys                    TYPE tty_hotkey,
          END OF ty_s_user_settings.
 
+  TYPES:
+          tty_dokil TYPE STANDARD TABLE OF dokil
+                         WITH NON-UNIQUE DEFAULT KEY.
+
   CONSTANTS:
     BEGIN OF c_type,
       commit TYPE zif_abapgit_definitions=>ty_type VALUE 'commit', "#EC NOTEXT


### PR DESCRIPTION
This commit adds three new methods to ZCL_ABAPGIT_OBJECTS_SUPER:
- SERIALIZE_LONGTEXTS
- DESERIALIZE_LONGTEXTS
- DELETE_LONGTEXTS

They can be called on demand in concrete object type serializers.

In this commit they were called from DTEL, DOMA and TABL

#1862 