### PR TITLE
gitignore and package.json improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+# Artefacts
+node_modules/
 package-lock.json
 zabapgit.abap

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "pretest": "abaplint --version && abaplint \"src/**/*.abap\"",
     "test": "abapmerge src/zabapgit.prog.abap > zabapgit.abap",
-    "_disabled_posttest": "abaplint zabapgit.abap"
+    "_disabled_posttest": "abaplint zabapgit.abap",
+    "lint": "node_modules/.bin/abaplint \"src/**/*.abap\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
gitignore: added `node_modules`, after `npm install` they are gittable now ...
package.json: explicit command for linter. But will work after this is fixed: https://github.com/larshp/abaplint/issues/297