### PR TITLE
Eslint

### DIFF
--- a/.abapgit.xml
+++ b/.abapgit.xml
@@ -15,6 +15,7 @@
     <item>/.gitignore</item>
     <item>/CODE_OF_CONDUCT.md</item>
     <item>/abaplint.json</item>
+    <item>/.eslintrc.yaml</item>
    </IGNORE>
   </DATA>
  </asx:values>

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,5 +1,4 @@
 ---
-root: true
 parserOptions:
   ecmaVersion: 5
 env:
@@ -7,8 +6,9 @@ env:
 extends:
   - eslint:recommended
 rules:
-  quotes: ['warn', 'single', { 'avoidEscape': true }]
+  quotes: ['error', 'double', { 'avoidEscape': true }]
   semi:   ['error', 'always', { 'omitLastInOneLineBlock': true}]
   no-console: off
   indent: ['error', 2]
   no-trailing-spaces: ['error']
+  no-unused-vars: ['warn']

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,0 +1,14 @@
+---
+root: true
+parserOptions:
+  ecmaVersion: 5
+env:
+  browser: true
+extends:
+  - eslint:recommended
+rules:
+  quotes: ['warn', 'single', { 'avoidEscape': true }]
+  semi:   ['error', 'always', { 'omitLastInOneLineBlock': true}]
+  no-console: off
+  indent: ['error', 2]
+  no-trailing-spaces: ['error']

--- a/package.json
+++ b/package.json
@@ -4,14 +4,16 @@
     "pretest": "abaplint --version && abaplint \"src/**/*.*\"",
     "test": "abapmerge src/zabapgit.prog.abap > zabapgit.abap",
     "_disabled_posttest": "abaplint zabapgit.abap",
-    "lint": "abaplint \"src/**/*.*\""
+    "lint": "abaplint \"src/**/*.*\"",
+    "eslint": "eslint src"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/larshp/abapGit.git"
   },
   "devDependencies": {
+    "abaplint": "^1.5.0",
     "abapmerge": "^0.11.0",
-    "abaplint": "^1.5.0"
+    "eslint": "^5.11.1"
   }
 }

--- a/src/zabapgit_js_common.w3mi.data.js
+++ b/src/zabapgit_js_common.w3mi.data.js
@@ -14,14 +14,16 @@ if (!Function.prototype.bind) {
     }
 
     var aArgs   = Array.prototype.slice.call(arguments, 1),
