### PR TITLE
repo->set refactoring, disconnect repo from persistence

### DIFF
--- a/src/persist/zcl_abapgit_persistence_repo.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_repo.clas.abap
@@ -9,7 +9,6 @@ CLASS zcl_abapgit_persistence_repo DEFINITION
     INTERFACES zif_abapgit_persist_repo .
 
     METHODS constructor .
-    CLASS-METHODS class_constructor .
   PROTECTED SECTION.
 
     ALIASES list
@@ -18,7 +17,7 @@ CLASS zcl_abapgit_persistence_repo DEFINITION
       FOR zif_abapgit_persist_repo~read .
   PRIVATE SECTION.
 
-    CLASS-DATA gt_meta_fields TYPE STANDARD TABLE OF abap_compname.
+    DATA mt_meta_fields TYPE STANDARD TABLE OF abap_compname.
     DATA mo_db TYPE REF TO zcl_abapgit_persistence_db .
 
     METHODS from_xml
@@ -44,7 +43,7 @@ ENDCLASS.
 
 CLASS ZCL_ABAPGIT_PERSISTENCE_REPO IMPLEMENTATION.
 
-  METHOD class_constructor.
+  METHOD constructor.
 
     DATA ls_dummy_meta_mask TYPE zif_abapgit_persistence=>ty_repo_meta_mask.
     DATA ls_dummy_meta      TYPE zif_abapgit_persistence=>ty_repo_xml.
@@ -52,19 +51,15 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_REPO IMPLEMENTATION.
     DATA lo_type_meta       TYPE REF TO cl_abap_structdescr.
     FIELD-SYMBOLS <ls_comp> LIKE LINE OF lo_type_meta_mask->components.
 
+    " Collect actual list of fields in repo meta data (used in update_meta)
     lo_type_meta_mask ?= cl_abap_structdescr=>describe_by_data( ls_dummy_meta_mask ).
     lo_type_meta      ?= cl_abap_structdescr=>describe_by_data( ls_dummy_meta ).
     LOOP AT lo_type_meta_mask->components ASSIGNING <ls_comp>.
-      APPEND <ls_comp>-name TO gt_meta_fields.
-      " Consistency protection, this will dump if meta and meta_mask types are out of sync
-      READ TABLE lo_type_meta->components TRANSPORTING NO FIELDS WITH KEY name = <ls_comp>-name.
-      ASSERT sy-subrc = 0.
+      APPEND <ls_comp>-name TO mt_meta_fields.
     ENDLOOP.
 
-  ENDMETHOD.
-
-  METHOD constructor.
     mo_db = zcl_abapgit_persistence_db=>get_instance( ).
+
   ENDMETHOD.
 
 
@@ -225,7 +220,7 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_REPO IMPLEMENTATION.
           lv_blob            TYPE zif_abapgit_persistence=>ty_content-data_str,
           ls_persistent_meta TYPE zif_abapgit_persistence=>ty_repo.
 
-    FIELD-SYMBOLS <lv_field>   LIKE LINE OF gt_meta_fields.
+    FIELD-SYMBOLS <lv_field>   LIKE LINE OF mt_meta_fields.
     FIELD-SYMBOLS <lv_dst>     TYPE ANY.
     FIELD-SYMBOLS <lv_src>     TYPE ANY.
     FIELD-SYMBOLS <lv_changed> TYPE abap_bool.
@@ -248,11 +243,14 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_REPO IMPLEMENTATION.
     ENDTRY.
 
     " Update
-    LOOP AT gt_meta_fields ASSIGNING <lv_field>.
+    LOOP AT mt_meta_fields ASSIGNING <lv_field>.
       ASSIGN COMPONENT <lv_field> OF STRUCTURE is_change_mask TO <lv_changed>.
+      ASSERT sy-subrc = 0.
       CHECK <lv_changed> = abap_true.
       ASSIGN COMPONENT <lv_field> OF STRUCTURE ls_persistent_meta TO <lv_dst>.
+      ASSERT sy-subrc = 0.
       ASSIGN COMPONENT <lv_field> OF STRUCTURE is_meta TO <lv_src>.
+      ASSERT sy-subrc = 0.
       <lv_dst> = <lv_src>.
     ENDLOOP.
 

