### PR TITLE
Changed event type, fixed fallback option fixes issue #1980

### DIFF
--- a/src/zabapgit_js_common.w3mi.data.js
+++ b/src/zabapgit_js_common.w3mi.data.js
@@ -932,7 +932,7 @@ Hotkeys.prototype.onkeydown = function(oEvent){
   }
 
   var 
-    sKey = oEvent.key || oEvent.keyCode,
+    sKey = oEvent.key || String.fromCharCode(oEvent.keyCode),
     fnHotkey = this.oKeyMap[sKey];
 
   if (fnHotkey) {
@@ -944,7 +944,7 @@ function setKeyBindings(oKeyMap){
 
   var oHotkeys = new Hotkeys(oKeyMap);
 
-  document.addEventListener('keydown', oHotkeys.onkeydown.bind(oHotkeys));
+  document.addEventListener('keypress', oHotkeys.onkeydown.bind(oHotkeys));
 
 }
 

--- a/src/zabapgit_js_common.w3mi.xml
+++ b/src/zabapgit_js_common.w3mi.xml
@@ -15,13 +15,13 @@
      <RELID>MI</RELID>
      <OBJID>ZABAPGIT_JS_COMMON</OBJID>
      <NAME>filename</NAME>
-     <VALUE>common.js</VALUE>
+     <VALUE>~wwwtmp.js</VALUE>
     </WWWPARAMS>
     <WWWPARAMS>
      <RELID>MI</RELID>
      <OBJID>ZABAPGIT_JS_COMMON</OBJID>
      <NAME>mimetype</NAME>
-     <VALUE>text/javascript</VALUE>
+     <VALUE>application/javascript</VALUE>
     </WWWPARAMS>
    </PARAMS>
   </asx:values>

--- a/src/zabapgit_js_common.w3mi.xml
+++ b/src/zabapgit_js_common.w3mi.xml
@@ -15,13 +15,13 @@
      <RELID>MI</RELID>
      <OBJID>ZABAPGIT_JS_COMMON</OBJID>
      <NAME>filename</NAME>
-     <VALUE>~wwwtmp.js</VALUE>
+     <VALUE>common.js</VALUE>
     </WWWPARAMS>
     <WWWPARAMS>
      <RELID>MI</RELID>
      <OBJID>ZABAPGIT_JS_COMMON</OBJID>
      <NAME>mimetype</NAME>
-     <VALUE>application/javascript</VALUE>
+     <VALUE>text/javascript</VALUE>
     </WWWPARAMS>
    </PARAMS>
   </asx:values>


### PR DESCRIPTION
@christianguenter2 
I changed 2 things in javascript:

1. replaced 

`oEvent.key || oEvent.keyCode`
with
`oEvent.key || String.fromCharCode( oEvent.keyCode)`

as the key code is numeric and we want the character value

2. replaced event 'keydown' with 'keypress', as in keydown I get the wrong keycode (i.e. 65 for 'a', converts to 'A' ) 