-        fToBind = this,
-        fNOP    = function() {},
-        fBound  = function() {
-          return fToBind.apply(this instanceof fNOP
-                 ? this
-                 : oThis,
-                 aArgs.concat(Array.prototype.slice.call(arguments)));
-        };
+      fToBind = this,
+      fNOP    = function() {},
+      fBound  = function() {
+        return fToBind.apply(
+          this instanceof fNOP
+            ? this
+            : oThis,
+          aArgs.concat(Array.prototype.slice.call(arguments))
+        );
+      };
 
     if (this.prototype) {
       fNOP.prototype = this.prototype;
@@ -35,8 +37,8 @@ if (!Function.prototype.bind) {
 // String includes polyfill, taken from https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/String/includes
 if (!String.prototype.includes) {
   String.prototype.includes = function(search, start) {
-    'use strict';
-    if (typeof start !== 'number') {
+    "use strict";
+    if (typeof start !== "number") {
       start = 0;
     }
 
@@ -132,11 +134,11 @@ function perfOut(prefix) {
   }
 
   var keys = Object.keys(totals);
-  for (var i = keys.length - 1; i >= 0; i--) {
+  for (var j = keys.length - 1; j >= 0; j--) {
     console.log(prefix
-      + " " + keys[i] + ": "
-      + totals[keys[i]].time.toFixed(3) + "ms"
-      + " (" + totals[keys[i]].count.toFixed() +")");
+      + " " + keys[j] + ": "
+      + totals[keys[j]].time.toFixed(3) + "ms"
+      + " (" + totals[keys[j]].count.toFixed() +")");
   }
 }
 
@@ -154,7 +156,7 @@ function perfClear() {
 // somehow only functions on window are visible for the select tag
 window.onTagTypeChange = function(oSelectObject){
   var sValue = oSelectObject.value;
-  submitSapeventForm({ 'type': sValue }, "change_tag_type", "post");
+  submitSapeventForm({ type: sValue }, "change_tag_type", "post");
 };
 
 /**********************************************************
@@ -163,12 +165,12 @@ window.onTagTypeChange = function(oSelectObject){
 // somehow only functions on window are visible for the select tag
 window.onOrderByChange = function(oSelectObject){
   var sValue = oSelectObject.value;
-  submitSapeventForm({ 'orderBy': sValue }, "change_order_by", "post");
+  submitSapeventForm({ orderBy: sValue }, "change_order_by", "post");
 };
 
 window.onDirectionChange = function(oSelectObject){
   var sValue = oSelectObject.value;
-  submitSapeventForm({ 'direction': sValue }, "direction", "post");
+  submitSapeventForm({ direction: sValue }, "direction", "post");
 };
 
 /**********************************************************
@@ -202,7 +204,7 @@ function StageHelper(params) {
     remove: "R",
     ignore: "I",
     reset:  "?",
-    isValid: function (status) { return "ARI?".indexOf(status) == -1; }
+    isValid: function (status) { return "ARI?".indexOf(status) == -1 }
   };
 
   this.TEMPLATES = {
@@ -222,7 +224,7 @@ StageHelper.prototype.setHooks = function() {
   this.dom.objectSearch.onkeypress = this.onFilter.bind(this);
   window.onbeforeunload            = this.onPageUnload.bind(this);
   window.onload                    = this.onPageLoad.bind(this);
-}
+};
 
 // Detect column index
 StageHelper.prototype.detectColumns = function() {
@@ -234,7 +236,7 @@ StageHelper.prototype.detectColumns = function() {
   }
 
   return colIndex;
-}
+};
 
 // Store table state on leaving the page
 StageHelper.prototype.onPageUnload = function() {
@@ -265,10 +267,11 @@ StageHelper.prototype.onTableClick = function (event) {
   var target = event.target || event.srcElement;
   if (!target) return;
 
+  var td;
   if (target.tagName === "A") {
-    var td = target.parentNode;
+    td = target.parentNode;
   } else if (target.tagName === "TD") {
-    var td = target;
+    td = target;
     if (td.children.length === 1 && td.children[0].tagName === "A") {
       target = td.children[0];
     } else return;
@@ -285,7 +288,7 @@ StageHelper.prototype.onTableClick = function (event) {
     this.iterateStageTab(true, function (row) {
       if (row.style.display !== "none"            // Not filtered out
         && row.className === targetRow.className  // Same context as header
-        ) {
+      ) {
         this.updateRow(row, status);
       }
     });
@@ -297,11 +300,11 @@ StageHelper.prototype.onTableClick = function (event) {
 // Search object
 StageHelper.prototype.onFilter = function (e) {
   if ( // Enter hit or clear, IE SUCKS !
-       e.type === "input" && !e.target.value && this.lastFilterValue
+    e.type === "input" && !e.target.value && this.lastFilterValue
     || e.type === "keypress" && e.which === 13 ) {
 
     this.applyFilterValue(e.target.value);
-    submitSapeventForm({ 'filterValue': e.target.value }, "stage_filter", "post");
+    submitSapeventForm({ filterValue: e.target.value }, "stage_filter", "post");
   }
 };
 
@@ -339,10 +342,10 @@ StageHelper.prototype.applyFilterToRow = function (row, filter) {
 
   // Update DOM
   row.style.display = isVisible ? "" : "none";
-  for (var i = targets.length - 1; i >= 0; i--) {
-    if (targets[i].isChanged) targets[i].elem.innerHTML = targets[i].newHtml;
+  for (var j = targets.length - 1; j >= 0; j--) {
+    if (targets[j].isChanged) targets[j].elem.innerHTML = targets[j].newHtml;
   }
-}
+};
 
 // Get how status should affect object counter
 StageHelper.prototype.getStatusImpact = function (status) {
@@ -353,7 +356,7 @@ StageHelper.prototype.getStatusImpact = function (status) {
   } else {
     return (status !== this.STATUS.reset) ? 1 : 0;
   }
-}
+};
 
 // Update table line
 StageHelper.prototype.updateRow = function (row, newStatus) {
@@ -367,7 +370,7 @@ StageHelper.prototype.updateRow = function (row, newStatus) {
   }
 
   this.choiseCount += this.getStatusImpact(newStatus) - this.getStatusImpact(oldStatus);
-}
+};
 
 // Update Status cell (render set of commands)
 StageHelper.prototype.updateRowStatus = function (row, status) {
@@ -377,7 +380,7 @@ StageHelper.prototype.updateRowStatus = function (row, status) {
   } else {
     row.cells[this.colIndex["status"]].classList.add(this.HIGHLIGHT_STYLE);
   }
-}
+};
 
 // Update Command cell (render set of commands)
 StageHelper.prototype.updateRowCommand = function (row, status) {
@@ -389,19 +392,19 @@ StageHelper.prototype.updateRowCommand = function (row, status) {
   } else {
     cell.innerHTML = this.TEMPLATES.cmdReset;
   }
-}
+};
 
 // Update menu items visibility
 StageHelper.prototype.updateMenu = function () {
   this.dom.commitBtn.style.display    = (this.choiseCount > 0) ? ""     : "none";
   this.dom.commitAllBtn.style.display = (this.choiseCount > 0) ? "none" : "";
   this.dom.fileCounter.innerHTML      = this.choiseCount.toString();
-}
+};
 
 // Submit stage state to the server
 StageHelper.prototype.submit = function () {
   submitSapeventForm(this.collectData(), this.formAction);
-}
+};
 
 // Extract data from the table
 StageHelper.prototype.collectData = function () {
@@ -410,7 +413,7 @@ StageHelper.prototype.collectData = function () {
     data[row.cells[this.colIndex["name"]].innerText] = row.cells[this.colIndex["status"]].innerText;
   });
   return data;
-}
+};
 
 // Table iteration helper
 StageHelper.prototype.iterateStageTab = function (changeMode, cb /*, ...*/) {
@@ -425,7 +428,7 @@ StageHelper.prototype.iterateStageTab = function (changeMode, cb /*, ...*/) {
   for (var b = 0, bN = table.tBodies.length; b < bN; b++) {
     var tbody = table.tBodies[b];
     for (var r = 0, rN = tbody.rows.length; r < rN; r++) {
-      args = [tbody.rows[r]].concat(restArgs);
+      var args = [tbody.rows[r]].concat(restArgs);
       cb.apply(this, args); // callback
     }
   }
@@ -434,7 +437,7 @@ StageHelper.prototype.iterateStageTab = function (changeMode, cb /*, ...*/) {
     this.dom.stageTab.style.display = "";
     window.scrollTo(0, scrollOffset);
   }
-}
+};
 
 /**********************************************************
  * Check list wrapper
@@ -446,11 +449,11 @@ function CheckListWrapper(id, cbAction) {
   this.id.onclick = this.onClick.bind(this);
 }
 
-CheckListWrapper.prototype.onClick = function(e) {
+CheckListWrapper.prototype.onClick = function(e) { // eslint-disable-line no-unused-vars
   // Get nodes
   var target = event.target || event.srcElement;
   if (!target) return;
-  if (target.tagName !== "A") { target = target.parentNode; } // icon clicked
+  if (target.tagName !== "A") { target = target.parentNode } // icon clicked
   if (target.tagName !== "A") return;
   if (target.parentNode.tagName !== "LI") return;
 
@@ -477,7 +480,7 @@ CheckListWrapper.prototype.onClick = function(e) {
 
   // Action callback
   this.cbAction(nodeLi.getAttribute("data-aux"), option, newState);
-}
+};
 
 /**********************************************************
  * Diff page logic
@@ -524,17 +527,17 @@ DiffHelper.prototype.applyFilter = function (attr, target, state) {
       div.style.display = state ? "" : "none";
     }
   });
-}
+};
 
 // Action on stage -> save visible diffs as state for stage page
-DiffHelper.prototype.onStage = function (e) {
+DiffHelper.prototype.onStage = function (e) { // eslint-disable-line no-unused-vars
   if (window.sessionStorage) {
     var data = this.buildStageCache();
     window.sessionStorage.setItem(this.pageSeed, JSON.stringify(data));
   }
   var getParams = {key: this.repoKey, seed: this.pageSeed};
   submitSapeventForm(getParams, this.stageAction, "get");
-}
+};
 
 // Collect visible diffs
 DiffHelper.prototype.buildStageCache = function () {
@@ -546,7 +549,7 @@ DiffHelper.prototype.buildStageCache = function () {
     }
   });
   return list;
-}
+};
 
 // Table iterator
 DiffHelper.prototype.iterateDiffList = function (cb /*, ...*/) {
@@ -556,10 +559,10 @@ DiffHelper.prototype.iterateDiffList = function (cb /*, ...*/) {
   for (var i = 0, iN = diffList.children.length; i < iN; i++) {
     var div = diffList.children[i];
     if (div.className !== "diff") continue;
-    args = [div].concat(restArgs);
+    var args = [div].concat(restArgs);
     cb.apply(this, args); // callback
   }
-}
+};
 
 // Highlight Filter button if filter is activate
 DiffHelper.prototype.highlightButton = function(state) {
@@ -578,7 +581,7 @@ DiffHelper.prototype.highlightButton = function(state) {
 // News announcement
 function toggleDisplay(divId) {
   var div = document.getElementById(divId);
-  if (div) div.style.display = (div.style.display) ? '' : 'none';
+  if (div) div.style.display = (div.style.display) ? "" : "none";
 }
 
 function KeyNavigation() {
@@ -603,7 +606,7 @@ KeyNavigation.prototype.onkeydown = function(oEvent) {
 };
 
 KeyNavigation.prototype.getLiSelected = function() {
-  return document.querySelector('li .selected');
+  return document.querySelector("li .selected");
 };
 
 KeyNavigation.prototype.getActiveElement = function () {
@@ -614,7 +617,7 @@ KeyNavigation.prototype.getActiveElementParent = function () {
   return this.getActiveElement().parentElement;
 };
 
-KeyNavigation.prototype.onEnterOrSpace = function (oEvent) {
+KeyNavigation.prototype.onEnterOrSpace = function (oEvent) { // eslint-disable-line no-unused-vars
 
   // Enter or space clicks the selected link
 
@@ -639,9 +642,9 @@ KeyNavigation.prototype.onArrowDown = function (oEvent) {
     // we deselect the current li and select the next sibling
     liNext = oActiveElementParent.nextElementSibling;
     if (liNext) {
-      liSelected.classList.toggle('selected');
+      liSelected.classList.toggle("selected");
       liNext.firstElementChild.focus();
-      oActiveElementParent.classList.toggle('selected');
+      oActiveElementParent.classList.toggle("selected");
       oEvent.preventDefault();
     }
 
@@ -651,7 +654,7 @@ KeyNavigation.prototype.onArrowDown = function (oEvent) {
     // the right element should have been activated in fnTooltipActivate
     liNext = this.getActiveElement().nextElementSibling;
     if (liNext) {
-      liNext.classList.toggle('selected');
+      liNext.classList.toggle("selected");
       liNext.firstElementChild.firstElementChild.focus();
       oEvent.preventDefault();
     }
@@ -669,9 +672,9 @@ KeyNavigation.prototype.onArrowUp = function (oEvent) {
 
   if (liSelected && liPrevious) {
 
-    liSelected.classList.toggle('selected');
+    liSelected.classList.toggle("selected");
     liPrevious.firstElementChild.focus();
-    this.getActiveElementParent().classList.toggle('selected');
+    this.getActiveElementParent().classList.toggle("selected");
     oEvent.preventDefault();
 
   }
@@ -684,7 +687,7 @@ function enableArrowListNavigation() {
 
   var oKeyNavigation = new KeyNavigation();
 
-  document.addEventListener('keydown', oKeyNavigation.onkeydown.bind(oKeyNavigation));
+  document.addEventListener("keydown", oKeyNavigation.onkeydown.bind(oKeyNavigation));
 
 }
 
@@ -694,14 +697,14 @@ function LinkHints(sLinkHintKey, sColor){
   this.oTooltipMap = {};
   this.bTooltipsOn = false;
   this.sPending = "";
-  this.aTooltipElements = document.querySelectorAll('a span');
+  this.aTooltipElements = document.querySelectorAll("a span");
 }
 
 LinkHints.prototype.fnRenderTooltip = function (oTooltip, iTooltipCounter) {
   if (this.bTooltipsOn) {
-    oTooltip.classList.remove('hidden');
+    oTooltip.classList.remove("hidden");
   } else {
-    oTooltip.classList.add('hidden');
+    oTooltip.classList.add("hidden");
   }
   oTooltip.innerHTML = iTooltipCounter;
   oTooltip.style.backgroundColor = this.sColor;
@@ -750,12 +753,12 @@ LinkHints.prototype.fnRemoveAllTooltips = function () {
   this.bTooltipsOn = false;
 
   [].forEach.call(this.aTooltipElements, function (oTooltip) {
-    oTooltip.classList.add('hidden');
+    oTooltip.classList.add("hidden");
   });
 
 };
 
-LinkHints.prototype.fnFilterTooltips = function (sPending) {
+LinkHints.prototype.fnFilterTooltips = function (sPending) { // eslint-disable-line no-unused-vars
 
   Object
     .keys(this.oTooltipMap)
@@ -767,10 +770,10 @@ LinkHints.prototype.fnFilterTooltips = function (sPending) {
 
       if (regex.test(sKey)) {
         // we have a partial match, grey out the matched part
-        oTooltip.innerHTML = sKey.replace(regex, "<div style='display:inline;color:lightgray'>" + this.sPending + '</div>');
+        oTooltip.innerHTML = sKey.replace(regex, "<div style='display:inline;color:lightgray'>" + this.sPending + "</div>");
       } else {
         // and hide the not matched tooltips
-        oTooltip.classList.add('hidden');
+        oTooltip.classList.add("hidden");
       }
 
     }.bind(this));
@@ -882,10 +885,10 @@ function Hotkeys(oKeyMap){
 }
 
 Hotkeys.prototype.showHotkeys = function() {
-  var elHotkeys = document.querySelector('#hotkeys');
+  var elHotkeys = document.querySelector("#hotkeys");
 
   if (elHotkeys) {
-    elHotkeys.style.display = (elHotkeys.style.display) ? '' : 'none';
+    elHotkeys.style.display = (elHotkeys.style.display) ? "" : "none";
   }
 };
 
@@ -901,13 +904,12 @@ Hotkeys.prototype.getSapEvent = function(sSapEvent) {
   var aSapEvents = document.querySelectorAll('a[href^="sapevent:' + sSapEvent + '"]');
 
   var aFilteredAndNormalizedSapEvents =
-        [].map.call(aSapEvents, function(oSapEvent){
-          return fnNormalizeSapEventHref(sSapEvent, oSapEvent);
-        })
-        .filter(function(elem){
-          // remove false positives
-          return (elem && !elem.includes("sapevent:"));
-        });
+    [].map.call(aSapEvents, function(oSapEvent){
+      return fnNormalizeSapEventHref(sSapEvent, oSapEvent);
+    }).filter(function(elem){
+      // remove false positives
+      return (elem && !elem.includes("sapevent:"));
+    });
 
   return (aFilteredAndNormalizedSapEvents && aFilteredAndNormalizedSapEvents[0]);
 
@@ -916,7 +918,7 @@ Hotkeys.prototype.getSapEvent = function(sSapEvent) {
 Hotkeys.prototype.onkeydown = function(oEvent){
 
   if (oEvent.defaultPrevented) {
-      return;
+    return;
   }
 
   var activeElementType = ((document.activeElement && document.activeElement.nodeName) || "");
@@ -938,8 +940,8 @@ function setKeyBindings(oKeyMap){
 
   var oHotkeys = new Hotkeys(oKeyMap);
 
-  document.addEventListener('keypress', oHotkeys.onkeydown.bind(oHotkeys));
-  setTimeout(function(){ 
+  document.addEventListener("keypress", oHotkeys.onkeydown.bind(oHotkeys));
+  setTimeout(function(){
     var div = document.getElementById("hotkeys-hint");
     if (div) div.style.opacity = 0.2;
   }, 4900);
@@ -958,20 +960,20 @@ function CSSPatchClassCombination(sClassLinkClicked, sClassCorrespondingLink){
 function Patch() {
 
   this.CSS_CLASS = {
-    ADD: 'add',
-    REMOVE: 'remove',
-    PATCH: 'patch',
-    PATCH_ACTIVE: 'patch-active'
+    ADD:          "add",
+    REMOVE:       "remove",
+    PATCH:        "patch",
+    PATCH_ACTIVE: "patch-active"
   };
 
   this.ID = {
-    STAGE: 'stage',
-    PATCH_ADD_ALL: 'patch_add_all',
-    PATCH_REMOVE_ALL: 'patch_remove_all'
+    STAGE:            "stage",
+    PATCH_ADD_ALL:    "patch_add_all",
+    PATCH_REMOVE_ALL: "patch_remove_all"
   };
 
   this.ACTION = {
-    PATCH_STAGE: 'patch_stage'
+    PATCH_STAGE: "patch_stage"
   };
 
   this.ADD_REMOVE = new CSSPatchClassCombination(this.CSS_CLASS.ADD, this.CSS_CLASS.REMOVE);
@@ -999,8 +1001,8 @@ Patch.prototype.registerClickHandlerAllFile = function(){
 
   // registers the link handlers for add and remove all changes for a file
 
-  this.registerClickHandlerForPatchLinkAll('#' + this.ID.PATCH_ADD_ALL, this.ADD_REMOVE);
-  this.registerClickHandlerForPatchLinkAll('#' + this.ID.PATCH_REMOVE_ALL, this.REMOVE_ADD);
+  this.registerClickHandlerForPatchLinkAll("#" + this.ID.PATCH_ADD_ALL, this.ADD_REMOVE);
+  this.registerClickHandlerForPatchLinkAll("#" + this.ID.PATCH_REMOVE_ALL, this.REMOVE_ADD);
 
 };
 
@@ -1011,11 +1013,11 @@ Patch.prototype.registerClickHandlerForPatchLink = function(oClassCombination) {
   // e.g. if you click on 'add' add is deactivated and 'remove'
   // is activated.
 
-  var elLinkAll = document.querySelectorAll('.' + this.CSS_CLASS.PATCH + ' a.' + oClassCombination.sClassLinkClicked);
+  var elLinkAll = document.querySelectorAll("." + this.CSS_CLASS.PATCH + " a." + oClassCombination.sClassLinkClicked);
 
   [].forEach.call(elLinkAll,function(elLink){
 
-    elLink.addEventListener('click',function(oEvent){
+    elLink.addEventListener("click",function(oEvent){
       this.togglePatchActiveForClassLink(oEvent, elLink, oClassCombination);
     }.bind(this));
 
@@ -1050,15 +1052,15 @@ Patch.prototype.getCorrespodingLinkId = function(sClickedLinkId, oClassCombinati
   //
   // and vice versa
 
-  var oRegexPatchClassPrefix = new RegExp('^' + oClassCombination.sClassLinkClicked );
+  var oRegexPatchClassPrefix = new RegExp("^" + oClassCombination.sClassLinkClicked );
   return sClickedLinkId.replace(oRegexPatchClassPrefix, oClassCombination.sClassCorrespondingLink);
 
 };
 
 Patch.prototype.escape = function(sFileName){
   return sFileName
-    .replace(/\./g,'\\.')
-    .replace(/\#/g,'\\#');
+    .replace(/\./g, "\\.")
+    .replace(/#/g, "\\#");
 };
 
 Patch.prototype.patchLinkClickAll = function(oClassCombination) {
@@ -1073,7 +1075,7 @@ Patch.prototype.patchLinkClickAll = function(oClassCombination) {
 
     oEvent.preventDefault();
 
-  }
+  };
 };
 
 Patch.prototype.registerClickHandlerForPatchLinkAll = function(sSelector, oClassCombination){
@@ -1081,15 +1083,15 @@ Patch.prototype.registerClickHandlerForPatchLinkAll = function(sSelector, oClass
   var elAll = document.querySelectorAll(sSelector);
 
   [].forEach.call(elAll, function(elem){
-    elem.addEventListener('click', this.patchLinkClickAll(oClassCombination).bind(this));
+    elem.addEventListener("click", this.patchLinkClickAll(oClassCombination).bind(this));
   }.bind(this));
 
 };
 
 Patch.prototype.registerStagePatch = function registerStagePatch(){
 
-  var elStage = document.querySelector('#' + this.ID.STAGE);
-  elStage.addEventListener('click', this.stagePatch.bind(this));
+  var elStage = document.querySelector("#" + this.ID.STAGE);
+  elStage.addEventListener("click", this.stagePatch.bind(this));
 
   // for hotkeys
   window.stagePatch = function(){
@@ -1102,10 +1104,10 @@ Patch.prototype.stagePatch = function() {
 
   // Collect add and remove info and submit to backend
 
-  var aAddPatch = this.collectActiveElementsForSelector('.' + this.CSS_CLASS.PATCH +' a.' + this.CSS_CLASS.ADD);
-  var aRemovePatch = this.collectActiveElementsForSelector('.' + this.CSS_CLASS.PATCH + ' a.' + this.CSS_CLASS.REMOVE);
+  var aAddPatch = this.collectActiveElementsForSelector("." + this.CSS_CLASS.PATCH +" a." + this.CSS_CLASS.ADD);
+  var aRemovePatch = this.collectActiveElementsForSelector("." + this.CSS_CLASS.PATCH + " a." + this.CSS_CLASS.REMOVE);
 
-  submitSapeventForm({'add': aAddPatch, 'remove': aRemovePatch}, this.ACTION.PATCH_STAGE, "post");
+  submitSapeventForm({"add": aAddPatch, "remove": aRemovePatch}, this.ACTION.PATCH_STAGE, "post");
 
 };
 
@@ -1137,20 +1139,20 @@ function registerStagePatch(){
 
 /**********************************************************
  * Page branch overview
- * 
+ *
  * Hovering a commit node in the branch overview will show
  * a popup with the commit details. Single click on a node
  * will fix the popup, so that users can select text. The
- * fixation is removed when any node is hovered or the popup 
+ * fixation is removed when any node is hovered or the popup
  * is closed via 'X'.
- * 
+ *
  **********************************************************/
 
 function BranchOverview() {
   this.bFixed = false;
   this.elCurrentCommit = {
     style : {
-      display: 'none'
+      display: "none"
     }
   };
 }
@@ -1158,19 +1160,19 @@ function BranchOverview() {
 BranchOverview.prototype.toggleCommit = function(sSha1, bFixPopup) {
 
   // If the popup is fixed, we just remove the fixation.
-  // The popup will then be hidden by the next call of hideCommit 
+  // The popup will then be hidden by the next call of hideCommit
   if (this.bFixed) {
     this.bFixed = false;
     return;
-  } 
+  }
 
   // We hide the previous shown commit popup
-  this.elCurrentCommit.style.display = 'none';
+  this.elCurrentCommit.style.display = "none";
 
   // Display the new commit popup if sha1 is supplied
   if (sSha1){
     this.elCurrentCommit = document.getElementById(sSha1);
-    this.elCurrentCommit.style.display = '';
+    this.elCurrentCommit.style.display = "";
 
     // and fix the popup so that the next hideCommit won't hide it.
     this.bFixed = bFixPopup;
@@ -1190,6 +1192,6 @@ BranchOverview.prototype.showCommit = function(event){
 };
 
 // Called by commit:mouseout
-BranchOverview.prototype.hideCommit = function (event){
+BranchOverview.prototype.hideCommit = function (event){ // eslint-disable-line no-unused-vars
   this.toggleCommit();
 };


### PR DESCRIPTION
to #2232 
@larshp @christianguenter2 

- decided to leave double quotes, as most of the code use them
- fixed liner suggestions, except no-unused-vars for most of functions - they are called from SAP so eslint does not know about that. I guess that maybe the rule can be disabled ... though it is useful ... or put pragmas everywhere (15 cases)
- probably would be a good idea to add this to travis (and refactor travis config in general ... e.g. keeping the token code there is very insecure)