### PR TITLE
Fix #2171 - removed dependency on field order

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
@@ -1,15 +1,19 @@
 CLASS zcl_abapgit_gui_page_repo_sett DEFINITION
-    PUBLIC FINAL
-    CREATE PUBLIC INHERITING FROM zcl_abapgit_gui_page.
+  PUBLIC
+  INHERITING FROM zcl_abapgit_gui_page
+  FINAL
+  CREATE PUBLIC .
 
   PUBLIC SECTION.
-    INTERFACES: zif_abapgit_gui_page_hotkey.
 
-    METHODS:
-      constructor
-        IMPORTING io_repo TYPE REF TO zcl_abapgit_repo,
-      zif_abapgit_gui_page~on_event REDEFINITION.
+    INTERFACES zif_abapgit_gui_page_hotkey .
 
+    METHODS constructor
+      IMPORTING
+        !io_repo TYPE REF TO zcl_abapgit_repo .
+
+    METHODS zif_abapgit_gui_page~on_event
+        REDEFINITION .
   PROTECTED SECTION.
 
     CONSTANTS:
@@ -54,7 +58,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_repo_sett IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -228,7 +232,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
 
     DATA: lo_dot          TYPE REF TO zcl_abapgit_dot_abapgit,
           ls_post_field   LIKE LINE OF it_post_fields,
-          lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt.
+          lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt,
+          lo_requirements TYPE REF TO lcl_requirements.
     FIELD-SYMBOLS: <ls_requirement> TYPE zif_abapgit_dot_abapgit=>ty_requirement.
 
 
@@ -242,23 +247,19 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
     ASSERT sy-subrc = 0.
     lo_dot->set_starting_folder( ls_post_field-value ).
 
+    lo_requirements = lcl_requirements=>new( ).
     LOOP AT it_post_fields INTO ls_post_field WHERE name CP 'req_*'.
       CASE ls_post_field-name+4(3).
         WHEN 'com'.
-          INSERT INITIAL LINE INTO TABLE lt_requirements ASSIGNING <ls_requirement>.
-          <ls_requirement>-component = ls_post_field-value.
+          lo_requirements->set_component( ls_post_field-value ).
         WHEN 'rel'.
-          <ls_requirement>-min_release = ls_post_field-value.
+          lo_requirements->set_min_release( ls_post_field-value ).
         WHEN 'pat'.
-          <ls_requirement>-min_patch = ls_post_field-value.
+          lo_requirements->set_min_patch( ls_post_field-value ).
       ENDCASE.
     ENDLOOP.
 
-    SORT lt_requirements BY component min_release min_patch.
-    DELETE lt_requirements WHERE component IS INITIAL.
-    DELETE ADJACENT DUPLICATES FROM lt_requirements COMPARING ALL FIELDS.
-
-    lo_dot->set_requirements( lt_requirements ).
+    lo_dot->set_requirements( lo_requirements->get_as_table( ) ).
 
     mo_repo->set_dot_abapgit( lo_dot ).
 

--- a/src/ui/zcl_abapgit_gui_page_repo_sett.clas.locals_imp.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_sett.clas.locals_imp.abap
@@ -23,7 +23,7 @@ ENDCLASS.
 CLASS lcl_requirements IMPLEMENTATION.
 
   METHOD new.
-    ro_result = NEW lcl_requirements( ).
+    CREATE OBJECT ro_result.
   ENDMETHOD.
 
   METHOD set_component.

