### PR TITLE
stage: remove also ignored local files

### DIFF
--- a/src/zcl_abapgit_stage_logic.clas.abap
+++ b/src/zcl_abapgit_stage_logic.clas.abap
@@ -52,7 +52,8 @@ CLASS ZCL_ABAPGIT_STAGE_LOGIC IMPLEMENTATION.
 
     DATA: lv_index TYPE i.
 
-    FIELD-SYMBOLS: <ls_remote> LIKE LINE OF cs_files-remote.
+    FIELD-SYMBOLS: <ls_remote> LIKE LINE OF cs_files-remote,
+                   <ls_local>  LIKE LINE OF cs_files-local.
 
 
     LOOP AT cs_files-remote ASSIGNING <ls_remote>.
@@ -66,6 +67,17 @@ CLASS ZCL_ABAPGIT_STAGE_LOGIC IMPLEMENTATION.
          AND <ls_remote>-filename = zif_abapgit_definitions=>c_dot_abapgit.
         " Remove .abapgit from remotes - it cannot be removed or ignored
         DELETE cs_files-remote INDEX lv_index.
+      ENDIF.
+
+    ENDLOOP.
+
+    LOOP AT cs_files-local ASSIGNING <ls_local>.
+      lv_index = sy-tabix.
+
+      IF io_repo->get_dot_abapgit( )->is_ignored(
+          iv_path     = <ls_local>-file-path
+          iv_filename = <ls_local>-file-filename ) = abap_true.
+        DELETE cs_files-local INDEX lv_index.
       ENDIF.
 
     ENDLOOP.


### PR DESCRIPTION
Ignored files posses the property that they do not exist in remotes but do exist in local
repositories.

Before this patch, local ignored files were displayed in the Stage.