### PR TITLE
Refactoring of CORR_INSERT and adjustment for object types

### DIFF
--- a/src/objects/zcl_abapgit_object_doma.clas.abap
+++ b/src/objects/zcl_abapgit_object_doma.clas.abap
@@ -265,7 +265,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DOMA IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'DD07V_TAB'
                   CHANGING cg_data = lt_dd07v ).
 
-    corr_insert( iv_package ).
+    corr_insert( iv_package = iv_package iv_object_class = 'DICT' ).
 
     lv_name = ms_item-obj_name. " type conversion
 

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -194,7 +194,7 @@ CLASS zcl_abapgit_object_dtel IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'TPARA'
                   CHANGING cg_data = ls_tpara ).
 
-    corr_insert( iv_package ).
+    corr_insert( iv_package = iv_package iv_object_class = 'DICT' ).
 
     lv_name = ms_item-obj_name. " type conversion
 

--- a/src/objects/zcl_abapgit_object_enqu.clas.abap
+++ b/src/objects/zcl_abapgit_object_enqu.clas.abap
@@ -72,7 +72,7 @@ CLASS zcl_abapgit_object_enqu IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'DD27P_TABLE'
                   CHANGING cg_data = lt_dd27p ).
 
-    corr_insert( iv_package ).
+    corr_insert( iv_package = iv_package iv_object_class = 'DICT' ).
 
     lv_name = ms_item-obj_name.
 

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -335,20 +335,7 @@ CLASS ZCL_ABAPGIT_OBJECT_MSAG IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'T100'
                   CHANGING cg_data = lt_t100 ).
 
-    CALL FUNCTION 'RS_CORR_INSERT'
-      EXPORTING
-        global_lock         = abap_true
-        devclass            = iv_package
-        object              = ls_t100a-arbgb
-        object_class        = 'T100'
-        mode                = 'INSERT'
-      EXCEPTIONS
-        cancelled           = 01
-        permission_failure  = 02
-        unknown_objectclass = 03.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'Error from RS_CORR_INSERT' ).
-    ENDIF.
+    corr_insert( iv_package ).
 
     SELECT * FROM t100u INTO TABLE lt_before
       WHERE arbgb = ls_t100a-arbgb ORDER BY msgnr. "#EC CI_GENBUFF "#EC CI_BYPASS

--- a/src/objects/zcl_abapgit_object_shlp.clas.abap
+++ b/src/objects/zcl_abapgit_object_shlp.clas.abap
@@ -165,7 +165,7 @@ CLASS zcl_abapgit_object_shlp IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'DD33V_TABLE'
                   CHANGING cg_data = lt_dd33v ).
 
-    corr_insert( iv_package ).
+    corr_insert( iv_package = iv_package iv_object_class = 'DICT' ).
 
     lv_name = ms_item-obj_name.
 

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -524,7 +524,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
       io_xml->read( EXPORTING iv_name = 'DD36M'
                     CHANGING cg_data = lt_dd36m ).
 
-      corr_insert( iv_package ).
+      corr_insert( iv_package = iv_package iv_object_class = 'DICT' ).
 
       lv_name = ms_item-obj_name. " type conversion
 

--- a/src/objects/zcl_abapgit_object_ttyp.clas.abap
+++ b/src/objects/zcl_abapgit_object_ttyp.clas.abap
@@ -150,7 +150,7 @@ CLASS zcl_abapgit_object_ttyp IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'DD43V'
                   CHANGING cg_data = lt_dd43v ).
 
-    corr_insert( iv_package ).
+    corr_insert( iv_package = iv_package iv_object_class = 'DICT' ).
 
     lv_name = ms_item-obj_name. " type conversion
 

--- a/src/objects/zcl_abapgit_object_view.clas.abap
+++ b/src/objects/zcl_abapgit_object_view.clas.abap
@@ -77,7 +77,7 @@ CLASS zcl_abapgit_object_view IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'DD28V_TABLE'
                   CHANGING cg_data = lt_dd28v ).
 
-    corr_insert( iv_package ).
+    corr_insert( iv_package = iv_package iv_object_class = 'DICT' ).
 
     lv_name = ms_item-obj_name. " type conversion
 

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -142,12 +142,8 @@ CLASS ZCL_ABAPGIT_OBJECTS_SUPER IMPLEMENTATION.
 
   METHOD corr_insert.
 
