### PR TITLE
allow changing remote and branch for write protect

### DIFF
--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -232,10 +232,6 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
 
   METHOD set_branch_name.
 
-    IF ms_data-local_settings-write_protected = abap_true.
-      zcx_abapgit_exception=>raise( 'Cannot switch branch. Local code is write-protected by repo config' ).
-    ENDIF.
-
     reset_remote( ).
     set( iv_branch_name = iv_branch_name ).
 
@@ -248,10 +244,6 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
 
 
   METHOD set_url.
-
-    IF ms_data-local_settings-write_protected = abap_true.
-      zcx_abapgit_exception=>raise( 'Cannot change URL. Local code is write-protected by repo config' ).
-    ENDIF.
 
     reset_remote( ).
     set( iv_url = iv_url ).


### PR DESCRIPTION
allow changing remote and branch for write protected repos. In the old days changing remote and branch triggered a pull, this is decoupled, so there should be no changes to the local code when switching remote or branch