### PR TITLE
Syntax error in ZCL_ABAPGIT_BRANCH_OVERVIEW (only on 731 SP7) #1914

### DIFF
--- a/src/zcl_abapgit_branch_overview.clas.abap
+++ b/src/zcl_abapgit_branch_overview.clas.abap
@@ -59,9 +59,8 @@ CLASS zcl_abapgit_branch_overview DEFINITION
     METHODS _get_1st_child_commit
       IMPORTING itr_commit_sha1s    TYPE tyt_commit_sha1_range
       EXPORTING etr_commit_sha1s    TYPE tyt_commit_sha1_range
-      CHANGING  ct_commits          TYPE ty_commits
-      RETURNING VALUE(e_1st_commit) TYPE zif_abapgit_definitions=>ty_commit.
-
+                e_1st_commit        TYPE zif_abapgit_definitions=>ty_commit
+      CHANGING  ct_commits          TYPE ty_commits.
 
 ENDCLASS.
 
@@ -490,8 +489,8 @@ CLASS zcl_abapgit_branch_overview IMPLEMENTATION.
       DO.
         _get_1st_child_commit( EXPORTING itr_commit_sha1s = ltr_parents
                                IMPORTING etr_commit_sha1s = ltr_parents
-                               CHANGING  ct_commits       = ct_commits
-                               RECEIVING e_1st_commit     = lv_next_commit ).
+                                         e_1st_commit     = lv_next_commit
+                               CHANGING  ct_commits       = ct_commits ).
         IF lv_next_commit IS INITIAL.
           EXIT. "DO
         ENDIF.


### PR DESCRIPTION
fix RETURNING with EXPORT/CHANGING <740 SP2