### PR TITLE
add some hint on proxy setup doc page

### DIFF
--- a/docs/guide-proxy-configuration.md
+++ b/docs/guide-proxy-configuration.md
@@ -8,3 +8,5 @@ Online projects only
 
 If your server is behind a proxy, it can be configured under Advanced -> Settings,
 ![](img/proxy.png)
+
+**Hint:** the URL must **not contain https://** -> just enter name or IP


### PR DESCRIPTION
including the https:// in the "URL" does lead to problems in resolving the name or ip and the error message is not helping to find this ... maybe also think on renaming the field in the future