-    DATA: lv_object           TYPE string,
-          lv_object_class     TYPE string,
-          lv_gui_is_available TYPE c,
-          lv_korrnum_check    TYPE e070-trkorr,
-          lv_ordernum_check   TYPE e070-trkorr,
-          lv_korrnum          TYPE e070-trkorr.
+    DATA: lv_object       TYPE string,
+          lv_object_class TYPE string.
 
     IF iv_object_class IS NOT INITIAL.
       lv_object_class = iv_object_class.
@@ -161,76 +157,21 @@ CLASS ZCL_ABAPGIT_OBJECTS_SUPER IMPLEMENTATION.
       lv_object       = ms_item-obj_name.
     ENDIF.
 
-    CALL FUNCTION 'GUI_IS_AVAILABLE'
-      IMPORTING
-        return = lv_gui_is_available.
-
-    IF lv_gui_is_available EQ abap_true.
-      CALL FUNCTION 'RS_CORR_INSERT'
-        EXPORTING
-          object              = lv_object
-          object_class        = lv_object_class
-          devclass            = iv_package
-          master_language     = mv_language
-          global_lock         = abap_true
-          mode                = 'I'
-        EXCEPTIONS
-          cancelled           = 1
-          permission_failure  = 2
-          unknown_objectclass = 3
-          OTHERS              = 4.
-    ELSE.
-
-      "check whether object is currently locked in different transport
-      CALL FUNCTION 'RS_CORR_CHECK'
-        EXPORTING
-          object              = lv_object
-          object_class        = lv_object_class
-          mode                = 'I'
-          global_lock         = abap_true
-          suppress_dialog     = abap_true
-        IMPORTING
-*         devclass            =
-*         error_info          =
-*         master_language     =
-          korrnum             = lv_korrnum_check
-          ordernum            = lv_ordernum_check
-*         transport_key       =
-*         tadire              =
-        EXCEPTIONS
-          cancelled           = 1
-          permission_failure  = 2
-          unknown_objectclass = 3
-          OTHERS              = 4.
-      CASE sy-subrc.
-        WHEN 0.
-          IF lv_ordernum_check IS NOT INITIAL.
-            "take task under lv_ordernum_check
-            lv_korrnum = lv_korrnum_check.
-          ELSE.
-            lv_korrnum = cl_abapgit_default_transport=>get_instance( )->get( )-ordernum.
-          ENDIF.
-        WHEN OTHERS.
-          cx_abapgit_exception=>raise_t100( ).
-      ENDCASE.
-
-      CALL FUNCTION 'RS_CORR_INSERT'
-        EXPORTING
-          object              = lv_object
-          object_class        = lv_object_class
-          mode                = 'I'
-          global_lock         = abap_true
-          korrnum             = lv_korrnum
-          devclass            = iv_package
-          author              = sy-uname
-          master_language     = mv_language "sy-langu
-          suppress_dialog     = abap_true
-        EXCEPTIONS
-          cancelled           = 1
-          permission_failure  = 2
-          unknown_objectclass = 3
-          OTHERS              = 4.
-    ENDIF.
+    CALL FUNCTION 'RS_CORR_INSERT'
+      EXPORTING
+        object              = lv_object
+        object_class        = lv_object_class
+        devclass            = iv_package
+        master_language     = mv_language
+        global_lock         = abap_true
+        author              = sy-uname
+        mode                = 'I'
+        suppress_dialog     = abap_true
+      EXCEPTIONS
+        cancelled           = 1
+        permission_failure  = 2
+        unknown_objectclass = 3
+        OTHERS              = 4.
     IF sy-subrc <> 0.
       cx_abapgit_exception=>raise_t100( ).
     ENDIF.

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -173,7 +173,7 @@ CLASS ZCL_ABAPGIT_OBJECTS_SUPER IMPLEMENTATION.
         unknown_objectclass = 3
         OTHERS              = 4.
     IF sy-subrc <> 0.
-      cx_abapgit_exception=>raise_t100( ).
+      zcx_abapgit_exception=>raise_t100( ).
     ENDIF.
 
   ENDMETHOD.


### PR DESCRIPTION
Method `ZCL_ABAPGIT_OBJECTS_SUPER->CORR_INSERT` enhanced to be used for several object types (dictionary and non-dictionary) in dialog and dark mode.
Fixes #2378 