### PR TITLE
Issue #1866 #790 hack for java sapgui

### DIFF
--- a/src/ui/zcl_abapgit_gui.clas.abap
+++ b/src/ui/zcl_abapgit_gui.clas.abap
@@ -412,12 +412,12 @@ CLASS zcl_abapgit_gui IMPLEMENTATION.
         ENDIF.
 
         "split rest in postdata format
-        WHILE rest <> ''.
+        WHILE pdata <> ''.
           APPEND INITIAL LINE TO postdata ASSIGNING <postdata>.
-          <postdata> = rest.
+          <postdata> = pdata.
           DESCRIBE FIELD <postdata> LENGTH pdatalen IN CHARACTER MODE.
-          IF strlen( rest ) >= pdatalen.
-            rest = rest+pdatalen.
+          IF strlen( pdata ) >= pdatalen.
+            pdata = pdata+pdatalen.
           ELSE.
             EXIT.
           ENDIF.

--- a/src/ui/zcl_abapgit_gui.clas.abap
+++ b/src/ui/zcl_abapgit_gui.clas.abap
@@ -76,7 +76,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
+CLASS zcl_abapgit_gui IMPLEMENTATION.
 
 
   METHOD back.
@@ -278,12 +278,39 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
 
 
   METHOD on_event.
+    DATA: lv_action(400) TYPE c,
+          lt_postdata    LIKE postdata,
+          lv_match       TYPE string,
+          lv_ofs TYPE i,
+          lv_len TYPE i,
+          lv_temp TYPE string.
+
+    FIELD-SYMBOLS: <postdata> LIKE LINE OF lt_postdata.
+
+    lv_action = action.
+    lt_postdata = postdata.
+    "hack for java webgui support
+    IF action = '__abapgit_dummy__'.
+      LOOP AT lt_postdata ASSIGNING <postdata>.
+        FIND REGEX '__ABAPGIT_ACTION=([^\s&]+)&?' IN <postdata> SUBMATCHES lv_match MATCH LENGTH lv_len MATCH OFFSET lv_ofs.
+        IF sy-subrc = 0.
+          if lv_ofs > 0.
+            lv_temp = <postdata>(lv_ofs).
+          endif.
+          lv_ofs = lv_ofs + lv_len.
+          CONCATENATE lv_temp <postdata>+lv_ofs into <postdata>.
+          lv_action = lv_match.
+          exit.
+        ENDIF.
+
+      ENDLOOP.
+    ENDIF.
 
     handle_action(
-      iv_action      = action
+      iv_action      = lv_action
       iv_frame       = frame
       iv_getdata     = getdata
-      it_postdata    = postdata
+      it_postdata    = lt_postdata
       it_query_table = query_table ).
 
   ENDMETHOD.                    "on_event

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -14,31 +14,24 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT CREATE PUBLIC.
         RETURNING
           VALUE(rt_hotkey_actions) TYPE zif_abapgit_gui_page_hotkey=>tty_hotkey_action.
 
-protected section.
+  PROTECTED SECTION.
 
-  types:
-    BEGIN OF ty_control,
+    TYPES: BEGIN OF ty_control,
              redirect_url TYPE string,
              page_title   TYPE string,
              page_menu    TYPE REF TO zcl_abapgit_html_toolbar,
-           END OF  ty_control .
+           END OF  ty_control.
 
-  data MS_CONTROL type TY_CONTROL .
+    DATA: ms_control TYPE ty_control.
 
-  methods DUMMY_HIDDEN_FORM
-    returning
-      value(RO_HTML) type STRING .
-  methods RENDER_CONTENT
-  abstract
-    returning
-      value(RO_HTML) type ref to ZCL_ABAPGIT_HTML
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods SCRIPTS
-    returning
-      value(RO_HTML) type ref to ZCL_ABAPGIT_HTML
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
+    METHODS render_content ABSTRACT
+      RETURNING VALUE(ro_html) TYPE REF TO zcl_abapgit_html
+      RAISING   zcx_abapgit_exception.
+
+    METHODS scripts
+      RETURNING VALUE(ro_html) TYPE REF TO zcl_abapgit_html
+      RAISING   zcx_abapgit_exception.
+
   PRIVATE SECTION.
     METHODS html_head
       RETURNING VALUE(ro_html) TYPE REF TO zcl_abapgit_html.
