### PR TITLE
2-step zip import

### DIFF
--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -47,7 +47,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_router IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
 
 
   METHOD get_page_background.
@@ -172,6 +172,17 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
 
     ENDIF.
 
+  ENDMETHOD.
+
+
+  METHOD jump_display_transport.
+    DATA: lv_transport TYPE trkorr.
+
+    lv_transport = iv_getdata.
+
+    CALL FUNCTION 'TR_DISPLAY_REQUEST'
+      EXPORTING
+        i_trkorr = lv_transport.
   ENDMETHOD.
 
 
@@ -319,6 +330,7 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
         " ZIP services actions
       WHEN zif_abapgit_definitions=>c_action-zip_import.                      " Import repo from ZIP
         zcl_abapgit_zip=>import( lv_key ).
+        zcl_abapgit_services_repo=>refresh( lv_key ).
         ev_state = zif_abapgit_definitions=>c_event_state-re_render.
       WHEN zif_abapgit_definitions=>c_action-zip_export.                      " Export repo as ZIP
         zcl_abapgit_zip=>export( zcl_abapgit_repo_srv=>get_instance( )->get( lv_key ) ).
@@ -381,15 +393,5 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
         ev_state = zif_abapgit_definitions=>c_event_state-not_handled.
     ENDCASE.
 
-  ENDMETHOD.
-
-  METHOD jump_display_transport.
-    DATA: lv_transport TYPE trkorr.
-
-    lv_transport = iv_getdata.
-
-    CALL FUNCTION 'TR_DISPLAY_REQUEST'
-      EXPORTING
-        i_trkorr = lv_transport.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_abapgit_repo_content_list.clas.abap
+++ b/src/zcl_abapgit_repo_content_list.clas.abap
@@ -29,11 +29,11 @@ CLASS zcl_abapgit_repo_content_list DEFINITION
     DATA: mo_repo TYPE REF TO zcl_abapgit_repo,
           mo_log  TYPE REF TO zcl_abapgit_log.
 
-    METHODS build_repo_items_offline
+    METHODS build_repo_items_local_only
       RETURNING VALUE(rt_repo_items) TYPE zif_abapgit_definitions=>tt_repo_items
       RAISING   zcx_abapgit_exception.
 
-    METHODS build_repo_items_online
+    METHODS build_repo_items_with_remote
       RETURNING VALUE(rt_repo_items) TYPE zif_abapgit_definitions=>tt_repo_items
       RAISING   zcx_abapgit_exception.
 
@@ -101,7 +101,7 @@ CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD build_repo_items_offline.
+  METHOD build_repo_items_local_only.
 
     DATA: lt_tadir TYPE zif_abapgit_definitions=>ty_tadir_tt,
           ls_item  TYPE zif_abapgit_definitions=>ty_item.
@@ -131,7 +131,7 @@ CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD build_repo_items_online.
+  METHOD build_repo_items_with_remote.
 
     DATA:
           ls_file        TYPE zif_abapgit_definitions=>ty_repo_file,
@@ -210,10 +210,10 @@ CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
 
     mo_log->clear( ).
 
-    IF mo_repo->is_offline( ) = abap_true.
-      rt_repo_items = build_repo_items_offline( ).
+    IF mo_repo->has_remote_source( ) = abap_true.
+      rt_repo_items = build_repo_items_with_remote( ).
     ELSE.
-      rt_repo_items = build_repo_items_online( ).
+      rt_repo_items = build_repo_items_local_only( ).
     ENDIF.
 
     IF iv_by_folders = abap_true.
@@ -222,7 +222,7 @@ CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
         CHANGING  ct_repo_items = rt_repo_items ).
     ENDIF.
 
-    IF iv_changes_only = abap_true AND mo_repo->is_offline( ) = abap_false.
+    IF iv_changes_only = abap_true.
       " There are never changes for offline repositories
       filter_changes( CHANGING ct_repo_items = rt_repo_items ).
     ENDIF.

--- a/src/zcl_abapgit_zip.clas.abap
+++ b/src/zcl_abapgit_zip.clas.abap
@@ -57,7 +57,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_zip IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_ZIP IMPLEMENTATION.
 
 
   METHOD encode_files.
@@ -403,11 +403,8 @@ CLASS zcl_abapgit_zip IMPLEMENTATION.
 
     DATA: lo_repo TYPE REF TO zcl_abapgit_repo_offline.
 
-
     lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
     lo_repo->set_files_remote( unzip_file( file_upload( ) ) ).
-
-    zcl_abapgit_services_repo=>gui_deserialize( lo_repo ).
 
   ENDMETHOD.
 
@@ -506,6 +503,8 @@ CLASS zcl_abapgit_zip IMPLEMENTATION.
                                                iv_data = <ls_file>-data ).
 
     ENDLOOP.
+
+    DELETE rt_files WHERE filename is initial.
 
     normalize_path( CHANGING ct_files = rt_files ).
 


### PR DESCRIPTION
Second try for 2-step zip import (#1950)
Should work well, but would be nice if someone can double test (@christianguenter2 seems like you were interested in the feature last time? :)) ).

Notes:
- No changes were done to: `jump_display_transport` - it's se80 auto reordering :) Also just  `colspan` fixes in `render_parent_dir`
- completely removed deserialize from zip. So no new actions compared to previous approach in #1953 (which is good)
- renamed methods of `ZCL_ABAPGIT_REPO_CONTENT_LIST` for sematics reasons