### PR TITLE
1.76.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,17 @@ Legend
 + : added
 - : removed
 
+2018-09-08 v1.76.0
+------------------
++ git patch, added to staging page
++ serialize all longtexts
++ ENQU clear redundant fields
+* suppress SHMA package popup
+* branch overview sorted by parent instead of time
+* handle error from RS_CUA_INTERNAL_FETCH
+* fix problem with branch list from bitbucket.org
+* allow empty blobs
+
 2018-08-12 v1.75.0
 ------------------
 + User exit CREATE_HTTP_CLIENT

--- a/src/zif_abapgit_version.intf.abap
+++ b/src/zif_abapgit_version.intf.abap
@@ -2,6 +2,6 @@ INTERFACE zif_abapgit_version
   PUBLIC .
 
   CONSTANTS gc_xml_version TYPE string VALUE 'v1.0.0' ##NO_TEXT.
-  CONSTANTS gc_abap_version TYPE string VALUE '1.75.0' ##NO_TEXT.
+  CONSTANTS gc_abap_version TYPE string VALUE '1.76.0' ##NO_TEXT.
 
 ENDINTERFACE.


### PR DESCRIPTION
git patch, added to staging page
serialize all longtexts
ENQU clear redundant fields
suppress SHMA package popup
branch overview sorted by parent instead of time
handle error from RS_CUA_INTERNAL_FETCH
fix problem with branch list from bitbucket.org
allow empty blobs