### PR TITLE
TRAN: ignore object not found while delete #2092

### DIFF
--- a/src/objects/zcl_abapgit_object_tran.clas.abap
+++ b/src/objects/zcl_abapgit_object_tran.clas.abap
@@ -510,7 +510,7 @@ CLASS zcl_abapgit_object_tran IMPLEMENTATION.
         transaction      = lv_transaction
       EXCEPTIONS
         not_excecuted    = 1
-        object_not_found = 2
+        object_not_found = 0
         OTHERS           = 3.
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( 'Error from RPY_TRANSACTION_DELETE' ).


### PR DESCRIPTION
If the transaction can't be found in FM RPY_TRANSACTION_DELETE, it's already deleted
#2092 