--- a/src/persist/zcl_abapgit_persistence_repo.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_repo.clas.abap
@@ -407,4 +407,45 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_REPO IMPLEMENTATION.
                    iv_data  = ls_content-data_str ).
 
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_persist_repo~update_metadata.
+
+    DATA:
+          lv_blob  TYPE zif_abapgit_persistence=>ty_content-data_str,
+          lv_field LIKE LINE OF it_change_log,
+          ls_repo  TYPE zif_abapgit_persistence=>ty_repo.
+
+    FIELD-SYMBOLS <vdst> TYPE ANY.
+    FIELD-SYMBOLS <vsrc> TYPE ANY.
+
+    " TODO validations ?? e.g. 'update, url empty' and/or change_log entries ?
+
+    ASSERT NOT iv_key IS INITIAL.
+
+    TRY.
+        ls_repo = read( iv_key ).
+      CATCH zcx_abapgit_not_found.
+        zcx_abapgit_exception=>raise( 'repo key not found' ).
+    ENDTRY.
+
+    IF it_change_log IS INITIAL.
+      RETURN.
+    ENDIF.
+
+    LOOP AT it_change_log INTO lv_field.
+      lv_field = to_upper( lv_field ).
+      ASSIGN COMPONENT lv_field OF STRUCTURE ls_repo TO <vdst>.
+      ASSIGN COMPONENT lv_field OF STRUCTURE is_meta TO <vsrc>.
+      <vdst> = <vsrc>.
+    ENDLOOP.
+
+    lv_blob = to_xml( ls_repo ).
+
+    mo_db->update( iv_type  = zcl_abapgit_persistence_db=>c_type_repo
+                   iv_value = iv_key
+                   iv_data  = lv_blob ).
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/persist/zif_abapgit_persist_repo.intf.abap
+++ b/src/persist/zif_abapgit_persist_repo.intf.abap
@@ -1,97 +1,48 @@
-INTERFACE zif_abapgit_persist_repo
-  PUBLIC .
+interface ZIF_ABAPGIT_PERSIST_REPO
+  public .
 
 
-  METHODS add
-    IMPORTING
-      !iv_url         TYPE string
-      !iv_branch_name TYPE string
-      !iv_branch      TYPE zif_abapgit_definitions=>ty_sha1 OPTIONAL
-      !iv_package     TYPE devclass
-      !iv_offline     TYPE sap_bool DEFAULT abap_false
-      !is_dot_abapgit TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit
-    RETURNING
-      VALUE(rv_key)   TYPE zif_abapgit_persistence=>ty_repo-key
-    RAISING
-      zcx_abapgit_exception .
-  METHODS delete
-    IMPORTING
-      !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
-    RAISING
-      zcx_abapgit_exception .
-  METHODS list
-    RETURNING
-      VALUE(rt_repos) TYPE zif_abapgit_persistence=>tt_repo
-    RAISING
-      zcx_abapgit_exception .
-  METHODS lock
-    IMPORTING
-      !iv_mode TYPE enqmode
-      !iv_key  TYPE zif_abapgit_persistence=>ty_repo-key
-    RAISING
-      zcx_abapgit_exception .
-  METHODS read
-    IMPORTING
-      !iv_key        TYPE zif_abapgit_persistence=>ty_repo-key
-    RETURNING
-      VALUE(rs_repo) TYPE zif_abapgit_persistence=>ty_repo
-    RAISING
-      zcx_abapgit_exception
-      zcx_abapgit_not_found .
-  METHODS update_branch_name
-    IMPORTING
-      !iv_key         TYPE zif_abapgit_persistence=>ty_repo-key
-      !iv_branch_name TYPE zif_abapgit_persistence=>ty_repo_xml-branch_name
-    RAISING
-      zcx_abapgit_exception .
-  METHODS update_deserialized
-    IMPORTING
-      !iv_key             TYPE zif_abapgit_persistence=>ty_value
-      !iv_deserialized_at TYPE timestampl
-      !iv_deserialized_by TYPE xubname
-    RAISING
-      zcx_abapgit_exception .
-  METHODS update_dot_abapgit
-    IMPORTING
-      !iv_key         TYPE zif_abapgit_persistence=>ty_repo-key
-      !is_dot_abapgit TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit
-    RAISING
-      zcx_abapgit_exception .
-  METHODS update_head_branch
-    IMPORTING
-      !iv_key         TYPE zif_abapgit_persistence=>ty_repo-key
-      !iv_head_branch TYPE zif_abapgit_persistence=>ty_repo_xml-head_branch
-    RAISING
-      zcx_abapgit_exception .
-  METHODS update_local_checksums
-    IMPORTING
-      !iv_key       TYPE zif_abapgit_persistence=>ty_repo-key
-      !it_checksums TYPE zif_abapgit_persistence=>ty_repo_xml-local_checksums
-    RAISING
-      zcx_abapgit_exception .
-  METHODS update_local_settings
-    IMPORTING
-      !iv_key      TYPE zif_abapgit_persistence=>ty_repo-key
-      !is_settings TYPE zif_abapgit_persistence=>ty_repo_xml-local_settings
-    RAISING
-      zcx_abapgit_exception .
-  METHODS update_offline
-    IMPORTING
-      !iv_key     TYPE zif_abapgit_persistence=>ty_repo-key
-      !iv_offline TYPE zif_abapgit_persistence=>ty_repo_xml-offline
-    RAISING
-      zcx_abapgit_exception .
-  METHODS update_url
-    IMPORTING
-      !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
-      !iv_url TYPE zif_abapgit_persistence=>ty_repo_xml-url
-    RAISING
-      zcx_abapgit_exception .
-  METHODS update_metadata
-    IMPORTING
-      !iv_key        TYPE zif_abapgit_persistence=>ty_repo-key
-      !is_meta       TYPE zif_abapgit_persistence=>ty_repo_xml
-      !it_change_log TYPE string_table
-    RAISING
-      zcx_abapgit_exception .
-ENDINTERFACE.
+  methods ADD
+    importing
+      !IV_URL type STRING
+      !IV_BRANCH_NAME type STRING
+      !IV_BRANCH type ZIF_ABAPGIT_DEFINITIONS=>TY_SHA1 optional
+      !IV_PACKAGE type DEVCLASS
+      !IV_OFFLINE type SAP_BOOL default ABAP_FALSE
+      !IS_DOT_ABAPGIT type ZIF_ABAPGIT_DOT_ABAPGIT=>TY_DOT_ABAPGIT
+    returning
+      value(RV_KEY) type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods DELETE
+    importing
+      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods LIST
+    returning
+      value(RT_REPOS) type ZIF_ABAPGIT_PERSISTENCE=>TT_REPO
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods LOCK
+    importing
+      !IV_MODE type ENQMODE
+      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods READ
+    importing
+      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
+    returning
+      value(RS_REPO) type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO
+    raising
+      ZCX_ABAPGIT_EXCEPTION
+      ZCX_ABAPGIT_NOT_FOUND .
+  methods UPDATE_METADATA
+    importing
+      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
+      !IS_META type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO_XML
+      !IS_CHANGE_MASK type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO_META_MASK
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+endinterface.

