### PR TITLE
UI: 2 step ZIP import

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_diff.clas.abap
@@ -773,12 +773,14 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
 
     " New line
     lv_mark = ` `.
-    IF iv_fstate = c_fstate-both OR is_diff_line-result = zif_abapgit_definitions=>c_diff-update.
-      lv_bg = ' diff_upd'.
-      lv_mark = `~`.
-    ELSEIF is_diff_line-result = zif_abapgit_definitions=>c_diff-insert.
-      lv_bg = ' diff_ins'.
-      lv_mark = `+`.
+    IF is_diff_line-result IS NOT INITIAL.
+      IF iv_fstate = c_fstate-both OR is_diff_line-result = zif_abapgit_definitions=>c_diff-update.
+        lv_bg = ' diff_upd'.
+        lv_mark = `~`.
+      ELSEIF is_diff_line-result = zif_abapgit_definitions=>c_diff-insert.
+        lv_bg = ' diff_ins'.
+        lv_mark = `+`.
+      ENDIF.
     ENDIF.
     lv_new = |<td class="num" line-num="{ is_diff_line-new_num }"></td>|
           && |<td class="code{ lv_bg }">{ lv_mark }{ is_diff_line-new }</td>|.
@@ -790,12 +792,14 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
     " Old line
     CLEAR lv_bg.
     lv_mark = ` `.
-    IF iv_fstate = c_fstate-both OR is_diff_line-result = zif_abapgit_definitions=>c_diff-update.
-      lv_bg = ' diff_upd'.
-      lv_mark = `~`.
-    ELSEIF is_diff_line-result = zif_abapgit_definitions=>c_diff-delete.
-      lv_bg = ' diff_del'.
-      lv_mark = `-`.
+    IF is_diff_line-result IS NOT INITIAL.
+      IF iv_fstate = c_fstate-both OR is_diff_line-result = zif_abapgit_definitions=>c_diff-update.
+        lv_bg = ' diff_upd'.
+        lv_mark = `~`.
+      ELSEIF is_diff_line-result = zif_abapgit_definitions=>c_diff-delete.
+        lv_bg = ' diff_del'.
+        lv_mark = `-`.
+      ENDIF.
     ENDIF.
     lv_old = |<td class="num" line-num="{ is_diff_line-old_num }"></td>|
           && |<td class="code{ lv_bg }">{ lv_mark }{ is_diff_line-old }</td>|.

--- a/src/ui/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_diff.clas.abap
@@ -163,7 +163,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
 
 
   METHOD add_to_stage.
@@ -424,7 +424,7 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
     DATA: lt_remote TYPE zif_abapgit_definitions=>ty_files_tt,
           lt_local  TYPE zif_abapgit_definitions=>ty_files_item_tt,
           lt_status TYPE zif_abapgit_definitions=>ty_results_tt,
-          lo_repo   TYPE REF TO zcl_abapgit_repo_online,
+          lo_repo   TYPE REF TO zcl_abapgit_repo,
           lv_ts     TYPE timestamp.
 
     FIELD-SYMBOLS: <ls_status> LIKE LINE OF lt_status.
@@ -446,7 +446,7 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
 
     ASSERT is_file IS INITIAL OR is_object IS INITIAL. " just one passed
 
-    lo_repo  ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
+    lo_repo   = zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
     lt_remote = lo_repo->get_files_remote( ).
     lt_local  = lo_repo->get_files_local( ).
     lt_status = lo_repo->status( ).
@@ -486,6 +486,40 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
     ENDIF.
 
     ms_control-page_menu  = build_menu( ).
+
+  ENDMETHOD.
+
+
+  METHOD get_diff_line.
+
+    DATA: lt_diff       TYPE zif_abapgit_definitions=>ty_diffs_tt,
+          lv_line_index TYPE sytabix.
+
+    FIELD-SYMBOLS: <ls_diff> LIKE LINE OF lt_diff.
+
+    lv_line_index = iv_line_index.
+    lt_diff = io_diff->get( ).
+
+    READ TABLE lt_diff INTO rs_diff
+                       INDEX lv_line_index.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Invalid line index { lv_line_index }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD get_diff_object.
+
+    FIELD-SYMBOLS: <ls_diff_file> LIKE LINE OF mt_diff_files.
+
+    READ TABLE mt_diff_files ASSIGNING <ls_diff_file>
+                             WITH KEY filename = iv_filename.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Invalid filename { iv_filename }| ).
+    ENDIF.
+
+    ro_diff = <ls_diff_file>-o_diff.
 
   ENDMETHOD.
 
