### PR TITLE
DOMA do not serialize texts without language #2311

### DIFF
--- a/src/objects/zcl_abapgit_object_doma.clas.abap
+++ b/src/objects/zcl_abapgit_object_doma.clas.abap
@@ -4,6 +4,7 @@ CLASS zcl_abapgit_object_doma DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
     INTERFACES zif_abapgit_object.
     ALIASES mo_files FOR zif_abapgit_object~mo_files.
 
+  PROTECTED SECTION.
   PRIVATE SECTION.
 
     TYPES: BEGIN OF ty_dd01_texts,
@@ -155,7 +156,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DOMA IMPLEMENTATION.
       APPEND INITIAL LINE TO lt_dd01_texts ASSIGNING <ls_dd01_text>.
       MOVE-CORRESPONDING ls_dd01v TO <ls_dd01_text>.
 
-      LOOP AT lt_dd07v ASSIGNING <ls_dd07v>.
+      LOOP AT lt_dd07v ASSIGNING <ls_dd07v> WHERE NOT ddlanguage IS INITIAL.
         APPEND INITIAL LINE TO lt_dd07_texts ASSIGNING <ls_dd07_text>.
         MOVE-CORRESPONDING <ls_dd07v> TO <ls_dd07_text>.
       ENDLOOP.


### PR DESCRIPTION
DOMA do not serialize texts without language #2311

Excluding translations without language key should be safe