### PR TITLE
Sort dynpros at serialize to get a consistent serialized file

### DIFF
--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -582,6 +582,8 @@ CLASS zcl_abapgit_objects_program IMPLEMENTATION.
     IF sy-subrc = 2.
       zcx_abapgit_exception=>raise( 'error from screen_list' ).
     ENDIF.
+    
+    SORT lt_d020s BY dnum ASCENDING.
 
 * loop dynpros and skip generated selection screens
     LOOP AT lt_d020s ASSIGNING <ls_d020s>


### PR DESCRIPTION
Sort dynpros at serialize to get a consistent serialized file.

In different systems `RS_SCREEN_LIST` may return a different order for dynpros.
I have a report with following Dynpros:
0100, 0101, 0200, 0201, 0300, 0301, 0302, 0400, 0401, 0500

After exporting from system "A" they were in the XML in the following order: 
0100, 0101, **0302**, **0500**, 0200, 0300, **0201**, 0301, 0400, 0401

After a fresh import into system "B" there was a diff for the marked dynrpos, since these are serialized in system "B" in the expected order.