### PR TITLE
fixed issue #1799 (dump for  < or > in attributes)

### DIFF
--- a/src/syntax/zcl_abapgit_syntax_xml.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_xml.clas.abap
@@ -19,7 +19,9 @@ CLASS zcl_abapgit_syntax_xml DEFINITION
       END OF c_token .
     CONSTANTS:
       BEGIN OF c_regex,
-        xml_tag  TYPE string VALUE '[<>]',                  "#EC NOTEXT
+        "for XML tags, we will use a submatch
+        " main pattern includes quoted strings so we can ignore < and > in attr values
+        xml_tag  TYPE string VALUE '(?:"[^"]*")|([<>])',    "#EC NOTEXT
         attr     TYPE string VALUE '\s[-a-z:_0-9]+\s*(?==)', "#EC NOTEXT
         attr_val TYPE string VALUE '["''][^''"]*[''"]',     "#EC NOTEXT
       END OF c_regex .
@@ -42,9 +44,10 @@ CLASS zcl_abapgit_syntax_xml IMPLEMENTATION.
 
     " Initialize instances of regular expressions
 
-    add_rule( iv_regex = c_regex-xml_tag
-              iv_token = c_token-xml_tag
-              iv_style = c_css-xml_tag ).
+    add_rule( iv_regex    = c_regex-xml_tag
+              iv_token    = c_token-xml_tag
+              iv_style    = c_css-xml_tag
+              iv_submatch = 1 ).
 
     add_rule( iv_regex = c_regex-attr
               iv_token = c_token-attr
@@ -113,6 +116,19 @@ CLASS zcl_abapgit_syntax_xml IMPLEMENTATION.
       lv_prev_token = <ls_match>-token.
       ASSIGN <ls_match> TO <ls_prev>.
     ENDLOOP.
+
+    "if the last XML tag is not closed, extend it to the end of the tag
+    IF    lv_prev_token = c_token-xml_tag
+      AND <ls_prev> IS ASSIGNED
+      AND <ls_prev>-length  = 1
+      AND <ls_prev>-text_tag = '<'.
+
+      FIND REGEX '<\s*[^\s]*' IN iv_line+<ls_prev>-offset MATCH LENGTH <ls_prev>-length.
+      IF sy-subrc <> 0.
+        <ls_prev>-length = 1.
+      ENDIF.
+
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
on top of a new regular expression I added support for submatches.

If relevant_submatch is not 0, a match is only reported if the relevant submatch has length > 0

Also, I added code to highlight XML tags which don't close on the line they open
I noticed a potential problem in attributes starting on a new line (regex starts with \s, so if not indented they're not recognised) but decided to leave those alone, worst case they won't be highlighted 

![image](https://user-images.githubusercontent.com/2453277/45540880-7447a600-b805-11e8-8aa6-8309f27b9067.png)