--- a/src/persist/zif_abapgit_persist_repo.intf.abap
+++ b/src/persist/zif_abapgit_persist_repo.intf.abap
@@ -1,48 +1,48 @@
-interface ZIF_ABAPGIT_PERSIST_REPO
-  public .
+INTERFACE zif_abapgit_persist_repo
+  PUBLIC .
 
 
-  methods ADD
-    importing
-      !IV_URL type STRING
-      !IV_BRANCH_NAME type STRING
-      !IV_BRANCH type ZIF_ABAPGIT_DEFINITIONS=>TY_SHA1 optional
-      !IV_PACKAGE type DEVCLASS
-      !IV_OFFLINE type SAP_BOOL default ABAP_FALSE
-      !IS_DOT_ABAPGIT type ZIF_ABAPGIT_DOT_ABAPGIT=>TY_DOT_ABAPGIT
-    returning
-      value(RV_KEY) type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods DELETE
-    importing
-      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods LIST
-    returning
-      value(RT_REPOS) type ZIF_ABAPGIT_PERSISTENCE=>TT_REPO
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods LOCK
-    importing
-      !IV_MODE type ENQMODE
-      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods READ
-    importing
-      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
-    returning
-      value(RS_REPO) type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO
-    raising
-      ZCX_ABAPGIT_EXCEPTION
-      ZCX_ABAPGIT_NOT_FOUND .
-  methods UPDATE_METADATA
-    importing
-      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
-      !IS_META type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO_XML
-      !IS_CHANGE_MASK type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO_META_MASK
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-endinterface.
+  METHODS add
+    IMPORTING
+      !iv_url TYPE string
+      !iv_branch_name TYPE string
+      !iv_branch TYPE zif_abapgit_definitions=>ty_sha1 OPTIONAL
+      !iv_package TYPE devclass
+      !iv_offline TYPE sap_bool DEFAULT abap_false
+      !is_dot_abapgit TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit
+    RETURNING
+      VALUE(rv_key) TYPE zif_abapgit_persistence=>ty_repo-key
+    RAISING
+      zcx_abapgit_exception .
+  METHODS delete
+    IMPORTING
+      !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+    RAISING
+      zcx_abapgit_exception .
+  METHODS list
+    RETURNING
+      VALUE(rt_repos) TYPE zif_abapgit_persistence=>tt_repo
+    RAISING
+      zcx_abapgit_exception .
+  METHODS lock
+    IMPORTING
+      !iv_mode TYPE enqmode
+      !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+    RAISING
+      zcx_abapgit_exception .
+  METHODS read
+    IMPORTING
+      !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+    RETURNING
+      VALUE(rs_repo) TYPE zif_abapgit_persistence=>ty_repo
+    RAISING
+      zcx_abapgit_exception
+      zcx_abapgit_not_found .
+  METHODS update_metadata
+    IMPORTING
+      !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      !is_meta TYPE zif_abapgit_persistence=>ty_repo_xml
+      !is_change_mask TYPE zif_abapgit_persistence=>ty_repo_meta_mask
+    RAISING
+      zcx_abapgit_exception .
+ENDINTERFACE.

--- a/src/persist/zif_abapgit_persist_repo.intf.abap
+++ b/src/persist/zif_abapgit_persist_repo.intf.abap
@@ -4,14 +4,14 @@ INTERFACE zif_abapgit_persist_repo
 
   METHODS add
     IMPORTING
-      !iv_url TYPE string
+      !iv_url         TYPE string
       !iv_branch_name TYPE string
-      !iv_branch TYPE zif_abapgit_definitions=>ty_sha1 OPTIONAL
-      !iv_package TYPE devclass
-      !iv_offline TYPE sap_bool DEFAULT abap_false
+      !iv_branch      TYPE zif_abapgit_definitions=>ty_sha1 OPTIONAL
+      !iv_package     TYPE devclass
+      !iv_offline     TYPE sap_bool DEFAULT abap_false
       !is_dot_abapgit TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit
     RETURNING
-      VALUE(rv_key) TYPE zif_abapgit_persistence=>ty_repo-key
+      VALUE(rv_key)   TYPE zif_abapgit_persistence=>ty_repo-key
     RAISING
       zcx_abapgit_exception .
   METHODS delete
@@ -27,12 +27,12 @@ INTERFACE zif_abapgit_persist_repo
   METHODS lock
     IMPORTING
       !iv_mode TYPE enqmode
-      !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      !iv_key  TYPE zif_abapgit_persistence=>ty_repo-key
     RAISING
       zcx_abapgit_exception .
   METHODS read
     IMPORTING
-      !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      !iv_key        TYPE zif_abapgit_persistence=>ty_repo-key
     RETURNING
       VALUE(rs_repo) TYPE zif_abapgit_persistence=>ty_repo
     RAISING
@@ -40,8 +40,8 @@ INTERFACE zif_abapgit_persist_repo
       zcx_abapgit_not_found .
   METHODS update_metadata
     IMPORTING
-      !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
-      !is_meta TYPE zif_abapgit_persistence=>ty_repo_xml
+      !iv_key         TYPE zif_abapgit_persistence=>ty_repo-key
+      !is_meta        TYPE zif_abapgit_persistence=>ty_repo_xml
       !is_change_mask TYPE zif_abapgit_persistence=>ty_repo_meta_mask
     RAISING
       zcx_abapgit_exception .

--- a/src/persist/zif_abapgit_persist_repo.intf.abap
+++ b/src/persist/zif_abapgit_persist_repo.intf.abap
@@ -87,4 +87,11 @@ INTERFACE zif_abapgit_persist_repo
       !iv_url TYPE zif_abapgit_persistence=>ty_repo_xml-url
     RAISING
       zcx_abapgit_exception .
+  METHODS update_metadata
+    IMPORTING
+      !iv_key        TYPE zif_abapgit_persistence=>ty_repo-key
+      !is_meta       TYPE zif_abapgit_persistence=>ty_repo_xml
+      !it_change_log TYPE string_table
+    RAISING
+      zcx_abapgit_exception .
 ENDINTERFACE.

--- a/src/persist/zif_abapgit_persistence.intf.abap
+++ b/src/persist/zif_abapgit_persistence.intf.abap
@@ -44,6 +44,22 @@ INTERFACE zif_abapgit_persistence PUBLIC.
            local_settings  TYPE ty_local_settings,
          END OF ty_repo_xml.
 
