### PR TITLE
Branch overview: show commit details when hover #1821

### DIFF
--- a/docs/other-external-libraries.md
+++ b/docs/other-external-libraries.md
@@ -9,4 +9,4 @@ abapGit uses a few external libraries, these are loaded via [cdnjs](https://cdnj
 Library   | Version | License
 :------------ | :------------ | :------------
 [octicons](https://github.com/primer/octicons) | 4.4.0 | MIT
-[gitgraph](https://github.com/nicoespeon/gitgraph.js) | 1.12.0 | MIT
+[gitgraph](https://github.com/nicoespeon/gitgraph.js) | 1.14.0 | MIT

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -60,6 +60,14 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION PUBLIC FINAL CREATE PUBLIC.
       RAISING
         zcx_abapgit_exception.
 
+    CLASS-METHODS render_commit_popup
+      IMPORTING
+        iv_content     TYPE csequence
+        iv_id          TYPE csequence
+      RETURNING
+        VALUE(ro_html) TYPE REF TO zcl_abapgit_html
+      RAISING
+        zcx_abapgit_exception.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -67,7 +75,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
+CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
 
 
   METHOD render_branch_span.
@@ -93,6 +101,26 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
       ro_html->add( lv_text ).
     ENDIF.
     ro_html->add( '</span>' ).
+
+  ENDMETHOD.
+
+
+  METHOD render_commit_popup.
+
+    CREATE OBJECT ro_html.
+
+    ro_html->add( '<ul class="hotkeys">' ).
+    ro_html->add( |<li>|
+      && |<span>{ iv_content }</span>|
+      && |</li>| ).
+    ro_html->add( '</ul>' ).
+
+    ro_html = render_infopanel(
+      iv_div_id     = |{ iv_id }|
+      iv_title      = 'Commit details'
+      iv_hide       = abap_true
+      iv_scrollable = abap_false
+      io_content    = ro_html ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
@@ -145,14 +145,14 @@ CLASS zcl_abapgit_gui_page_boverview IMPLEMENTATION.
           }", author: "{
           <ls_commit>-author }", sha1: "{
           <ls_commit>-sha1(7) }", tag: "{ lv_tag
-          }", onClick:gBranchOveriew.fnOnCommitClick.bind(gBranchOveriew)\});| ).
+          }", onClick:gBranchOveriew.onCommitClick.bind(gBranchOveriew)\});| ).
       ELSE.
         ro_html->add( |{ escape_branch( <ls_commit>-merge ) }.merge({
           escape_branch( <ls_commit>-branch ) }, \{message: "{
           escape_message( <ls_commit>-message ) }", long: "{ escape_message( concat_lines_of( table = <ls_commit>-body
                                                                                               sep   = ` ` ) )
           }", author: "{ <ls_commit>-author }", sha1: "{
-          <ls_commit>-sha1(7) }", onClick:gBranchOveriew.fnOnCommitClick.bind(gBranchOveriew)\});| ).
+          <ls_commit>-sha1(7) }", onClick:gBranchOveriew.onCommitClick.bind(gBranchOveriew)\});| ).
       ENDIF.
 
       LOOP AT <ls_commit>-create ASSIGNING <ls_create>.
@@ -170,9 +170,9 @@ CLASS zcl_abapgit_gui_page_boverview IMPLEMENTATION.
     ENDLOOP.
 
     ro_html->add(
-       |gitGraph.addEventListener( "commit:mouseover", gBranchOveriew.fnShowCommit.bind(gBranchOveriew) );| ).
+       |gitGraph.addEventListener( "commit:mouseover", gBranchOveriew.showCommit.bind(gBranchOveriew) );| ).
     ro_html->add(
-       |gitGraph.addEventListener( "commit:mouseout",  gBranchOveriew.fnHideCommit.bind(gBranchOveriew) );| ).
+       |gitGraph.addEventListener( "commit:mouseout",  gBranchOveriew.hideCommit.bind(gBranchOveriew) );| ).
 
     ro_html->add( '</script>' ).
 

--- a/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
@@ -56,15 +56,21 @@ CLASS zcl_abapgit_gui_page_boverview DEFINITION
         RETURNING VALUE(rv_string) TYPE string,
       escape_message
         IMPORTING iv_string        TYPE string
-        RETURNING VALUE(rv_string) TYPE string.
+        RETURNING VALUE(rv_string) TYPE string,
+      render_commit_popups
+        RETURNING VALUE(ro_html) TYPE REF TO zcl_abapgit_html
+        RAISING   zcx_abapgit_exception.
 ENDCLASS.
+
 
 
 CLASS zcl_abapgit_gui_page_boverview IMPLEMENTATION.
 
+
   METHOD body.
-    DATA: lv_tag                 TYPE string.
-    DATA: lv_branch_display_name TYPE string.
+
+    DATA: lv_tag                 TYPE string,
+          lv_branch_display_name TYPE string.
 
     FIELD-SYMBOLS: <ls_commit> LIKE LINE OF mt_commits,
                    <ls_create> LIKE LINE OF <ls_commit>-create.
@@ -88,7 +94,7 @@ CLASS zcl_abapgit_gui_page_boverview IMPLEMENTATION.
     ro_html->add( '<canvas id="gitGraph"></canvas>' ).
 
     ro_html->add( '<script type="text/javascript" src="https://cdnjs.' &&
-      'cloudflare.com/ajax/libs/gitgraph.js/1.12.0/gitgraph.min.js">' &&
+      'cloudflare.com/ajax/libs/gitgraph.js/1.14.0/gitgraph.min.js">' &&
       '</script>' ) ##NO_TEXT.
 
     ro_html->add( '<script type="text/javascript">' ).
@@ -109,8 +115,10 @@ CLASS zcl_abapgit_gui_page_boverview IMPLEMENTATION.
     ro_html->add( '  template: myTemplateConfig,' ).
     ro_html->add( '  orientation: "vertical-reverse"' ).
     ro_html->add( '});' ).
+    ro_html->add( 'var gBranchOveriew = new BranchOverview();' ).
 
     LOOP AT mt_commits ASSIGNING <ls_commit>.
+
       IF sy-tabix = 1.
 * assumption: all branches are created from master, todo
         ro_html->add( |var {
@@ -132,15 +140,19 @@ CLASS zcl_abapgit_gui_page_boverview IMPLEMENTATION.
                                   sep   = ` | ` ).
 
         ro_html->add( |{ escape_branch( <ls_commit>-branch ) }.commit(\{message: "{
-          escape_message( <ls_commit>-message ) }", author: "{
+          escape_message( <ls_commit>-message ) }", long: "{ escape_message( concat_lines_of( table = <ls_commit>-body
+                                                                                              sep   = ` ` ) )
+          }", author: "{
           <ls_commit>-author }", sha1: "{
-          <ls_commit>-sha1(7) }", tag: "{ lv_tag }"\});| ).
+          <ls_commit>-sha1(7) }", tag: "{ lv_tag
+          }", onClick:gBranchOveriew.fnOnCommitClick.bind(gBranchOveriew)\});| ).
       ELSE.
         ro_html->add( |{ escape_branch( <ls_commit>-merge ) }.merge({
           escape_branch( <ls_commit>-branch ) }, \{message: "{
-          escape_message( <ls_commit>-message ) }", author: "{
-          <ls_commit>-author }", sha1: "{
-          <ls_commit>-sha1(7) }"\});| ).
+          escape_message( <ls_commit>-message ) }", long: "{ escape_message( concat_lines_of( table = <ls_commit>-body
+                                                                                              sep   = ` ` ) )
+          }", author: "{ <ls_commit>-author }", sha1: "{
+          <ls_commit>-sha1(7) }", onClick:gBranchOveriew.fnOnCommitClick.bind(gBranchOveriew)\});| ).
       ENDIF.
 
       LOOP AT <ls_commit>-create ASSIGNING <ls_create>.
@@ -157,7 +169,14 @@ CLASS zcl_abapgit_gui_page_boverview IMPLEMENTATION.
 
     ENDLOOP.
 
+    ro_html->add(
+       |gitGraph.addEventListener( "commit:mouseover", gBranchOveriew.fnShowCommit.bind(gBranchOveriew) );| ).
+    ro_html->add(
+       |gitGraph.addEventListener( "commit:mouseout",  gBranchOveriew.fnHideCommit.bind(gBranchOveriew) );| ).
+
     ro_html->add( '</script>' ).
+
+    ro_html->add( render_commit_popups( ) ).
 
   ENDMETHOD.
 
@@ -327,4 +346,63 @@ CLASS zcl_abapgit_gui_page_boverview IMPLEMENTATION.
     ENDCASE.
 
   ENDMETHOD.
+
+  METHOD render_commit_popups.
+
+    DATA: lv_time    TYPE char10,
+          lv_date    TYPE sy-datum,
+          lv_content TYPE string.
+
+    FIELD-SYMBOLS: <ls_commit> LIKE LINE OF mt_commits.
+
+    CREATE OBJECT ro_html.
+
+    LOOP AT mt_commits ASSIGNING <ls_commit>.
+
+      CLEAR: lv_time, lv_date.
+
+      PERFORM p6_to_date_time_tz IN PROGRAM rstr0400
+                                 USING <ls_commit>-time
+                                       lv_time
+                                       lv_date.
+
+      lv_content = |<table class="commit">|
+                && |  <tr>|
+                && |    <td class="title">Author</td>|
+                && |    <td>{ <ls_commit>-author }</td>|
+                && |  </tr>|
+                && |  <tr>|
+                && |    <td class="title">SHA1</td>|
+                && |    <td>{ <ls_commit>-sha1 }</td>|
+                && |  </tr>|
+                && |  <tr>|
+                && |    <td class="title">Date/Time</td>|
+                && |    <td>{ lv_date DATE = USER }</td>|
+                && |  </tr>|
+                && |  <tr>|
+                && |    <td class="title">Message</td>|
+                && |    <td>{ <ls_commit>-message }</td>|
+                && |  </tr>|
+                && |  <tr>|.
+
+      IF <ls_commit>-body IS NOT INITIAL.
+        lv_content = lv_content
+                  && |<td class="title">Body</td>|
+                  && |<td>{ concat_lines_of( table = <ls_commit>-body
+                                             sep   = |<br/>| ) }</td>|.
+      ENDIF.
+
+      lv_content = lv_content
+                && |  </tr>|
+                && |</table>|.
+
+      ro_html->add( zcl_abapgit_gui_chunk_lib=>render_commit_popup( iv_id      = <ls_commit>-sha1(7)
+                                                                    iv_content = lv_content ) ).
+
+    ENDLOOP.
+
+
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/zabapgit_css_common.w3mi.data.css
+++ b/src/zabapgit_css_common.w3mi.data.css
@@ -915,8 +915,8 @@ div.info-panel div.info-list td {
   color: lightgrey !important; 
 }
 
-/* HOTKEYS */
 
+/* HOTKEYS */
 ul.hotkeys {
   list-style-type: none;
   padding: 0;
@@ -951,4 +951,10 @@ div.corner-hint {
   opacity: 0.5;
   background: white;
   z-index: 99;
+}
+
+/* Commit popup */
+table.commit tr .title {
+  font-weight: bold;
+  vertical-align: top;
 }

--- a/src/zabapgit_js_common.w3mi.data.js
+++ b/src/zabapgit_js_common.w3mi.data.js
@@ -1146,7 +1146,7 @@ function BranchOverview() {
   };
 }
 
-BranchOverview.prototype.fnToggleCommit = function(sha1) {
+BranchOverview.prototype.toggleCommit = function(sha1) {
 
   if (this.elCurrentCommit.style.display && this.bFixed) {
     this.elCurrentCommit.style.display = 'none';
@@ -1159,11 +1159,11 @@ BranchOverview.prototype.fnToggleCommit = function(sha1) {
 
 };
 
-BranchOverview.prototype.fnOnCommitClick = function(commit){
-  this.fnToggleCommit(commit.sha1);
+BranchOverview.prototype.onCommitClick = function(commit){
+  this.toggleCommit(commit.sha1);
 };
 
-BranchOverview.prototype.fnShowCommit = function(event){
+BranchOverview.prototype.showCommit = function(event){
   // If there is any commit visible we hide it first
   if (this.elCurrentCommit.style.display) {
     this.elCurrentCommit.style.display = 'none';
@@ -1174,7 +1174,7 @@ BranchOverview.prototype.fnShowCommit = function(event){
   this.bFixed = false;
 };
 
-BranchOverview.prototype.fnHideCommit = function (event){
+BranchOverview.prototype.hideCommit = function (event){
   if (!this.bFixed){
     this.elCurrentCommit.style.display = 'none';
   }

--- a/src/zabapgit_js_common.w3mi.data.js
+++ b/src/zabapgit_js_common.w3mi.data.js
@@ -1119,7 +1119,6 @@ Patch.prototype.collectActiveElementsForSelector = function(sSelector){
 
 };
 
-
 function preparePatch(){
 
   var oPatch = new Patch();
@@ -1133,3 +1132,50 @@ function registerStagePatch(){
   oPatch.registerStagePatch();
 
 }
+
+/**********************************************************
+ * Page branch overview
+ **********************************************************/
+
+function BranchOverview() {
+  this.bFixed = false;
+  this.elCurrentCommit = {
+    style : {
+      display: 'none'
+    }
+  };
+}
+
+BranchOverview.prototype.fnToggleCommit = function(sha1) {
+
+  if (this.elCurrentCommit.style.display && this.bFixed) {
+    this.elCurrentCommit.style.display = 'none';
+    this.bFixed = false;
+  } else {
+    this.elCurrentCommit = document.getElementById(sha1);
+    this.elCurrentCommit.style.display = '';
+    this.bFixed = true;
+  }
+
+};
+
+BranchOverview.prototype.fnOnCommitClick = function(commit){
+  this.fnToggleCommit(commit.sha1);
+};
+
+BranchOverview.prototype.fnShowCommit = function(event){
+  // If there is any commit visible we hide it first
+  if (this.elCurrentCommit.style.display) {
+    this.elCurrentCommit.style.display = 'none';
+  }
+
+  this.elCurrentCommit = document.getElementById(event.data.sha1);
+  this.elCurrentCommit.style.display = '';
+  this.bFixed = false;
+};
+
+BranchOverview.prototype.fnHideCommit = function (event){
+  if (!this.bFixed){
+    this.elCurrentCommit.style.display = 'none';
+  }
+};

--- a/src/zabapgit_js_common.w3mi.data.js
+++ b/src/zabapgit_js_common.w3mi.data.js
@@ -1135,6 +1135,13 @@ function registerStagePatch(){
 
 /**********************************************************
  * Page branch overview
+ * 
+ * Hovering a commit node in the branch overview will show
+ * a popup with the commit details. Single click on a node
+ * will fix the popup, so that users can select text. The
+ * fixation is removed when any node is hovered or the popup 
+ * is closed via 'X'.
+ * 
  **********************************************************/
 
 function BranchOverview() {
@@ -1146,36 +1153,41 @@ function BranchOverview() {
   };
 }
 
-BranchOverview.prototype.toggleCommit = function(sha1) {
+BranchOverview.prototype.toggleCommit = function(sSha1, bFixPopup) {
 
-  if (this.elCurrentCommit.style.display && this.bFixed) {
-    this.elCurrentCommit.style.display = 'none';
+  // If the popup is fixed, we just remove the fixation.
+  // The popup will then be hidden by the next call of hideCommit 
+  if (this.bFixed) {
     this.bFixed = false;
-  } else {
-    this.elCurrentCommit = document.getElementById(sha1);
+    return;
+  } 
+
+  // We hide the previous shown commit popup
+  this.elCurrentCommit.style.display = 'none';
+
+  // Display the new commit popup if sha1 is supplied
+  if (sSha1){
+    this.elCurrentCommit = document.getElementById(sSha1);
     this.elCurrentCommit.style.display = '';
-    this.bFixed = true;
+
+    // and fix the popup so that the next hideCommit won't hide it.
+    this.bFixed = bFixPopup;
+
   }
 
 };
 
+// called by onClick of commit nodes in branch overview
 BranchOverview.prototype.onCommitClick = function(commit){
-  this.toggleCommit(commit.sha1);
+  this.toggleCommit(commit.sha1, true);
 };
 
+// Called by commit:mouseover
 BranchOverview.prototype.showCommit = function(event){
-  // If there is any commit visible we hide it first
-  if (this.elCurrentCommit.style.display) {
-    this.elCurrentCommit.style.display = 'none';
-  }
-
-  this.elCurrentCommit = document.getElementById(event.data.sha1);
-  this.elCurrentCommit.style.display = '';
-  this.bFixed = false;
+  this.toggleCommit(event.data.sha1);
 };
 
+// Called by commit:mouseout
 BranchOverview.prototype.hideCommit = function (event){
-  if (!this.bFixed){
-    this.elCurrentCommit.style.display = 'none';
-  }
+  this.toggleCommit();
 };

--- a/src/zcl_abapgit_branch_overview.clas.abap
+++ b/src/zcl_abapgit_branch_overview.clas.abap
@@ -75,7 +75,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_BRANCH_OVERVIEW IMPLEMENTATION.
+CLASS zcl_abapgit_branch_overview IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -349,7 +349,8 @@ CLASS ZCL_ABAPGIT_BRANCH_OVERVIEW IMPLEMENTATION.
           lt_body   TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
           ls_raw    TYPE zcl_abapgit_git_pack=>ty_commit.
 
-    FIELD-SYMBOLS: <ls_object> LIKE LINE OF it_objects.
+    FIELD-SYMBOLS: <ls_object> LIKE LINE OF it_objects,
+                   <lv_body>   TYPE string.
 
 
     LOOP AT it_objects ASSIGNING <ls_object> USING KEY type
@@ -370,6 +371,11 @@ CLASS ZCL_ABAPGIT_BRANCH_OVERVIEW IMPLEMENTATION.
       ENDIF.
 
       READ TABLE lt_body INDEX 1 INTO ls_commit-message.  "#EC CI_SUBRC
+      " The second line is always empty. Therefore we omit it.
+      LOOP AT lt_body ASSIGNING <lv_body>
+                      FROM 3.
+        INSERT <lv_body> INTO TABLE ls_commit-body.
+      ENDLOOP.
 
 * unix time stamps are in same time zone, so ignore the zone,
       FIND REGEX zif_abapgit_definitions=>c_author_regex IN ls_raw-author
@@ -418,7 +424,6 @@ CLASS ZCL_ABAPGIT_BRANCH_OVERVIEW IMPLEMENTATION.
                    <ls_temp>     LIKE LINE OF lt_temp,
                    <ls_temp_end> LIKE LINE OF lt_temp,
                    <ls_commit>   LIKE LINE OF it_commits.
-
 
     LOOP AT mt_branches ASSIGNING <ls_branch>.
 

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -249,6 +249,7 @@ INTERFACE zif_abapgit_definitions PUBLIC.
            email      TYPE string,
            time       TYPE string,
            message    TYPE string,
+           body       TYPE stringtab,
            branch     TYPE string,
            merge      TYPE string,
            tags       TYPE stringtab,


### PR DESCRIPTION
- update to latest gitgraph
- show commit details (Author, date and time, commit message, message body and long SHA1) when hover
- click on commit fixes the popup so one can mark text and copy text

![abapgit_bo](https://user-images.githubusercontent.com/17437789/49655660-823f4880-fa3b-11e8-8bc8-e0359021c395.gif)

#1821 
