### PR TITLE
DEVC: get package from devclass or object name #2081

### DIFF
--- a/src/objects/zcl_abapgit_object_devc.clas.abap
+++ b/src/objects/zcl_abapgit_object_devc.clas.abap
@@ -42,7 +42,11 @@ CLASS zcl_abapgit_object_devc IMPLEMENTATION.
   METHOD constructor.
     super->constructor( is_item     = is_item
                         iv_language = iv_language ).
-    mv_local_devclass = is_item-devclass.
+    IF is_item-devclass IS NOT INITIAL.
+      mv_local_devclass = is_item-devclass.
+    ELSE.
+      mv_local_devclass = is_item-obj_name.
+    ENDIF.
   ENDMETHOD.
 
 


### PR DESCRIPTION
devclass for a package is (again?) empty for the DEVC object (740SP11) so obj_name is used as fallback