+  TYPES:
+    BEGIN OF ty_repo_meta_mask,
+      url             TYPE abap_bool,
+      branch_name     TYPE abap_bool,
+      package         TYPE abap_bool,
+      created_by      TYPE abap_bool,
+      created_at      TYPE abap_bool,
+      deserialized_by TYPE abap_bool,
+      deserialized_at TYPE abap_bool,
+      offline         TYPE abap_bool,
+      local_checksums TYPE abap_bool,
+      dot_abapgit     TYPE abap_bool,
+      head_branch     TYPE abap_bool,
+      local_settings  TYPE abap_bool,
+    END OF ty_repo_meta_mask.
+
   TYPES: BEGIN OF ty_repo,
            key TYPE zif_abapgit_persistence=>ty_value.
       INCLUDE TYPE ty_repo_xml.

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -395,10 +395,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
       RAISE EXCEPTION TYPE zcx_abapgit_cancel.
     ENDIF.
 
-    zcl_abapgit_repo_srv=>get_instance( )->switch_repo_type(
-      iv_key = iv_key
-      iv_offline = abap_false ).
-
+    zcl_abapgit_repo_srv=>get_instance( )->get( iv_key )->switch_repo_type( iv_offline = abap_false ).
     lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
     lo_repo->set_url( ls_popup-url ).
     lo_repo->set_branch_name( ls_popup-branch_name ).
@@ -451,7 +448,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
       RAISE EXCEPTION TYPE zcx_abapgit_cancel.
     ENDIF.
 
-    zcl_abapgit_repo_srv=>get_instance( )->switch_repo_type( iv_key = iv_key  iv_offline = abap_true ).
+    zcl_abapgit_repo_srv=>get_instance( )->get( iv_key )->switch_repo_type( iv_offline = abap_true ).
 
     COMMIT WORK.
 

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -7,10 +7,9 @@ CLASS zcl_abapgit_repo DEFINITION
 
   PUBLIC SECTION.
 
-    EVENTS on_metadata_change
-      EXPORTING
-        VALUE(IS_META) TYPE zif_abapgit_persistence=>ty_repo_xml
-        VALUE(IT_CHANGE_LOG) TYPE string_table .
+    METHODS subscribe_on_meta_change
+      IMPORTING
+        ii_subscriber TYPE REF TO zif_abapgit_repo_srv.
     METHODS deserialize_checks
       RETURNING
         VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_deserialize_checks
@@ -154,10 +153,14 @@ CLASS zcl_abapgit_repo DEFINITION
     METHODS reset_remote .
   PRIVATE SECTION.
 
+    DATA mi_subscriber TYPE REF TO zif_abapgit_repo_srv .
+
     TYPES:
       ty_cache_tt TYPE SORTED TABLE OF zif_abapgit_definitions=>ty_file_item
                              WITH NON-UNIQUE KEY item .
-
+    METHODS notify_subscribers
+      RAISING
+        zcx_abapgit_exception .
     METHODS apply_filter
       IMPORTING
         !it_filter TYPE zif_abapgit_definitions=>ty_tadir_tt
@@ -544,6 +547,13 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD notify_subscribers.
+    IF mi_subscriber IS BOUND.
+      " TODO
+    ENDIF.
+  ENDMETHOD.
+
+
   METHOD rebuild_local_checksums.
 
     DATA:
@@ -720,11 +730,11 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
       APPEND 'deserialized_at' TO lt_change_log.
     ENDIF.
 
-    MOVE-CORRESPONDING ms_data TO ls_meta_slug.
-    RAISE EVENT on_metadata_change
-      EXPORTING
-        is_meta = ls_meta_slug
-        it_change_log = lt_change_log.
+*    MOVE-CORRESPONDING ms_data TO ls_meta_slug.
+*    RAISE EVENT on_metadata_change
+*      EXPORTING
+*        is_meta = ls_meta_slug
+*        it_change_log = lt_change_log.
 
   ENDMETHOD.
 
@@ -759,6 +769,11 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
     rt_results = mt_status.
 
+  ENDMETHOD.
+
+
+  METHOD subscribe_on_meta_change.
+    mi_subscriber = ii_subscriber.
   ENDMETHOD.
 
 

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -1,15 +1,13 @@
 CLASS zcl_abapgit_repo DEFINITION
   PUBLIC
   ABSTRACT
-  CREATE PUBLIC
-
-  GLOBAL FRIENDS zcl_abapgit_repo_srv .
+  CREATE PUBLIC.
 
   PUBLIC SECTION.
 
-    METHODS subscribe_on_meta_change
+    METHODS bind_listener
       IMPORTING
-        ii_subscriber TYPE REF TO zif_abapgit_repo_srv.
+        ii_listener TYPE REF TO zif_abapgit_repo_listener.
     METHODS deserialize_checks
       RETURNING
         VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_deserialize_checks
@@ -54,9 +52,6 @@ CLASS zcl_abapgit_repo DEFINITION
     METHODS get_package
       RETURNING
         VALUE(rv_package) TYPE zif_abapgit_persistence=>ty_repo-package .
-    METHODS delete
-      RAISING
-        zcx_abapgit_exception .
     METHODS get_dot_abapgit
       RETURNING
         VALUE(ro_dot_abapgit) TYPE REF TO zcl_abapgit_dot_abapgit .
@@ -125,6 +120,11 @@ CLASS zcl_abapgit_repo DEFINITION
         VALUE(rt_unnecessary_local_objects) TYPE zif_abapgit_definitions=>ty_tadir_tt
       RAISING
         zcx_abapgit_exception .
+    METHODS switch_repo_type
+      IMPORTING
+        iv_offline TYPE abap_bool
+      RAISING
+        zcx_abapgit_exception .
 
   PROTECTED SECTION.
 
