### PR TITLE
Avoid use of the RS package in BASIS systems

### DIFF
--- a/src/objects/zcl_abapgit_objects_generic.clas.abap
+++ b/src/objects/zcl_abapgit_objects_generic.clas.abap
@@ -117,7 +117,7 @@ CLASS ZCL_ABAPGIT_OBJECTS_GENERIC IMPLEMENTATION.
     FIELD-SYMBOLS <ls_object_method> LIKE LINE OF mt_object_method.
 
 
-    ls_cts_object_entry-pgmid    = rs_c_pgmid_r3tr.
+    ls_cts_object_entry-pgmid    = seok_pgmid_r3tr.
     ls_cts_object_entry-object   = ms_item-obj_type.
     ls_cts_object_entry-obj_name = ms_item-obj_name.
     INSERT ls_cts_object_entry INTO TABLE lt_cts_object_entry.
@@ -160,7 +160,7 @@ CLASS ZCL_ABAPGIT_OBJECTS_GENERIC IMPLEMENTATION.
     IF sy-subrc = 0.
       lv_client = sy-mandt.
 
-      ls_cts_object_entry-pgmid    = rs_c_pgmid_r3tr.
+      ls_cts_object_entry-pgmid    = seok_pgmid_r3tr.
       ls_cts_object_entry-object   = ms_item-obj_type.
       ls_cts_object_entry-obj_name = ms_item-obj_name.
       INSERT ls_cts_object_entry INTO TABLE lt_cts_object_entry.

--- a/src/objects/zcl_abapgit_objects_generic.clas.abap
+++ b/src/objects/zcl_abapgit_objects_generic.clas.abap
@@ -545,9 +545,9 @@ CLASS ZCL_ABAPGIT_OBJECTS_GENERIC IMPLEMENTATION.
         CONTINUE.
       ENDIF.
       IF ls_objkey-value = '*'.
-        lv_is_asterix = rs_c_true.
+        lv_is_asterix = abap_true.
       ENDIF.
-      IF lv_is_asterix = rs_c_true.
+      IF lv_is_asterix = abap_true.
         CONTINUE.
       ENDIF.
       IF NOT lv_where_statement IS INITIAL.


### PR DESCRIPTION
I managed to create a user in our BASIS system and successfully ran abapGit there. I just committed a report and pulled few classes, dcls and ddls. Unfortunately, one DDLS could not be pulled but I have no idea why and I don't find it relevant.

I had to replace two constants from the package RS with some other constants. Please, take a look at the commits.

Related to #1826 