@@ -1039,38 +1073,4 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
     ENDCASE.
 
   ENDMETHOD.
-
-  METHOD get_diff_object.
-
-    FIELD-SYMBOLS: <ls_diff_file> LIKE LINE OF mt_diff_files.
-
-    READ TABLE mt_diff_files ASSIGNING <ls_diff_file>
-                             WITH KEY filename = iv_filename.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Invalid filename { iv_filename }| ).
-    ENDIF.
-
-    ro_diff = <ls_diff_file>-o_diff.
-
-  ENDMETHOD.
-
-
-  METHOD get_diff_line.
-
-    DATA: lt_diff       TYPE zif_abapgit_definitions=>ty_diffs_tt,
-          lv_line_index TYPE sytabix.
-
-    FIELD-SYMBOLS: <ls_diff> LIKE LINE OF lt_diff.
-
-    lv_line_index = iv_line_index.
-    lt_diff = io_diff->get( ).
-
-    READ TABLE lt_diff INTO rs_diff
-                       INDEX lv_line_index.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Invalid line index { lv_line_index }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_view_repo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_view_repo.clas.abap
@@ -106,7 +106,7 @@ CLASS zcl_abapgit_gui_view_repo IMPLEMENTATION.
 
     CREATE OBJECT ro_toolbar.
 