@@ -153,12 +153,14 @@ CLASS zcl_abapgit_repo DEFINITION
     METHODS reset_remote .
   PRIVATE SECTION.
 
-    DATA mi_subscriber TYPE REF TO zif_abapgit_repo_srv .
+    DATA mi_listener TYPE REF TO zif_abapgit_repo_listener .
 
     TYPES:
       ty_cache_tt TYPE SORTED TABLE OF zif_abapgit_definitions=>ty_file_item
                              WITH NON-UNIQUE KEY item .
-    METHODS notify_subscribers
+    METHODS notify_listener
+      IMPORTING
+        is_change_mask TYPE zif_abapgit_persistence=>ty_repo_meta_mask
       RAISING
         zcx_abapgit_exception .
     METHODS apply_filter
@@ -252,13 +254,6 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
         input  = iv_spras
       IMPORTING
         output = rv_spras.
-
-  ENDMETHOD.
-
-
-  METHOD delete.
-
-    zcl_abapgit_persist_factory=>get_repo( )->delete( ms_data-key ).
 
   ENDMETHOD.
 
@@ -547,10 +542,18 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD notify_subscribers.
-    IF mi_subscriber IS BOUND.
-      " TODO
+  METHOD notify_listener.
+
+    DATA ls_meta_slug TYPE zif_abapgit_persistence=>ty_repo_xml.
+
+    IF mi_listener IS BOUND.
+      MOVE-CORRESPONDING ms_data TO ls_meta_slug.
+      mi_listener->on_meta_change(
+        iv_key         = ms_data-key
+        is_meta        = ls_meta_slug
+        is_change_mask = is_change_mask ).
     ENDIF.
+
   ENDMETHOD.
 
 
@@ -648,9 +651,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 * TODO: refactor
 
     DATA:
-          lt_change_log TYPE string_table,
-          ls_meta_slug TYPE zif_abapgit_persistence=>ty_repo_xml,
-          li_persistence TYPE REF TO zif_abapgit_persist_repo.
+          ls_mask        TYPE zif_abapgit_persistence=>ty_repo_meta_mask.
 
 
     ASSERT it_checksums IS SUPPLIED
@@ -663,78 +664,50 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
       OR iv_deserialized_by IS SUPPLIED
       OR iv_deserialized_at IS SUPPLIED.
 
-    li_persistence = zcl_abapgit_persist_factory=>get_repo( ).
 
     IF it_checksums IS SUPPLIED.
-      li_persistence->update_local_checksums(
-        iv_key       = ms_data-key
-        it_checksums = it_checksums ).
       ms_data-local_checksums = it_checksums.
-      APPEND 'local_checksums' TO lt_change_log.
+      ls_mask-local_checksums = abap_true.
     ENDIF.
 
     IF iv_url IS SUPPLIED.
-      li_persistence->update_url(
-        iv_key = ms_data-key
-        iv_url = iv_url ).
       ms_data-url = iv_url.
-      APPEND 'url' TO lt_change_log.
+      ls_mask-url = abap_true.
     ENDIF.
 
     IF iv_branch_name IS SUPPLIED.
-      li_persistence->update_branch_name(
-        iv_key         = ms_data-key
-        iv_branch_name = iv_branch_name ).
       ms_data-branch_name = iv_branch_name.
-      APPEND 'branch_name' TO lt_change_log.
+      ls_mask-branch_name = abap_true.
     ENDIF.
 
     IF iv_head_branch IS SUPPLIED.
-      li_persistence->update_head_branch(
-        iv_key         = ms_data-key
-        iv_head_branch = iv_head_branch ).
       ms_data-head_branch = iv_head_branch.
-      APPEND 'head_branch' TO lt_change_log.
+      ls_mask-head_branch = abap_true.
     ENDIF.
 
     IF iv_offline IS SUPPLIED.
-      li_persistence->update_offline(
-        iv_key     = ms_data-key
-        iv_offline = iv_offline ).
       ms_data-offline = iv_offline.
-      APPEND 'offline' TO lt_change_log.
+      ls_mask-offline = abap_true.
     ENDIF.
 
     IF is_dot_abapgit IS SUPPLIED.
-      li_persistence->update_dot_abapgit(
-        iv_key         = ms_data-key
-        is_dot_abapgit = is_dot_abapgit ).
       ms_data-dot_abapgit = is_dot_abapgit.
-      APPEND 'dot_abapgit' TO lt_change_log.
+      ls_mask-dot_abapgit = abap_true.
     ENDIF.
 
     IF is_local_settings IS SUPPLIED.
-      li_persistence->update_local_settings(
-        iv_key      = ms_data-key
-        is_settings = is_local_settings ).
       ms_data-local_settings = is_local_settings.
-      APPEND 'local_settings' TO lt_change_log.
+      ls_mask-local_settings = abap_true.
     ENDIF.
 
     IF iv_deserialized_at IS SUPPLIED OR iv_deserialized_by IS SUPPLIED.
-      li_persistence->update_deserialized(
-        iv_key             = ms_data-key
-        iv_deserialized_at = iv_deserialized_at
-        iv_deserialized_by = iv_deserialized_by ).
       ms_data-deserialized_at = iv_deserialized_at.
-      APPEND 'deserialized_at' TO lt_change_log.
+      ms_data-deserialized_by = iv_deserialized_by.
+      ls_mask-deserialized_at = abap_true.
+      ls_mask-deserialized_by = abap_true.
     ENDIF.
 
-*    MOVE-CORRESPONDING ms_data TO ls_meta_slug.
-*    RAISE EVENT on_metadata_change
-*      EXPORTING
-*        is_meta = ls_meta_slug
-*        it_change_log = lt_change_log.
+    notify_listener( ls_mask ).
 
   ENDMETHOD.
 
@@ -772,8 +745,8 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD subscribe_on_meta_change.
-    mi_subscriber = ii_subscriber.
+  METHOD bind_listener.
+    mi_listener = ii_listener.
   ENDMETHOD.
 
 
