### PR TITLE
SICF: Decouple from core, #1941

### DIFF
--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -293,6 +293,8 @@ CLASS ZCL_ABAPGIT_OBJECT_SICF IMPLEMENTATION.
 
   METHOD read_sicf_url.
 
+* note: this method is called dynamically from some places
+
     DATA: lv_name    TYPE icfname,
           lv_url     TYPE string,
           lv_parguid TYPE icfparguid.
@@ -321,6 +323,8 @@ CLASS ZCL_ABAPGIT_OBJECT_SICF IMPLEMENTATION.
 
 
   METHOD read_tadir_sicf.
+
+* note: this method is called dynamically from some places
 
     DATA: lt_tadir    TYPE zif_abapgit_definitions=>ty_tadir_tt,
           lv_hash     TYPE text25,

--- a/src/zcl_abapgit_tadir.clas.abap
+++ b/src/zcl_abapgit_tadir.clas.abap
@@ -54,9 +54,9 @@ CLASS ZCL_ABAPGIT_TADIR IMPLEMENTATION.
     DATA: lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
     DATA: last_package    TYPE devclass VALUE cl_abap_char_utilities=>horizontal_tab.
 
-    FIELD-SYMBOLS: <ls_tdevc> LIKE LINE OF lt_tdevc,
-                   <ls_tadir> LIKE LINE OF rt_tadir,
-                   <lv_package>  TYPE devclass.
+    FIELD-SYMBOLS: <ls_tdevc>   LIKE LINE OF lt_tdevc,
+                   <ls_tadir>   LIKE LINE OF rt_tadir,
+                   <lv_package> TYPE devclass.
 
     "Determine Packages to Read
     DATA: lt_packages TYPE zif_abapgit_sap_package=>ty_devclass_tt.
@@ -139,7 +139,15 @@ CLASS ZCL_ABAPGIT_TADIR IMPLEMENTATION.
       CASE <ls_tadir>-object.
         WHEN 'SICF'.
 * replace the internal GUID with a hash of the path
-          <ls_tadir>-obj_name+15 = zcl_abapgit_object_sicf=>read_sicf_url( <ls_tadir>-obj_name ).
+          TRY.
+              CALL METHOD ('ZCL_ABAPGIT_OBJECT_SICF')=>read_sicf_url
+                EXPORTING
+                  iv_obj_name = <ls_tadir>-obj_name
+                RECEIVING
+                  rv_hash     = <ls_tadir>-obj_name+15.
+            CATCH cx_sy_dyn_call_illegal_method.
+* SICF might not be supported in some systems, assume this code is not called
+          ENDTRY.
       ENDCASE.
     ENDLOOP.
 
@@ -251,9 +259,16 @@ CLASS ZCL_ABAPGIT_TADIR IMPLEMENTATION.
   METHOD zif_abapgit_tadir~read_single.
 
     IF iv_object = 'SICF'.
-      rs_tadir = zcl_abapgit_object_sicf=>read_tadir_sicf(
-        iv_pgmid    = iv_pgmid
-        iv_obj_name = iv_obj_name ).
+      TRY.
+          CALL METHOD ('ZCL_ABAPGIT_OBJECT_SICF')=>read_tadir
+            EXPORTING
+              iv_pgmid    = iv_pgmid
+              iv_obj_name = iv_obj_name
+            RECEIVING
+              rs_tadir    = rs_tadir.
+        CATCH cx_sy_dyn_call_illegal_method.
+* SICF might not be supported in some systems, assume this code is not called
+      ENDTRY.
     ELSE.
       SELECT SINGLE * FROM tadir INTO CORRESPONDING FIELDS OF rs_tadir
         WHERE pgmid = iv_pgmid


### PR DESCRIPTION
Change calls to static SICF methods to dynamic, in order to be able to support systems which do not have SICF objects.

#1941