### PR TITLE
Update zcl_abapgit_2fa_auth_base.clas.abap

### DIFF
--- a/src/http/zcl_abapgit_2fa_auth_base.clas.abap
+++ b/src/http/zcl_abapgit_2fa_auth_base.clas.abap
@@ -1,4 +1,4 @@
-"! Default {@link ZIF_ABAPGIT_2FA_AUTHENTICATOR} implementation
+"! Default &#123;&#64;link ZIF_ABAPGIT_2FA_AUTHENTICATOR&#125; implementation
 CLASS zcl_abapgit_2fa_auth_base DEFINITION
   PUBLIC
   ABSTRACT
@@ -17,7 +17,7 @@ CLASS zcl_abapgit_2fa_auth_base DEFINITION
     METHODS:
       "! @parameter iv_supported_url_regex | Regular expression to check if a repository url is
       "!                                     supported, used for default implementation of
-      "!                                     {@link .METH:supports_url}
+      "!                                     &#123;&#64;link .METH:supports_url&#125;
       constructor IMPORTING iv_supported_url_regex TYPE clike.
   PROTECTED SECTION.
     CLASS-METHODS:

--- a/src/http/zcl_abapgit_2fa_auth_registry.clas.abap
+++ b/src/http/zcl_abapgit_2fa_auth_registry.clas.abap
@@ -1,4 +1,4 @@
-"! Static registry class to find {@link ZIF_ABAPGIT_2FA_AUTHENTICATOR} instances
+"! Static registry class to find &#123;&#64;link ZIF_ABAPGIT_2FA_AUTHENTICATOR&#125; instances
 CLASS zcl_abapgit_2fa_auth_registry DEFINITION
   PUBLIC
   FINAL


### PR DESCRIPTION
Proper escape sequences are used instead of the characters '{', '}' and '@', now the ABAP Doc is rendered properly, after this change is implemented the warnings that were shown in SAP GUI during compilation are gone.
![image](https://user-images.githubusercontent.com/36721657/52432262-4d6a7300-2b0a-11e9-915d-14e0fe74ccb7.png)