@@ -868,4 +841,25 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
     set( it_checksums = lt_checksums ).
 
   ENDMETHOD.
+
+
+  METHOD switch_repo_type.
+
+    IF iv_offline = ms_data-offline.
+      zcx_abapgit_exception=>raise( |Cannot switch_repo_type, offline already = "{ ms_data-offline }"| ).
+    ENDIF.
+
+    IF iv_offline = abap_true. " On-line -> OFFline
+      set(
+        iv_url         = zcl_abapgit_url=>name( ms_data-url )
+        iv_branch_name = ''
+        iv_head_branch = ''
+        iv_offline     = abap_true ).
+    ELSE. " OFFline -> On-line
+      set( iv_offline = abap_false ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
 ENDCLASS.

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -7,6 +7,10 @@ CLASS zcl_abapgit_repo DEFINITION
 
   PUBLIC SECTION.
 
+    EVENTS on_metadata_change
+      EXPORTING
+        VALUE(IS_META) TYPE zif_abapgit_persistence=>ty_repo_xml
+        VALUE(IT_CHANGE_LOG) TYPE string_table .
     METHODS deserialize_checks
       RETURNING
         VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_deserialize_checks
@@ -633,7 +637,10 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
 * TODO: refactor
 
-    DATA: li_persistence TYPE REF TO zif_abapgit_persist_repo.
+    DATA:
+          lt_change_log TYPE string_table,
+          ls_meta_slug TYPE zif_abapgit_persistence=>ty_repo_xml,
+          li_persistence TYPE REF TO zif_abapgit_persist_repo.
 
 
     ASSERT it_checksums IS SUPPLIED
@@ -653,6 +660,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
         iv_key       = ms_data-key
         it_checksums = it_checksums ).
       ms_data-local_checksums = it_checksums.
+      APPEND 'local_checksums' TO lt_change_log.
     ENDIF.
 
     IF iv_url IS SUPPLIED.
@@ -660,6 +668,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
         iv_key = ms_data-key
         iv_url = iv_url ).
       ms_data-url = iv_url.
+      APPEND 'url' TO lt_change_log.
     ENDIF.
 
     IF iv_branch_name IS SUPPLIED.
@@ -667,6 +676,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
         iv_key         = ms_data-key
         iv_branch_name = iv_branch_name ).
       ms_data-branch_name = iv_branch_name.
+      APPEND 'branch_name' TO lt_change_log.
     ENDIF.
 
     IF iv_head_branch IS SUPPLIED.
@@ -674,6 +684,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
         iv_key         = ms_data-key
         iv_head_branch = iv_head_branch ).
       ms_data-head_branch = iv_head_branch.
+      APPEND 'head_branch' TO lt_change_log.
     ENDIF.
 
     IF iv_offline IS SUPPLIED.
@@ -681,6 +692,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
         iv_key     = ms_data-key
         iv_offline = iv_offline ).
       ms_data-offline = iv_offline.
+      APPEND 'offline' TO lt_change_log.
     ENDIF.
 
     IF is_dot_abapgit IS SUPPLIED.
@@ -688,6 +700,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
         iv_key         = ms_data-key
         is_dot_abapgit = is_dot_abapgit ).
       ms_data-dot_abapgit = is_dot_abapgit.
+      APPEND 'dot_abapgit' TO lt_change_log.
     ENDIF.
 
     IF is_local_settings IS SUPPLIED.
@@ -695,6 +708,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
         iv_key      = ms_data-key
         is_settings = is_local_settings ).
       ms_data-local_settings = is_local_settings.
+      APPEND 'local_settings' TO lt_change_log.
     ENDIF.
 
     IF iv_deserialized_at IS SUPPLIED OR iv_deserialized_by IS SUPPLIED.
@@ -703,7 +717,14 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
         iv_deserialized_at = iv_deserialized_at
         iv_deserialized_by = iv_deserialized_by ).
       ms_data-deserialized_at = iv_deserialized_at.
+      APPEND 'deserialized_at' TO lt_change_log.
     ENDIF.
+
+    MOVE-CORRESPONDING ms_data TO ls_meta_slug.
+    RAISE EVENT on_metadata_change
+      EXPORTING
+        is_meta = ls_meta_slug
+        it_change_log = lt_change_log.
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -10,9 +10,6 @@ CLASS zcl_abapgit_repo_srv DEFINITION
     CLASS-METHODS get_instance
       RETURNING
         VALUE(ri_srv) TYPE REF TO zif_abapgit_repo_srv .
-    METHODS handle_repo_meta_change
-      FOR EVENT on_metadata_change of zcl_abapgit_repo
-      IMPORTING is_meta it_change_log sender.
 
   PRIVATE SECTION.
 
@@ -32,7 +29,6 @@ CLASS zcl_abapgit_repo_srv DEFINITION
     METHODS refresh
       RAISING
         zcx_abapgit_exception .
-    METHODS constructor .
     METHODS is_sap_object_allowed
       RETURNING
         VALUE(rv_allowed) TYPE abap_bool .
@@ -74,36 +70,11 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD constructor.
-    SET HANDLER me->handle_repo_meta_change FOR ALL INSTANCES ACTIVATION 'X'.
-  ENDMETHOD.
-
-
   METHOD get_instance.
     IF gi_ref IS INITIAL.
       CREATE OBJECT gi_ref TYPE zcl_abapgit_repo_srv.
     ENDIF.
     ri_srv = gi_ref.
-  ENDMETHOD.
-
-
-  METHOD handle_repo_meta_change.
-
-    DATA:
-         lo_repo TYPE REF TO zcl_abapgit_repo,
-         li_persistence TYPE REF TO zif_abapgit_persist_repo.
-
-    lo_repo ?= sender.
-    lo_repo->get_key( ).
-
-    " TODO: how to catch exceptions ?
-
-    li_persistence = zcl_abapgit_persist_factory=>get_repo( ).
-    li_persistence->update_metadata(
-      iv_key        = lo_repo->get_key( )
-      is_meta       = is_meta
-      it_change_log = it_change_log ).
-
   ENDMETHOD.
 
 