-    IF mo_repo->is_offline( ) = abap_false.
+    IF mo_repo->is_offline( ) = abap_false or mo_repo->has_remote( ) = abap_true.
       ro_toolbar->add(  " Show/Hide files
         iv_txt = 'Show files'
         iv_chk = boolc( NOT mv_hide_files = abap_true )
@@ -556,6 +556,7 @@ CLASS zcl_abapgit_gui_view_repo IMPLEMENTATION.
         ev_state        = zif_abapgit_definitions=>c_event_state-re_render.
       WHEN c_actions-zip_import2_apply.
         zcl_abapgit_services_repo=>gui_deserialize( mo_repo ).
+        mo_repo->reset_remote( ).
         ev_state        = zif_abapgit_definitions=>c_event_state-re_render.
     ENDCASE.
 

--- a/src/ui/zcl_abapgit_gui_view_repo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_view_repo.clas.abap
@@ -84,7 +84,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_view_repo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_VIEW_REPO IMPLEMENTATION.
 
 
   METHOD build_dir_jump_link.
@@ -106,7 +106,7 @@ CLASS zcl_abapgit_gui_view_repo IMPLEMENTATION.
 
     CREATE OBJECT ro_toolbar.
 
-    IF mo_repo->is_offline( ) = abap_false or mo_repo->has_remote( ) = abap_true.
+    IF mo_repo->has_remote( ) = abap_true.
       ro_toolbar->add(  " Show/Hide files
         iv_txt = 'Show files'
         iv_chk = boolc( NOT mv_hide_files = abap_true )
@@ -301,10 +301,6 @@ CLASS zcl_abapgit_gui_view_repo IMPLEMENTATION.
     super->constructor( ).
 
     mo_repo         = zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
-    IF mo_repo->is_offline( ) = abap_true.
-      mo_repo->reset_remote( ). " reset on new "show" if ZIP was loaded
-    ENDIF.
-
     mv_cur_dir      = '/'. " Root
     mv_hide_files   = zcl_abapgit_persistence_user=>get_instance( )->get_hide_files( ).
     mv_changes_only = zcl_abapgit_persistence_user=>get_instance( )->get_changes_only( ).
@@ -423,7 +419,7 @@ CLASS zcl_abapgit_gui_view_repo IMPLEMENTATION.
       ENDIF.
     ENDIF.
 
-    IF mo_repo->is_offline( ) = abap_false OR mo_repo->has_remote( ) = abap_true.
+    IF mo_repo->has_remote( ) = abap_true.
 
       " Files
       ro_html->add( '<td class="files">' ).
@@ -527,6 +523,11 @@ CLASS zcl_abapgit_gui_view_repo IMPLEMENTATION.
     ro_html->add( '</tr>' ).
 
   ENDMETHOD. "render_parent_dir
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
+
+  ENDMETHOD.
 
 
   METHOD zif_abapgit_gui_page~on_event.
@@ -656,10 +657,4 @@ CLASS zcl_abapgit_gui_view_repo IMPLEMENTATION.
     ENDTRY.
 
   ENDMETHOD.  "lif_gui_page~render
-
-
-  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -368,35 +368,6 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD has_remote.
-    rv_yes = boolc( lines( mt_remote ) > 0 ).
-  ENDMETHOD.
-
-
-  METHOD reset_remote.
-    CLEAR mt_remote.
-    reset_status( ).
-  ENDMETHOD.
-
-
-  METHOD reset_status.
-    CLEAR mt_status.
-  ENDMETHOD.  " reset_status.
-
-
-  METHOD status.
-
-    IF lines( mt_status ) = 0.
-      mt_status = zcl_abapgit_file_status=>status(
-        io_repo = me
-        io_log  = io_log ).
-    ENDIF.
-
-    rt_results = mt_status.
-
-  ENDMETHOD.
-
-
   METHOD get_key.
     rv_key = ms_data-key.
   ENDMETHOD.                    "get_key
@@ -440,6 +411,11 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
   METHOD get_package.
     rv_package = ms_data-package.
   ENDMETHOD.                    "get_package
+
+
+  METHOD has_remote.
+    rv_yes = boolc( lines( mt_remote ) > 0 ).
+  ENDMETHOD.
 
 
   METHOD is_offline.
@@ -487,12 +463,24 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
   METHOD refresh.
 
     mv_do_local_refresh = abap_true.
+    reset_remote( ).
 
     IF iv_drop_cache = abap_true.
       CLEAR: mv_last_serialization, mt_local.
     ENDIF.
 
   ENDMETHOD.                    "refresh
+
+
+  METHOD reset_remote.
+    CLEAR mt_remote.
+    reset_status( ).
+  ENDMETHOD.
+
+
+  METHOD reset_status.
+    CLEAR mt_status.
+  ENDMETHOD.  " reset_status.
 
 
   METHOD run_code_inspector.
@@ -616,6 +604,19 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
   METHOD set_local_settings.
 
     set( is_local_settings = is_settings ).
+
+  ENDMETHOD.
+
+
+  METHOD status.
+
+    IF lines( mt_status ) = 0.
+      mt_status = zcl_abapgit_file_status=>status(
+        io_repo = me
+        io_log  = io_log ).
+    ENDIF.
+
+    rt_results = mt_status.
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -125,7 +125,9 @@ CLASS zcl_abapgit_repo DEFINITION
     DATA mv_last_serialization TYPE timestamp .
     DATA ms_data TYPE zif_abapgit_persistence=>ty_repo .
     DATA mv_code_inspector_successful TYPE abap_bool .
+    DATA mt_status TYPE zif_abapgit_definitions=>ty_results_tt .
 
+    METHODS reset_status .
     METHODS set
       IMPORTING
         !it_checksums       TYPE zif_abapgit_persistence=>ty_local_checksum_tt OPTIONAL
@@ -372,15 +374,25 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
 
   METHOD reset_remote.
-    clear mt_remote.
+    CLEAR mt_remote.
+    reset_status( ).
   ENDMETHOD.
+
+
+  METHOD reset_status.
+    CLEAR mt_status.
+  ENDMETHOD.  " reset_status.
 
 
   METHOD status.
 
-    rt_results = zcl_abapgit_file_status=>status(
-      io_repo = me
-      io_log  = io_log ). " No caching by default
+    IF lines( mt_status ) = 0.
+      mt_status = zcl_abapgit_file_status=>status(
+        io_repo = me
+        io_log  = io_log ).
+    ENDIF.
+
+    rt_results = mt_status.
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -47,6 +47,9 @@ CLASS zcl_abapgit_repo DEFINITION
         VALUE(rt_files) TYPE zif_abapgit_definitions=>ty_files_tt
       RAISING
         zcx_abapgit_exception .
+    METHODS has_remote
+      RETURNING VALUE(rv_yes) TYPE abap_bool .
+    METHODS reset_remote.
     METHODS get_package
       RETURNING
         VALUE(rv_package) TYPE zif_abapgit_persistence=>ty_repo-package .
@@ -107,6 +110,14 @@ CLASS zcl_abapgit_repo DEFINITION
         VALUE(rt_list) TYPE scit_alvlist
       RAISING
         zcx_abapgit_exception .
+    METHODS status
+      IMPORTING
+        !io_log           TYPE REF TO zcl_abapgit_log OPTIONAL
+      RETURNING
+        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
+      RAISING
+        zcx_abapgit_exception .
+
   PROTECTED SECTION.
     DATA mt_local TYPE zif_abapgit_definitions=>ty_files_item_tt .
     DATA mt_remote TYPE zif_abapgit_definitions=>ty_files_tt .
@@ -352,6 +363,25 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
   METHOD get_files_remote.
     rt_files = mt_remote.
+  ENDMETHOD.
+
+
+  METHOD has_remote.
+    rv_yes = boolc( lines( mt_remote ) > 0 ).
+  ENDMETHOD.
+
+
+  METHOD reset_remote.
+    clear mt_remote.
+  ENDMETHOD.
+
+
+  METHOD status.
+
+    rt_results = zcl_abapgit_file_status=>status(
+      io_repo = me
+      io_log  = io_log ). " No caching by default
+
   ENDMETHOD.
 
 

--- a/src/zcl_abapgit_repo_content_list.clas.abap
+++ b/src/zcl_abapgit_repo_content_list.clas.abap
@@ -47,7 +47,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
 
 
   METHOD build_folders.
@@ -208,7 +208,7 @@ CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
         CHANGING  ct_repo_items = rt_repo_items ).
     ENDIF.
 
-    IF iv_changes_only = abap_true AND ( mo_repo->is_offline( ) = abap_false or mo_repo->has_remote( ) = abap_true ).
+    IF iv_changes_only = abap_true AND mo_repo->has_remote( ) = abap_true.
       " There are never changes for offline repositories
       filter_changes( CHANGING ct_repo_items = rt_repo_items ).
     ENDIF.

--- a/src/zcl_abapgit_repo_content_list.clas.abap
+++ b/src/zcl_abapgit_repo_content_list.clas.abap
@@ -125,7 +125,7 @@ CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
 
   METHOD build_repo_items_online.
 
-    DATA: lo_repo_online TYPE REF TO zcl_abapgit_repo_online,
+    DATA:
           ls_file        TYPE zif_abapgit_definitions=>ty_repo_file,
           lt_status      TYPE zif_abapgit_definitions=>ty_results_tt.
 
@@ -133,8 +133,7 @@ CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
                    <ls_repo_item> LIKE LINE OF rt_repo_items.
 
 
-    lo_repo_online ?= mo_repo.
-    lt_status       = lo_repo_online->status( mo_log ).
+    lt_status       = mo_repo->status( mo_log ).
 
     LOOP AT lt_status ASSIGNING <ls_status>.
       AT NEW obj_name. "obj_type + obj_name
@@ -197,7 +196,7 @@ CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
 
     mo_log->clear( ).
 
-    IF mo_repo->is_offline( ) = abap_true.
+    IF mo_repo->is_offline( ) = abap_true AND mo_repo->has_remote( ) = abap_false.
       rt_repo_items = build_repo_items_offline( ).
     ELSE.
       rt_repo_items = build_repo_items_online( ).

--- a/src/zcl_abapgit_repo_content_list.clas.abap
+++ b/src/zcl_abapgit_repo_content_list.clas.abap
@@ -208,7 +208,7 @@ CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
         CHANGING  ct_repo_items = rt_repo_items ).
     ENDIF.
 
