### PR TITLE
fix whitespace and other minor changes

### DIFF
--- a/src/objects/ecatt/zcl_abapgit_ecatt_sp_upload.clas.abap
+++ b/src/objects/ecatt/zcl_abapgit_ecatt_sp_upload.clas.abap
@@ -168,7 +168,7 @@ CLASS ZCL_ABAPGIT_ECATT_SP_UPLOAD IMPLEMENTATION.
 * Devesh,C5129871  18.07.2011  Releasing enqueu after uploading
 *begin
     TRY.
-        ecatt_object->close_object( im_suppress_events ='X' ).
+        ecatt_object->close_object( im_suppress_events = 'X' ).
       CATCH cx_ecatt_apl INTO lx_ecatt.
     ENDTRY.
 *end

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -4,42 +4,46 @@ CLASS zcl_abapgit_object_msag DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
     INTERFACES zif_abapgit_object.
     ALIASES mo_files FOR zif_abapgit_object~mo_files.
 
+  PROTECTED SECTION.
   PRIVATE SECTION.
-    TYPES: BEGIN OF ty_t100_texts,
-             sprsl TYPE t100-sprsl,
-             msgnr TYPE t100-msgnr,
-             text  TYPE t100-text,
-           END OF ty_t100_texts,
-           tt_t100_texts TYPE STANDARD TABLE OF ty_t100_texts,
-           tty_t100      TYPE STANDARD TABLE OF t100
-                         WITH NON-UNIQUE DEFAULT KEY,
-           BEGIN OF ty_longtext,
-             dokil TYPE dokil,
-             head  TYPE thead,
-             lines TYPE tline_tab,
-           END OF ty_longtext,
-           tty_longtexts TYPE STANDARD TABLE OF ty_longtext
-                              WITH NON-UNIQUE DEFAULT KEY.
 
-    METHODS:
-      serialize_texts
-        IMPORTING io_xml TYPE REF TO zcl_abapgit_xml_output
-        RAISING   zcx_abapgit_exception,
-      deserialize_texts
-        IMPORTING io_xml TYPE REF TO zcl_abapgit_xml_input
-        RAISING   zcx_abapgit_exception,
-      serialize_longtexts_msag
-        IMPORTING it_t100 TYPE zcl_abapgit_object_msag=>tty_t100
-                  io_xml  TYPE REF TO zcl_abapgit_xml_output
-        RAISING   zcx_abapgit_exception,
-      delete_msgid IMPORTING iv_message_id TYPE arbgb,
-      free_access_permission
-        IMPORTING
-          iv_message_id TYPE arbgb,
-      delete_documentation
-        IMPORTING
-          iv_message_id TYPE arbgb.
+    TYPES:
+      BEGIN OF ty_t100_texts,
+        sprsl TYPE t100-sprsl,
+        msgnr TYPE t100-msgnr,
+        text  TYPE t100-text,
+      END OF ty_t100_texts .
+    TYPES:
+      tt_t100_texts TYPE STANDARD TABLE OF ty_t100_texts .
+    TYPES:
+      tty_t100      TYPE STANDARD TABLE OF t100
+                           WITH NON-UNIQUE DEFAULT KEY .
 
+    METHODS serialize_texts
+      IMPORTING
+        !io_xml TYPE REF TO zcl_abapgit_xml_output
+      RAISING
+        zcx_abapgit_exception .
+    METHODS deserialize_texts
+      IMPORTING
+        !io_xml TYPE REF TO zcl_abapgit_xml_input
+      RAISING
+        zcx_abapgit_exception .
+    METHODS serialize_longtexts_msag
+      IMPORTING
+        !it_t100 TYPE zcl_abapgit_object_msag=>tty_t100
+        !io_xml  TYPE REF TO zcl_abapgit_xml_output
+      RAISING
+        zcx_abapgit_exception .
+    METHODS delete_msgid
+      IMPORTING
+        !iv_message_id TYPE arbgb .
+    METHODS free_access_permission
+      IMPORTING
+        !iv_message_id TYPE arbgb .
+    METHODS delete_documentation
+      IMPORTING
+        !iv_message_id TYPE arbgb .
 ENDCLASS.
 
 