@@ -320,6 +291,20 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
 
     ro_repo->refresh( ).
     ro_repo->find_remote_dot_abapgit( ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_repo_srv~on_repo_meta_change.
+
+    DATA:
+         li_persistence TYPE REF TO zif_abapgit_persist_repo.
+
+    li_persistence = zcl_abapgit_persist_factory=>get_repo( ).
+    li_persistence->update_metadata(
+      iv_key        = iv_key
+      is_meta       = is_meta
+      it_change_log = it_change_log ).
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -6,6 +6,7 @@ CLASS zcl_abapgit_repo_srv DEFINITION
   PUBLIC SECTION.
 
     INTERFACES zif_abapgit_repo_srv .
+    INTERFACES zif_abapgit_repo_listener .
 
     CLASS-METHODS get_instance
       RETURNING
@@ -32,9 +33,20 @@ CLASS zcl_abapgit_repo_srv DEFINITION
     METHODS is_sap_object_allowed
       RETURNING
         VALUE(rv_allowed) TYPE abap_bool .
+    METHODS instantiate_and_add
+      IMPORTING
+        !is_repo_meta TYPE zif_abapgit_persistence=>ty_repo
+      RAISING
+        zcx_abapgit_exception .
     METHODS add
       IMPORTING
         !io_repo TYPE REF TO zcl_abapgit_repo
+      RAISING
+        zcx_abapgit_exception .
+    METHODS reinstantiate_repo
+      IMPORTING
+        !iv_key  TYPE zif_abapgit_persistence=>ty_repo-key
+        !is_meta TYPE zif_abapgit_persistence=>ty_repo_xml
       RAISING
         zcx_abapgit_exception .
     METHODS validate_sub_super_packages
@@ -65,7 +77,29 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
       ENDIF.
     ENDLOOP.
 
+    io_repo->bind_listener( me ).
     APPEND io_repo TO mt_list.
+
+  ENDMETHOD.
+
+
+  METHOD instantiate_and_add.
+
+    DATA:
+      lo_online  TYPE REF TO zcl_abapgit_repo_online,
+      lo_offline TYPE REF TO zcl_abapgit_repo_offline.
+
+    IF is_repo_meta-offline = abap_false.
+      CREATE OBJECT lo_online
+        EXPORTING
+          is_data = is_repo_meta.
+      add( lo_online ).
+    ELSE.
+      CREATE OBJECT lo_offline
+        EXPORTING
+          is_data = is_repo_meta.
+      add( lo_offline ).
+    ENDIF.
 
   ENDMETHOD.
 
@@ -103,17 +137,7 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
 
     lt_list = zcl_abapgit_persist_factory=>get_repo( )->list( ).
     LOOP AT lt_list ASSIGNING <ls_list>.
-      IF <ls_list>-offline = abap_false.
-        CREATE OBJECT lo_online
-          EXPORTING
-            is_data = <ls_list>.
-        APPEND lo_online TO mt_list.
-      ELSE.
-        CREATE OBJECT lo_offline
-          EXPORTING
-            is_data = <ls_list>.
-        APPEND lo_offline TO mt_list.
-      ENDIF.
+      instantiate_and_add( <ls_list> ).
     ENDLOOP.
 
     mv_init = abap_true.
@@ -154,7 +178,7 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
 
   METHOD zif_abapgit_repo_srv~delete.
 
-    io_repo->delete( ).
+    zcl_abapgit_persist_factory=>get_repo( )->delete( io_repo->get_key( ) ).
 
     DELETE TABLE mt_list FROM io_repo.
     ASSERT sy-subrc = 0.
@@ -295,16 +319,41 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_abapgit_repo_srv~on_repo_meta_change.
+  METHOD zif_abapgit_repo_listener~on_meta_change.
 
-    DATA:
-         li_persistence TYPE REF TO zif_abapgit_persist_repo.
+    DATA li_persistence TYPE REF TO zif_abapgit_persist_repo.
 
     li_persistence = zcl_abapgit_persist_factory=>get_repo( ).
     li_persistence->update_metadata(
-      iv_key        = iv_key
-      is_meta       = is_meta
-      it_change_log = it_change_log ).
+      iv_key         = iv_key
+      is_meta        = is_meta
+      is_change_mask = is_change_mask ).
+
+
+    " Recreate repo instance if type changed
+    IF is_change_mask-offline = abap_true.
+      reinstantiate_repo(
+        iv_key  = iv_key
+        is_meta = is_meta ).
+
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD reinstantiate_repo.
+
+      DATA lo_repo      TYPE REF TO zcl_abapgit_repo.
+      DATA ls_full_meta TYPE zif_abapgit_persistence=>ty_repo.
+
+      lo_repo = get( iv_key ).
+      DELETE TABLE mt_list FROM lo_repo.
+      ASSERT sy-subrc IS INITIAL.
+
+      MOVE-CORRESPONDING is_meta TO ls_full_meta.
+      ls_full_meta-key = iv_key.
+
+      instantiate_and_add( ls_full_meta ).
 
   ENDMETHOD.
 
@@ -328,38 +377,6 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
                                  is_checks = is_checks ).
 
     delete( io_repo ).
