### PR TITLE
Sapscript : sequence of Windows in tdlines files

### DIFF
--- a/src/objects/zcl_abapgit_object_form.clas.abap
+++ b/src/objects/zcl_abapgit_object_form.clas.abap
@@ -449,6 +449,26 @@ CLASS zcl_abapgit_object_form IMPLEMENTATION.
         tabs         = es_form_data-tabs
         windows      = es_form_data-windows.
 
+    DATA(lv_firstloop) = abap_true.
+    DATA(lt_windows)   = es_form_data-windows.
+    DATA(lt_lines)     = et_lines.
+    SORT lt_windows BY tdwindow.
+
+    REFRESH et_lines.
+    LOOP AT lt_windows INTO DATA(ls_windows).
+      lv_firstloop = abap_true.
+      READ TABLE lt_lines INTO DATA(ls_lines) WITH KEY tdformat = '/W'
+                                                       tdline = ls_windows-tdwindow.
+      LOOP AT lt_lines INTO ls_lines FROM sy-tabix.
+        IF lv_firstloop = abap_false AND
+           ls_lines-tdformat = '/W'.
+          EXIT.
+        ENDIF.
+        APPEND ls_lines TO et_lines.
+        lv_firstloop = abap_false.
+      ENDLOOP.
+    ENDLOOP.
+    
   ENDMETHOD.
 
 


### PR DESCRIPTION
Hello Lars,

You can find a code modification in the method _read_form of class zcl_abapgit_object_form related to the issue #2188
I have added a logic to sort by windows name the contains of the internal table ET_LINES . It allows to have always thre same sequence of  windows code in the file (xxxxxxxxxxgit.form.tdlines). Then file comparison will work with all export.

Regards
Christophe