@@ -76,11 +69,15 @@ protected section.
       RAISING
         zcx_abapgit_exception.
 
+    METHODS dummy_hidden_form
+      RETURNING
+        value(rv_html) TYPE string.
+
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page IMPLEMENTATION.
 
 
   METHOD add_hotkeys.
@@ -109,35 +106,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
     io_html->add( |setKeyBindings({ lv_json });| ).
 
   ENDMETHOD.
-
-
-  METHOD call_browser.
-
-    cl_gui_frontend_services=>execute(
-      EXPORTING
-        document               = |{ iv_url }|
-      EXCEPTIONS
-        cntl_error             = 1
-        error_no_gui           = 2
-        bad_parameter          = 3
-        file_not_found         = 4
-        path_not_found         = 5
-        file_extension_unknown = 6
-        error_execute_failed   = 7
-        synchronous_failed     = 8
-        not_supported_by_gui   = 9
-        OTHERS                 = 10 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise_t100( ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  method DUMMY_HIDDEN_FORM.
-    ro_html = '<form id="__ABAPGIT_EVENT_DUMMY__" method="POST" action="sapevent:__abapgit_dummy__"></form>'.
-  endmethod.
 
 
   METHOD footer.
@@ -331,4 +299,34 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
     ro_html->add( '</html>' ).                              "#EC NOTEXT
 
   ENDMETHOD.  " lif_gui_page~render.
+
+  METHOD call_browser.
+
+    cl_gui_frontend_services=>execute(
+      EXPORTING
+        document               = |{ iv_url }|
+      EXCEPTIONS
+        cntl_error             = 1
+        error_no_gui           = 2
+        bad_parameter          = 3
+        file_not_found         = 4
+        path_not_found         = 5
+        file_extension_unknown = 6
+        error_execute_failed   = 7
+        synchronous_failed     = 8
+        not_supported_by_gui   = 9
+        OTHERS                 = 10 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD dummy_hidden_form.
+    rv_html = '<form id="__ABAPGIT_EVENT_DUMMY__" method="POST" action="sapevent:__abapgit_dummy__"></form>'.
+  ENDMETHOD.
+
 ENDCLASS.
+

--- a/src/zabapgit_js_common.w3mi.data.js
+++ b/src/zabapgit_js_common.w3mi.data.js
@@ -62,7 +62,12 @@ function debugOutput(text, dstID) {
 // Find/Create hidden form and submit with sapevent
 function submitSapeventForm(params, action, method) {
   var dummyid = "__ABAPGIT_EVENT_DUMMY__";
-  var form = document.getElementById(dummyid);
+  var form;
+  //for get create a dynamic form on the fly
+  //for post use the static one in the page if found to work around sapgui java bugs
+  if (!method || method.toLowerCase() !== "get") {
+    form = document.getElementById(dummyid);
+  }
   if (form) {
     while (form.firstChild) form.removeChild(form.firstChild);
     //java gui breaks if we change the form action, so we pass it as a form field instead

--- a/src/zabapgit_js_common.w3mi.data.js
+++ b/src/zabapgit_js_common.w3mi.data.js
@@ -63,9 +63,11 @@ function debugOutput(text, dstID) {
 function submitSapeventForm(params, action, method) {
   var dummyid = "__ABAPGIT_EVENT_DUMMY__";
   var form;
-  //for get create a dynamic form on the fly
-  //for post use the static one in the page if found to work around sapgui java bugs
-  if (!method || method.toLowerCase() !== "get") {
+  //SAPGUI java does not send postdata if we change the post action
+  //so if the method is not get and we have parameters we use a form with a constant ID
+  //already embedded in the page and pass the action as a parameter
+  //if not we create a new form and use that
+  if ((!method || method.toLowerCase() !== "get") && Object.keys(params).length > 0) {
     form = document.getElementById(dummyid);
   }
   if (form) {
@@ -78,7 +80,7 @@ function submitSapeventForm(params, action, method) {
     form.appendChild(hiddenField);
   }
   else {
-    //no dummy form in page, create one. Won'r work in java GUI
+    //no dummy form selected in page, create one
     form = document.createElement("form");
     form.setAttribute("action", "sapevent:" + action);
     form.setAttribute("method", method || "post");

--- a/src/zabapgit_js_common.w3mi.data.js
+++ b/src/zabapgit_js_common.w3mi.data.js
@@ -59,13 +59,27 @@ function debugOutput(text, dstID) {
   stdout.innerHTML = stdout.innerHTML + wrapped;
 }
 
-// Create hidden form and submit with sapevent
+// Find/Create hidden form and submit with sapevent
 function submitSapeventForm(params, action, method) {
-  var form = document.createElement("form");
-  form.setAttribute("method", method || "post");
-  form.setAttribute("action", "sapevent:" + action);
-  
-  for(var key in params) {
+  var dummyid = "__ABAPGIT_EVENT_DUMMY__";
+  var form = document.getElementById(dummyid);
+  if (form) {
+    while (form.firstChild) form.removeChild(form.firstChild);
+    //java gui breaks if we change the form action, so we pass it as a form field instead
+    var hiddenField = document.createElement("input");
+    hiddenField.setAttribute("type", "hidden");
+    hiddenField.setAttribute("name", "__ABAPGIT_ACTION");
+    hiddenField.setAttribute("value", action);
+    form.appendChild(hiddenField);
+  }
+  else {
+    //no dummy form in page, create one. Won'r work in java GUI
+    form = document.createElement("form");
+    form.setAttribute("action", "sapevent:" + action);
+    form.setAttribute("method", method || "post");
+  }
+
+  for (var key in params) {
     var hiddenField = document.createElement("input");
     hiddenField.setAttribute("type", "hidden");
     hiddenField.setAttribute("name", key);
@@ -73,7 +87,8 @@ function submitSapeventForm(params, action, method) {
     form.appendChild(hiddenField);
   }
 
-  document.body.appendChild(form);
+  if (form.id !== dummyid)
+    document.body.appendChild(form);//new form created, add it to body
   form.submit();
 }
 

--- a/src/zabapgit_js_common.w3mi.xml
+++ b/src/zabapgit_js_common.w3mi.xml
@@ -15,13 +15,13 @@
      <RELID>MI</RELID>
      <OBJID>ZABAPGIT_JS_COMMON</OBJID>
      <NAME>filename</NAME>
-     <VALUE>common.js</VALUE>
+     <VALUE>~wwwtmp.js</VALUE>
     </WWWPARAMS>
     <WWWPARAMS>
      <RELID>MI</RELID>
      <OBJID>ZABAPGIT_JS_COMMON</OBJID>
      <NAME>mimetype</NAME>
-     <VALUE>text/javascript</VALUE>
+     <VALUE>application/javascript</VALUE>
     </WWWPARAMS>
    </PARAMS>
   </asx:values>


### PR DESCRIPTION
After a lot of troubleshooting I found out the issue is a bug in the embedded browser.

With either a dynamically added form or an existing one, after we do a 

`form.setAttribute("action", "sapevent:" + action);`

post breaks (get would still work, up to 2048 char of payload).

So the proposed solution is:

- embed a form with a known ID and dummy action in the page
- look it up with a getElementById (fall back to create if not found)
- add an extra hidden field with the actual action requested
- when the GUI recognizes the dummy action, it extracts it from postdata 
- passes down a cleaned postdata with the action requested in javascript 

PS: just realised I don't handle gets properly, will fix it ASAP, don't bother reviewing before that but please let me know if you think it's too cumbersome for the few java gui users