--- a/src/ui/zcl_abapgit_gui_page_repo_sett.clas.locals_imp.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_sett.clas.locals_imp.abap
@@ -1,0 +1,73 @@
+CLASS lcl_requirements DEFINITION CREATE PRIVATE.
+
+  "This assumes grouping, any duplicate field will trigger a new record.
+  "Not perfect, but a little better than assuming a sequence
+
+  PUBLIC SECTION.
+    CLASS-METHODS new
+      RETURNING VALUE(ro_result) TYPE REF TO lcl_requirements.
+
+    METHODS set_component   IMPORTING iv_component   TYPE string.
+    METHODS set_min_release IMPORTING iv_min_release TYPE string.
+    METHODS set_min_patch   IMPORTING iv_min_patch   TYPE string.
+
+    METHODS get_as_table
+      RETURNING VALUE(rt_requirements) TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt.
+
+  PRIVATE SECTION.
+    DATA: ms_requirement  TYPE zif_abapgit_dot_abapgit=>ty_requirement,
+          mt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt.
+
+ENDCLASS.
+
+CLASS lcl_requirements IMPLEMENTATION.
+
+  METHOD new.
+    ro_result = NEW lcl_requirements( ).
+  ENDMETHOD.
+
+  METHOD set_component.
+
+    IF ms_requirement-component IS NOT INITIAL.
+      APPEND ms_requirement TO mt_requirements.
+      CLEAR ms_requirement.
+    ENDIF.
+    ms_requirement-component = iv_component.
+
+  ENDMETHOD.
+
+  METHOD set_min_patch.
+
+    IF ms_requirement-min_patch IS NOT INITIAL.
+      APPEND ms_requirement TO mt_requirements.
+      CLEAR ms_requirement.
+    ENDIF.
+    ms_requirement-min_patch = iv_min_patch.
+
+  ENDMETHOD.
+
+  METHOD set_min_release.
+
+    IF ms_requirement-min_release IS NOT INITIAL.
+      APPEND ms_requirement TO mt_requirements.
+      CLEAR ms_requirement.
+    ENDIF.
+    ms_requirement-min_release = iv_min_release.
+
+  ENDMETHOD.
+
+  METHOD get_as_table.
+
+    IF ms_requirement IS NOT INITIAL.
+      APPEND ms_requirement TO mt_requirements.
+    ENDIF.
+
+    SORT mt_requirements BY component min_release min_patch.
+    DELETE mt_requirements WHERE component IS INITIAL.
+    DELETE ADJACENT DUPLICATES FROM mt_requirements COMPARING ALL FIELDS.
+
+    rt_requirements = mt_requirements.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_repo_sett.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_sett.clas.testclasses.abap
@@ -1,0 +1,73 @@
+CLASS ltcl_requirements DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+    DATA mo_cut TYPE REF TO lcl_requirements.
+
+    METHODS setup.
+    METHODS different_fields_are_one_group FOR TESTING RAISING cx_static_check.
+    METHODS repeat_field_adds_new_group    FOR TESTING RAISING cx_static_check.
+    METHODS check_field_mapping FOR TESTING RAISING cx_static_check.
+
+ENDCLASS.
+
+
+CLASS ltcl_requirements IMPLEMENTATION.
+
+  METHOD setup.
+    mo_cut = lcl_requirements=>new( ).
+  ENDMETHOD.
+
+  METHOD check_field_mapping.
+    DATA lv_lines TYPE i.
+    DATA ls_actual       TYPE zif_abapgit_dot_abapgit=>ty_requirement.
+    DATA ls_expected     TYPE zif_abapgit_dot_abapgit=>ty_requirement.
+    DATA lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt.
+
+    mo_cut->set_component( '2' ).
+    mo_cut->set_min_release( '3' ).
+    mo_cut->set_min_patch( '4' ).
+
+    lt_requirements = mo_cut->get_as_table( ).
+    READ TABLE lt_requirements INDEX 1 INTO ls_actual.
+
+    ls_expected-component   = '2'.
+    ls_expected-min_release = '3'.
+    ls_expected-min_patch   = '4'.
+
+    cl_abap_unit_assert=>assert_equals( act = ls_actual
+                                        exp = ls_expected ).
+  ENDMETHOD.
+
+  METHOD different_fields_are_one_group.
+    DATA lv_lines TYPE i.
+    DATA lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt.
+
+    mo_cut->set_component( '1' ).
+    mo_cut->set_min_release( '1' ).
+    mo_cut->set_min_patch( '1' ).
+
+    lt_requirements = mo_cut->get_as_table( ).
+    DESCRIBE TABLE lt_requirements LINES lv_lines.
+
+    cl_abap_unit_assert=>assert_equals( act = lv_lines
+                                        exp = 1 ).
+  ENDMETHOD.
+
+  METHOD repeat_field_adds_new_group.
+    DATA lv_lines TYPE i.
+    DATA lt_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt.
+
+    mo_cut->set_component( '1' ).
+    mo_cut->set_min_release( '1' ).
+    mo_cut->set_component( '1' ).
+
+    lt_requirements = mo_cut->get_as_table( ).
+    DESCRIBE TABLE lt_requirements LINES lv_lines.
+
+    cl_abap_unit_assert=>assert_equals( act = lv_lines
+                                        exp = 2 ).
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_repo_sett.clas.xml
+++ b/src/ui/zcl_abapgit_gui_page_repo_sett.clas.xml
@@ -11,6 +11,7 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>


### PR DESCRIPTION
Rather than assuming fields arrive in a sequence, I've pushed it into a local class that only assumes the fields of a row are grouped. Not perfect but it works.