### PR TITLE
Changed default text in branch popup

### DIFF
--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -688,17 +688,25 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
   METHOD zif_abapgit_popups~popup_to_create_transp_branch.
     DATA: lt_fields             TYPE TABLE OF sval,
           lv_transports_as_text TYPE string,
+          lv_desc_as_text       TYPE string,
           ls_transport_header   LIKE LINE OF it_transport_headers.
     DATA: lv_branch_name        TYPE spo_value.
     DATA: lv_commit_text        TYPE spo_value.
 
     CLEAR: rs_transport_branch-branch_name, rs_transport_branch-commit_text.
 
-    lv_transports_as_text = 'Transport(s)'.
-    LOOP AT it_transport_headers INTO ls_transport_header.
-      CONCATENATE lv_transports_as_text '_' ls_transport_header-trkorr INTO lv_transports_as_text.
-    ENDLOOP.
+    IF lines( it_transport_headers ) = 1.   " If we only have one transport selected set branch name to Transport name and commit description to transport description.
+      ls_transport_header = it_transport_headers[ 1 ].
+      lv_transports_as_text = ls_transport_header-trkorr.
+      SELECT SINGLE as4text FROM e07t WHERE trkorr = @ls_transport_header-trkorr AND langu = @sy-langu INTO @lv_desc_as_text .
+    ELSE.   " Else set branch name and commit message to 'Transport(s)_TRXXXXXX_TRXXXXX'
+      lv_transports_as_text = 'Transport(s)'.
+      LOOP AT it_transport_headers INTO ls_transport_header.
+        CONCATENATE lv_transports_as_text '_' ls_transport_header-trkorr INTO lv_transports_as_text.
+      ENDLOOP.
+      lv_desc_as_text = lv_transports_as_text.
 
+    ENDIF.
     add_field( EXPORTING iv_tabname   = 'TEXTL'
                          iv_fieldname = 'LINE'
                          iv_fieldtext = 'Branch name'
@@ -708,7 +716,7 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
     add_field( EXPORTING iv_tabname   = 'ABAPTXT255'
                          iv_fieldname = 'LINE'
                          iv_fieldtext = 'Commit text'
-                         iv_value     = lv_transports_as_text
+                         iv_value     = lv_desc_as_text
                CHANGING ct_fields     = lt_fields ).
 
     _popup_2_get_values( EXPORTING iv_popup_title    = 'Transport to new Branch' "#EC NOTEXT

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -695,10 +695,14 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
     CLEAR: rs_transport_branch-branch_name, rs_transport_branch-commit_text.
 
-    IF lines( it_transport_headers ) = 1.   " If we only have one transport selected set branch name to Transport name and commit description to transport description.
-      ls_transport_header = it_transport_headers[ 1 ].
+    " If we only have one transport selected set branch name to Transport name and commit description to transport description.
+    IF lines( it_transport_headers ) = 1.
+      READ TABLE it_transport_headers INDEX 1 INTO ls_transport_header.
       lv_transports_as_text = ls_transport_header-trkorr.
-      SELECT SINGLE as4text FROM e07t WHERE trkorr = @ls_transport_header-trkorr AND langu = @sy-langu INTO @lv_desc_as_text .
+      SELECT SINGLE as4text FROM e07t INTO lv_desc_as_text  WHERE
+        trkorr = ls_transport_header-trkorr AND
+        langu = sy-langu .
+
     ELSE.   " Else set branch name and commit message to 'Transport(s)_TRXXXXXX_TRXXXXX'
       lv_transports_as_text = 'Transport(s)'.
       LOOP AT it_transport_headers INTO ls_transport_header.

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -695,7 +695,8 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
     CLEAR: rs_transport_branch-branch_name, rs_transport_branch-commit_text.
 
-    " If we only have one transport selected set branch name to Transport name and commit description to transport description.
+    " If we only have one transport selected set branch name to Transport
+    " name and commit description to transport description.
     IF lines( it_transport_headers ) = 1.
       READ TABLE it_transport_headers INDEX 1 INTO ls_transport_header.
       lv_transports_as_text = ls_transport_header-trkorr.


### PR DESCRIPTION
When only selecting one transport in in Transport to Branch it is handy if the branch name and commit message defaults to the transport number and transport description.

I've added a check to see if only one transport is selected and if so uses the transport number as branch name and transport description as commit message.

If more than multiple transports are selected the logic is untouched. 

Is there a better way to get the text from E07t than a select directly in the popup? It feels like overkill to implement a whole repo class for this single select.