--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -465,7 +465,7 @@ CLASS ZCL_ABAPGIT_OBJECTS_PROGRAM IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'error from RS_CORR_INSERT' ).
     ENDIF.
 
-    READ TABLE it_tpool INTO ls_tpool WITH KEY id = 'R'.  "#EC CI_SUBRC
+    READ TABLE it_tpool INTO ls_tpool WITH KEY id = 'R'.
     IF sy-subrc = 0.
 * there is a bug in RPY_PROGRAM_UPDATE, the header line of TTAB is not
 * cleared, so the title length might be inherited from a different program.

--- a/src/ui/zcl_abapgit_gui_page_merge_res.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_merge_res.clas.abap
@@ -460,7 +460,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MERGE_RES IMPLEMENTATION.
       ro_html->add( '</form>' ).                            "#EC NOTEXT
       ro_html->add( '<th class="num"></th>' ).              "#EC NOTEXT
       ro_html->add( '<form id="source_form" method="post" action="sapevent:apply_source">' ). "#EC NOTEXT
-      ro_html->add( '<th>Source  - ' && mo_merge->get_source_branch( ) &&' - ' ). "#EC NOTEXT
+      ro_html->add( '<th>Source  - ' && mo_merge->get_source_branch( ) && ' - ' ). "#EC NOTEXT
       ro_html->add_a( iv_act = 'submitFormById(''source_form'');' "#EC NOTEXT
                       iv_txt = 'Apply'
                       iv_typ = zif_abapgit_definitions=>c_action_type-onclick
@@ -473,9 +473,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MERGE_RES IMPLEMENTATION.
       ro_html->add( '<thead class="header">' ).             "#EC NOTEXT
       ro_html->add( '<tr>' ).                               "#EC NOTEXT
       ro_html->add( '<th class="num"></th>' ).              "#EC NOTEXT
-      ro_html->add( '<th>Target - ' && mo_repo->get_branch_name( ) &&'</th> ' ). "#EC NOTEXT
+      ro_html->add( '<th>Target - ' && mo_repo->get_branch_name( ) && '</th> ' ). "#EC NOTEXT
       ro_html->add( '<th class="num"></th>' ).              "#EC NOTEXT
-      ro_html->add( '<th>Source - ' && mo_merge->get_source_branch( ) &&'</th> ' ). "#EC NOTEXT
+      ro_html->add( '<th>Source - ' && mo_merge->get_source_branch( ) && '</th> ' ). "#EC NOTEXT
       ro_html->add( '</tr>' ).                              "#EC NOTEXT
       ro_html->add( '</thead>' ).                           "#EC NOTEXT
     ENDIF.

--- a/src/zcl_abapgit_file_status.clas.abap
+++ b/src/zcl_abapgit_file_status.clas.abap
@@ -11,6 +11,7 @@ CLASS zcl_abapgit_file_status DEFINITION
       RETURNING VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
       RAISING   zcx_abapgit_exception.
 
+  PROTECTED SECTION.
   PRIVATE SECTION.
 
     CLASS-METHODS:
@@ -424,7 +425,6 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
           iv_path     = <ls_result>-path
           iv_filename = <ls_result>-filename ) = abap_true.
         DELETE rt_results INDEX lv_index.
-        CONTINUE.
       ENDIF.
     ENDLOOP.
 

--- a/src/zcx_abapgit_exception.clas.testclasses.abap
+++ b/src/zcx_abapgit_exception.clas.testclasses.abap
@@ -171,7 +171,7 @@ CLASS ltcl_test IMPLEMENTATION.
                  msgno TYPE symsgno VALUE '001',
                  msgv1 TYPE symsgv VALUE 'Variable 1',
                  msgv2 TYPE symsgv VALUE 'Variable 2',
-                 msgv3 TYPE symsgv VALUE'Variable 3',
+                 msgv3 TYPE symsgv VALUE 'Variable 3',
                  msgv4 TYPE symsgv VALUE IS INITIAL,
                END OF lc_msg4.
 


### PR DESCRIPTION
* Whitespace before and after `'`
* unused types removed from MSAG class
* a single CI_SUBRC removed, as `subrc` is checked in next statement
* CONTINUE removed in file status class, as the next statement is ENDLOOP