### PR TITLE
move method get_unnecessary_local_objs #2127

### DIFF
--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -1,13 +1,13 @@
 CLASS zcl_abapgit_repo DEFINITION
   PUBLIC
   ABSTRACT
-  CREATE PUBLIC.
+  CREATE PUBLIC .
 
   PUBLIC SECTION.
 
     METHODS bind_listener
       IMPORTING
-        ii_listener TYPE REF TO zif_abapgit_repo_listener.
+        !ii_listener TYPE REF TO zif_abapgit_repo_listener .
     METHODS deserialize_checks
       RETURNING
         VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_deserialize_checks
@@ -101,9 +101,9 @@ CLASS zcl_abapgit_repo DEFINITION
         zcx_abapgit_exception .
     METHODS run_code_inspector
       IMPORTING
-        iv_check_variant TYPE string
+        !iv_check_variant TYPE string
       RETURNING
-        VALUE(rt_list)   TYPE scit_alvlist
+        VALUE(rt_list)    TYPE scit_alvlist
       RAISING
         zcx_abapgit_exception .
     METHODS has_remote_source
@@ -117,17 +117,11 @@ CLASS zcl_abapgit_repo DEFINITION
         VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
       RAISING
         zcx_abapgit_exception .
-    METHODS get_unnecessary_local_objs
-      RETURNING
-        VALUE(rt_unnecessary_local_objects) TYPE zif_abapgit_definitions=>ty_tadir_tt
-      RAISING
-        zcx_abapgit_exception .
     METHODS switch_repo_type
       IMPORTING
-        iv_offline TYPE abap_bool
+        !iv_offline TYPE abap_bool
       RAISING
         zcx_abapgit_exception .
-
   PROTECTED SECTION.
 
     DATA mt_local TYPE zif_abapgit_definitions=>ty_files_item_tt .
@@ -440,52 +434,6 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
   METHOD get_package.
     rv_package = ms_data-package.
-  ENDMETHOD.
-
-
-  METHOD get_unnecessary_local_objs.
-
-    DATA: lt_tadir        TYPE zif_abapgit_definitions=>ty_tadir_tt,
-          lt_tadir_unique TYPE HASHED TABLE OF zif_abapgit_definitions=>ty_tadir
-                               WITH UNIQUE KEY pgmid object obj_name,
-          lt_local        TYPE zif_abapgit_definitions=>ty_files_item_tt,
-          lt_remote       TYPE zif_abapgit_definitions=>ty_files_tt,
-          lt_status       TYPE zif_abapgit_definitions=>ty_results_tt,
-          lv_package      TYPE zif_abapgit_persistence=>ty_repo-package.
-
-    FIELD-SYMBOLS: <ls_status> TYPE zif_abapgit_definitions=>ty_result,
-                   <ls_tadir>  TYPE zif_abapgit_definitions=>ty_tadir.
-
-
-    " delete objects which are added locally but are not in remote repo
-    lt_local  = get_files_local( ).
-    lt_remote = get_files_remote( ).
-    lt_status = status( ).
-
-    lv_package = get_package( ).
-    lt_tadir = zcl_abapgit_factory=>get_tadir( )->read( lv_package ).
-    SORT lt_tadir BY pgmid ASCENDING object ASCENDING obj_name ASCENDING devclass ASCENDING.
-
-    LOOP AT lt_status ASSIGNING <ls_status>
-                      WHERE lstate = zif_abapgit_definitions=>c_state-added.
-
-      READ TABLE lt_tadir ASSIGNING <ls_tadir>
-                          WITH KEY pgmid    = 'R3TR'
-                                   object   = <ls_status>-obj_type
-                                   obj_name = <ls_status>-obj_name
-                                   devclass = <ls_status>-package
-                          BINARY SEARCH.
-      IF sy-subrc <> 0.
-* skip objects that does not exist locally
-        CONTINUE.
-      ENDIF.
-
-      INSERT <ls_tadir> INTO TABLE lt_tadir_unique.
-
-    ENDLOOP.
-
-    rt_unnecessary_local_objects = lt_tadir_unique.
-
   ENDMETHOD.
 
 


### PR DESCRIPTION
move method get_unnecessary_local_objs #2127

public from class `zcl_abapgit_repo` to protected in class `zcl_abapgit_services_git`, this is probably not the final place for the method, but for now just trying to reduce the weight of `zcl_abapgit_repo`