-    IF iv_changes_only = abap_true AND mo_repo->is_offline( ) = abap_false.
+    IF iv_changes_only = abap_true AND ( mo_repo->is_offline( ) = abap_false or mo_repo->has_remote( ) = abap_true ).
       " There are never changes for offline repositories
       filter_changes( CHANGING ct_repo_items = rt_repo_items ).
     ENDIF.

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -65,9 +65,7 @@ CLASS zcl_abapgit_repo_online DEFINITION
     DATA mt_objects TYPE zif_abapgit_definitions=>ty_objects_tt .
     DATA mv_branch TYPE zif_abapgit_definitions=>ty_sha1 .
     DATA mv_initialized TYPE abap_bool .
-    DATA mt_status TYPE zif_abapgit_definitions=>ty_results_tt .
 
-    METHODS reset_status .
     METHODS initialize
       RAISING
         zcx_abapgit_exception .
@@ -311,14 +309,8 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
 
   ENDMETHOD.                    "refresh
 
-
-  METHOD reset_status.
-    CLEAR mt_status.
-  ENDMETHOD.  " reset_status.
-
   METHOD reset_remote.
     super->reset_remote( ).
-    reset_status( ).
     mv_initialized = abap_false.
   ENDMETHOD.
 
@@ -354,11 +346,7 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
   METHOD status.
 
     initialize( ).