-
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_repo_srv~switch_repo_type.
-
-* todo, this should be a method on the repo instead?
-
-    DATA lo_repo TYPE REF TO zcl_abapgit_repo.
-
-    FIELD-SYMBOLS <lo_repo> LIKE LINE OF mt_list.
-
-    lo_repo = get( iv_key ).
-    READ TABLE mt_list ASSIGNING <lo_repo> FROM lo_repo.
-    ASSERT sy-subrc IS INITIAL.
-    ASSERT iv_offline <> lo_repo->ms_data-offline.
-
-    IF iv_offline = abap_true. " On-line -> OFFline
-      lo_repo->set(
-        iv_url         = zcl_abapgit_url=>name( lo_repo->ms_data-url )
-        iv_branch_name = ''
-        iv_head_branch = ''
-        iv_offline     = abap_true ).
-      CREATE OBJECT <lo_repo> TYPE zcl_abapgit_repo_offline
-        EXPORTING
-          is_data = lo_repo->ms_data.
-    ELSE. " OFFline -> On-line
-      lo_repo->set( iv_offline = abap_false ).
-      CREATE OBJECT <lo_repo> TYPE zcl_abapgit_repo_online
-        EXPORTING
-          is_data = lo_repo->ms_data.
-    ENDIF.
 
   ENDMETHOD.
 

--- a/src/zif_abapgit_repo_listener.intf.abap
+++ b/src/zif_abapgit_repo_listener.intf.abap
@@ -1,13 +1,13 @@
-interface ZIF_ABAPGIT_REPO_LISTENER
-  public .
+INTERFACE zif_abapgit_repo_listener
+  PUBLIC .
 
 
-  interface ZIF_ABAPGIT_PERSISTENCE load .
-  methods ON_META_CHANGE
-    importing
-      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
-      !IS_META type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO_XML
-      !IS_CHANGE_MASK type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO_META_MASK
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-endinterface.
+  INTERFACE zif_abapgit_persistence LOAD .
+  METHODS on_meta_change
+    IMPORTING
+      !iv_key TYPE zif_abapgit_persistence=>ty_repo-key
+      !is_meta TYPE zif_abapgit_persistence=>ty_repo_xml
+      !is_change_mask TYPE zif_abapgit_persistence=>ty_repo_meta_mask
+    RAISING
+      zcx_abapgit_exception .
+ENDINTERFACE.

--- a/src/zif_abapgit_repo_listener.intf.abap
+++ b/src/zif_abapgit_repo_listener.intf.abap
@@ -1,0 +1,13 @@
+interface ZIF_ABAPGIT_REPO_LISTENER
+  public .
+
+
+  interface ZIF_ABAPGIT_PERSISTENCE load .
+  methods ON_META_CHANGE
+    importing
+      !IV_KEY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-KEY
+      !IS_META type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO_XML
+      !IS_CHANGE_MASK type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO_META_MASK
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+endinterface.

--- a/src/zif_abapgit_repo_listener.intf.xml
+++ b/src/zif_abapgit_repo_listener.intf.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_ABAPGIT_REPO_LISTENER</CLSNAME>
+    <VERSION>1</VERSION>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Abapgit repo listener</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zif_abapgit_repo_srv.intf.abap
+++ b/src/zif_abapgit_repo_srv.intf.abap
@@ -50,12 +50,6 @@ INTERFACE zif_abapgit_repo_srv
       is_checks TYPE zif_abapgit_definitions=>ty_delete_checks
     RAISING
       zcx_abapgit_exception .
-  METHODS switch_repo_type
-    IMPORTING
-      !iv_key     TYPE zif_abapgit_persistence=>ty_value
-      !iv_offline TYPE abap_bool
-    RAISING
-      zcx_abapgit_exception .
   METHODS validate_package
     IMPORTING
       !iv_package TYPE devclass

--- a/src/zif_abapgit_repo_srv.intf.abap
+++ b/src/zif_abapgit_repo_srv.intf.abap
@@ -55,11 +55,4 @@ INTERFACE zif_abapgit_repo_srv
       !iv_package TYPE devclass
     RAISING
       zcx_abapgit_exception .
-  METHODS on_repo_meta_change
-    IMPORTING
-      IV_KEY        TYPE zif_abapgit_persistence=>ty_repo-key
-      IS_META       TYPE zif_abapgit_persistence=>ty_repo_xml
-      IT_CHANGE_LOG TYPE string_table
-    RAISING
-      zcx_abapgit_exception .
 ENDINTERFACE.

--- a/src/zif_abapgit_repo_srv.intf.abap
+++ b/src/zif_abapgit_repo_srv.intf.abap
@@ -61,4 +61,11 @@ INTERFACE zif_abapgit_repo_srv
       !iv_package TYPE devclass
     RAISING
       zcx_abapgit_exception .
+  METHODS on_repo_meta_change
+    IMPORTING
+      IV_KEY        TYPE zif_abapgit_persistence=>ty_repo-key
+      IS_META       TYPE zif_abapgit_persistence=>ty_repo_xml
+      IT_CHANGE_LOG TYPE string_table
+    RAISING
+      zcx_abapgit_exception .
 ENDINTERFACE.


### PR DESCRIPTION
to #2127 

OK here is the beta code for points B, C and D from the original discussion. (they are interconnected so could not really do separately)

Briefly:
- repo now has `bind_listener` to assign an object with `ZIF_ABAPGIT_REPO_LISTENER`
- repo does not call persistence itself, instead calls `notify_lister` which triggers `ZIF_ABAPGIT_REPO_LISTENER` instance if bound
- SRV implements the listener and calls to persistence
- persistence is unified a bit - there is only one method now `update_metadata` - looks cleaner and no code duplication
- `delete_repo` moved to SRV
- `switch_repo_type` moved to repo, however this is a bit more complex because SRV has to recreate it (also posted an opinion on this in #1757  ), so SRV kept some part of the code
- however this was enough to remove `friends` between repo and SRV

Doubts
- `delete_checks` remained in repo. And I feel that it is right but no strong argumentation. Kind of `delete_checks` is about repo content and not repo management (like `delete`).
- in the implemented code `iv_key` is passed separately from all other repo meta. Looks like I overcomplicated this ... probably should be complete `ms_data` ... what do you think ?
- private methods of srv can be further fine-tuned and merged. Maybe will have a look yet.






