### PR TITLE
SUSC: delete in more direct way - no confirm popup #2036

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "license": "MIT",
   "scripts": {
-    "pretest": "abaplint \"src/**/*.abap\"",
+    "pretest": "abaplint --version && abaplint \"src/**/*.abap\"",
     "test": "abapmerge src/zabapgit.prog.abap > zabapgit.abap",
     "_disabled_posttest": "abaplint zabapgit.abap"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "license": "MIT",
   "scripts": {
-    "pretest": "abaplint --version && abaplint \"src/**/*.abap\"",
+    "pretest": "abaplint \"src/**/*.abap\"",
     "test": "abapmerge src/zabapgit.prog.abap > zabapgit.abap",
     "_disabled_posttest": "abaplint zabapgit.abap"
   },

--- a/src/objects/zcl_abapgit_object_susc.clas.abap
+++ b/src/objects/zcl_abapgit_object_susc.clas.abap
@@ -118,9 +118,9 @@ CLASS zcl_abapgit_object_susc IMPLEMENTATION.
         RETURN.
     ENDTRY.
 
-    has_authorization( EXPORTING iv_object_type = lv_object_type
-                                 iv_class       = lv_auth_object_class
-                                 iv_activity    = activity_delete_06 ).
+    has_authorization( iv_object_type = lv_object_type
+                       iv_class       = lv_auth_object_class
+                       iv_activity    = activity_delete_06 ).
 
     is_used( lv_auth_object_class ).
 

--- a/src/objects/zcl_abapgit_object_susc.clas.abap
+++ b/src/objects/zcl_abapgit_object_susc.clas.abap
@@ -85,13 +85,91 @@ CLASS zcl_abapgit_object_susc IMPLEMENTATION.
 
   METHOD zif_abapgit_object~delete.
 
-    DATA: lv_objclass TYPE tobc-oclss.
+    DATA: objclass     TYPE tobc-oclss.
+    DATA: message_text TYPE string.
 
-    lv_objclass = ms_item-obj_name.
-    CALL FUNCTION 'SUSR_DELETE_OBJECT_CLASS'
+    objclass = ms_item-obj_name.
+
+* Copy of FM 'SUSR_DELETE_OBJECT_CLASS' 740SP08
+* I hate to do this, but there is no other way
+    DATA:
+      lr_susc   TYPE REF TO cl_auth_tools,
+      ls_tobct  TYPE tobct,
+      ls_tadir  TYPE tadir,
+      ls_tdevc  TYPE tdevc,
+      ld_dummy  TYPE xuobjclass,
+      ld_tr_obj TYPE e071-obj_name,
+      ld_korret TYPE char1, "tv_c1,
+      ld_answer TYPE char1. "tv_c1.
+*-----------------------------------------------------------------------
+    CREATE OBJECT lr_susc.
+
+* 1st - existence check, get data for deletion
+    lr_susc->susc_get_class( EXPORTING oclss    = objclass
+                             IMPORTING ps_tobct = ls_tobct
+                                       ps_tadir = ls_tadir ).
+    IF ls_tobct IS INITIAL.
+      zcx_abapgit_exception=>raise_t100( iv_msgid = '01'
+                                         iv_msgno = '434'
+                                         iv_msgv1 = |{ objclass }| ).
+    ENDIF.
+
+* 2nd - authority-check
+    IF lr_susc->susc_auth_check( oclss = objclass
+                                 actvt = '06' ) <> 0.
+      zcx_abapgit_exception=>raise_t100( iv_msgid = '01'
+                                         iv_msgno = '467' ).
+    ENDIF.
+
+* 3rd - where used in auth.-objects test
+    SELECT SINGLE oclss FROM tobj INTO ld_dummy
+      WHERE oclss = objclass     ##WARN_OK.
+    IF sy-subrc = 0.
+      zcx_abapgit_exception=>raise_t100( iv_msgid = '01'
+                                         iv_msgno = '212'
+                                         iv_msgv1 = |{ ld_dummy }| ).
+    ENDIF.
+
+*!!! delete confirmation popup !!!
+
+* 5th - create a transport task
+    ld_tr_obj = objclass.
+    CALL FUNCTION 'SUSR_COMMEDITCHECK'
       EXPORTING
-        objclass = lv_objclass.
+        objectname       = ld_tr_obj
+        transobjecttype  = 'C'
+      IMPORTING
+        return_from_korr = ld_korret
+        return_ls_tadir  = ls_tadir.
 
+    IF ld_korret <> 'M'.
+      zcx_abapgit_exception=>raise( |error in SUSC delete at SUSR_COMMEDITCHECK| ).
+    ENDIF.
+* now the real deletion
+    DELETE FROM tobc  WHERE oclss = objclass.
+    DELETE FROM tobct WHERE oclss = objclass.           "#EC CI_NOFIRST
+
+* follow-up action ... clean up in table tadir
+    CALL FUNCTION 'TR_DEVCLASS_GET'
+      EXPORTING
+        iv_devclass = ls_tadir-devclass
+      IMPORTING
+        es_tdevc    = ls_tdevc
+      EXCEPTIONS
+        OTHERS      = 1.
+    IF sy-subrc = 0 AND ls_tdevc-korrflag IS INITIAL.
+*   object classes are not connected with the CTS
+*   -> if a TADIR-entry exists, we have to reorganize it manualy
+      CALL FUNCTION 'TR_TADIR_INTERFACE'
+        EXPORTING
+          wi_delete_tadir_entry = 'X'
+          wi_test_modus         = space
+          wi_tadir_pgmid        = ls_tadir-pgmid
+          wi_tadir_object       = ls_tadir-object
+          wi_tadir_obj_name     = ls_tadir-obj_name
+        EXCEPTIONS
+          OTHERS                = 0.
+    ENDIF.
   ENDMETHOD.
 
   METHOD zif_abapgit_object~jump.


### PR DESCRIPTION
delete needs to be done similar to FM SUSR_DELETE_OBJECT_CLASS
I really hate this but there is no other way

There are not relevant changes in FM SUSR_DELETE_OBJECT_CLASS from 702SP14 to 740SP08

#2036