-
-    IF lines( mt_status ) = 0.
-      mt_status = super->status( io_log ).
-    ENDIF.
-    rt_results = mt_status.
+    rt_results = super->status( io_log ).
 
   ENDMETHOD.                    "status
 

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -44,13 +44,8 @@ CLASS zcl_abapgit_repo_online DEFINITION
         VALUE(rt_objects) TYPE zif_abapgit_definitions=>ty_objects_tt
       RAISING
         zcx_abapgit_exception .
-    METHODS status
-      IMPORTING
-        !io_log           TYPE REF TO zcl_abapgit_log OPTIONAL
-      RETURNING
-        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
-      RAISING
-        zcx_abapgit_exception .
+    METHODS status REDEFINITION.
+    METHODS reset_remote REDEFINITION.
     METHODS get_unnecessary_local_objs
       RETURNING
         VALUE(rt_unnecessary_local_objects) TYPE zif_abapgit_definitions=>ty_tadir_tt
@@ -321,6 +316,11 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
     CLEAR mt_status.
   ENDMETHOD.  " reset_status.
 
+  METHOD reset_remote.
+    super->reset_remote( ).
+    reset_status( ).
+    mv_initialized = abap_false.
+  ENDMETHOD.
 
   METHOD set_branch_name.
 
@@ -356,8 +356,7 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
     initialize( ).
 
     IF lines( mt_status ) = 0.
-      mt_status = zcl_abapgit_file_status=>status( io_repo = me
-                                                   io_log  = io_log ).
+      mt_status = super->status( io_log ).
     ENDIF.
     rt_results = mt_status.
 

--- a/src/zcl_abapgit_zip.clas.abap
+++ b/src/zcl_abapgit_zip.clas.abap
@@ -6,7 +6,8 @@ CLASS zcl_abapgit_zip DEFINITION
 
     CLASS-METHODS import
       IMPORTING
-        !iv_key TYPE zif_abapgit_persistence=>ty_value
+        iv_key TYPE zif_abapgit_persistence=>ty_value
+        iv_no_deserialize TYPE abap_bool DEFAULT abap_false
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS export
@@ -409,7 +410,9 @@ CLASS ZCL_ABAPGIT_ZIP IMPLEMENTATION.
     lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
     lo_repo->set_files_remote( unzip_file( file_upload( ) ) ).
 
-    zcl_abapgit_services_repo=>gui_deserialize( lo_repo ).
+    if iv_no_deserialize = abap_false.
+      zcl_abapgit_services_repo=>gui_deserialize( lo_repo ).
+    endif.
 
   ENDMETHOD.                    "import
 

--- a/src/zcl_abapgit_zip.clas.abap
+++ b/src/zcl_abapgit_zip.clas.abap
@@ -512,6 +512,8 @@ CLASS ZCL_ABAPGIT_ZIP IMPLEMENTATION.
 
     ENDLOOP.
 
+    DELETE rt_files WHERE filename is initial.
+
     normalize_path( CHANGING ct_files = rt_files ).
 
   ENDMETHOD.                    "decode_files


### PR DESCRIPTION
Seems to work. (see issue for screenshot and intentions) #1950, #816
on the way: bugfixed diff page - yellowed all the lines when MM status

details
- `get_diff_line` wasn't change, just moved magically
- base repo now has `has_remote`, `reset_remote`, `status`, `reset_status` (`mt_status` also moved to base)
- `zip->import` skips deserialization on `iv_no_deserialize = true`
- files can be shown only when offline repo "has_remote"
- **question**  I forgot how `mt_objects` works in online repo - should it be also cleared on `reset_remote` ?
