### PR TITLE
Ignore files not in local repo

### DIFF
--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -688,17 +688,25 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
   METHOD zif_abapgit_popups~popup_to_create_transp_branch.
     DATA: lt_fields             TYPE TABLE OF sval,
           lv_transports_as_text TYPE string,
+          lv_desc_as_text       TYPE string,
           ls_transport_header   LIKE LINE OF it_transport_headers.
     DATA: lv_branch_name        TYPE spo_value.
     DATA: lv_commit_text        TYPE spo_value.
 
     CLEAR: rs_transport_branch-branch_name, rs_transport_branch-commit_text.
 
-    lv_transports_as_text = 'Transport(s)'.
-    LOOP AT it_transport_headers INTO ls_transport_header.
-      CONCATENATE lv_transports_as_text '_' ls_transport_header-trkorr INTO lv_transports_as_text.
-    ENDLOOP.
+    IF lines( it_transport_headers ) = 1.   " If we only have one transport selected set branch name to Transport name and commit description to transport description.
+      ls_transport_header = it_transport_headers[ 1 ].
+      lv_transports_as_text = ls_transport_header-trkorr.
+      SELECT SINGLE as4text FROM e07t WHERE trkorr = @ls_transport_header-trkorr AND langu = @sy-langu INTO @lv_desc_as_text .
+    ELSE.   " Else set branch name and commit message to 'Transport(s)_TRXXXXXX_TRXXXXX'
+      lv_transports_as_text = 'Transport(s)'.
+      LOOP AT it_transport_headers INTO ls_transport_header.
+        CONCATENATE lv_transports_as_text '_' ls_transport_header-trkorr INTO lv_transports_as_text.
+      ENDLOOP.
+      lv_desc_as_text = lv_transports_as_text.
 
+    ENDIF.
     add_field( EXPORTING iv_tabname   = 'TEXTL'
                          iv_fieldname = 'LINE'
                          iv_fieldtext = 'Branch name'
@@ -708,7 +716,7 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
     add_field( EXPORTING iv_tabname   = 'ABAPTXT255'
                          iv_fieldname = 'LINE'
                          iv_fieldtext = 'Commit text'
-                         iv_value     = lv_transports_as_text
+                         iv_value     = lv_desc_as_text
                CHANGING ct_fields     = lt_fields ).
 
     _popup_2_get_values( EXPORTING iv_popup_title    = 'Transport to new Branch' "#EC NOTEXT

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -695,10 +695,14 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
     CLEAR: rs_transport_branch-branch_name, rs_transport_branch-commit_text.
 
-    IF lines( it_transport_headers ) = 1.   " If we only have one transport selected set branch name to Transport name and commit description to transport description.
-      ls_transport_header = it_transport_headers[ 1 ].
+    " If we only have one transport selected set branch name to Transport name and commit description to transport description.
+    IF lines( it_transport_headers ) = 1.
+      READ TABLE it_transport_headers INDEX 1 INTO ls_transport_header.
       lv_transports_as_text = ls_transport_header-trkorr.
-      SELECT SINGLE as4text FROM e07t WHERE trkorr = @ls_transport_header-trkorr AND langu = @sy-langu INTO @lv_desc_as_text .
+      SELECT SINGLE as4text FROM e07t INTO lv_desc_as_text  WHERE
+        trkorr = ls_transport_header-trkorr AND
+        langu = sy-langu .
+
     ELSE.   " Else set branch name and commit message to 'Transport(s)_TRXXXXXX_TRXXXXX'
       lv_transports_as_text = 'Transport(s)'.
       LOOP AT it_transport_headers INTO ls_transport_header.

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -695,7 +695,8 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
     CLEAR: rs_transport_branch-branch_name, rs_transport_branch-commit_text.
 
-    " If we only have one transport selected set branch name to Transport name and commit description to transport description.
+    " If we only have one transport selected set branch name to Transport
+    " name and commit description to transport description.
     IF lines( it_transport_headers ) = 1.
       READ TABLE it_transport_headers INDEX 1 INTO ls_transport_header.
       lv_transports_as_text = ls_transport_header-trkorr.

--- a/src/zcl_abapgit_transport_objects.clas.testclasses.abap
+++ b/src/zcl_abapgit_transport_objects.clas.testclasses.abap
@@ -179,8 +179,8 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
       iv_filename = 'CL_FOO.abap'
       iv_path     = '/path'
       iv_data     = 'data' ).
-then_it_should_raise_exception(
-      iv_with_text = 'Object CL_FOO not found in the local repository files' ).
+    then_it_should_raise_exception(
+          iv_with_text = 'Object CL_FOO not found in the local repository files' ).
   ENDMETHOD.
 
   METHOD cant_be_added_with_del_flag.

--- a/src/zcl_abapgit_transport_objects.clas.testclasses.abap
+++ b/src/zcl_abapgit_transport_objects.clas.testclasses.abap
@@ -43,7 +43,8 @@ CLASS ltcl_transport_objects DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HA
       then_it_should_remove_at_stage
         IMPORTING
           iv_filename TYPE string
-          iv_path     TYPE string.
+          iv_path     TYPE string,
+      then_it_should_not_raise_excpt.
 
     DATA: mo_transport_objects TYPE REF TO zcl_abapgit_transport_objects,
           mt_transport_objects TYPE zif_abapgit_definitions=>ty_tadir_tt,
@@ -157,8 +158,10 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
       iv_obj_type   = 'CLAS'
       iv_lstate     = zif_abapgit_definitions=>c_state-added ).
 
-    then_it_should_raise_exception(
-      iv_with_text = 'Object CL_A_CLASS_NOT_IN_REPO not found in the local repository files' ).
+        then_it_should_not_raise_excpt( ).
+
+ "   then_it_should_raise_exception(
+ "     iv_with_text = 'Object CL_A_CLASS_NOT_IN_REPO not found in the local repository files' ).
   ENDMETHOD.
 
   METHOD object_not_in_local_files.
@@ -178,8 +181,7 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
       iv_filename = 'CL_FOO.abap'
       iv_path     = '/path'
       iv_data     = 'data' ).
-
-    then_it_should_raise_exception(
+then_it_should_raise_exception(
       iv_with_text = 'Object CL_FOO not found in the local repository files' ).
   ENDMETHOD.
 
@@ -357,6 +359,16 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
     IF sy-subrc <> 0.
       cl_abap_unit_assert=>fail( |Object { iv_filename } not removed in stage| ).
     ENDIF.
+  ENDMETHOD.
+
+  METHOD then_it_should_not_raise_excpt.
+    DATA: lx_exception TYPE REF TO zcx_abapgit_exception.
+
+    TRY.
+        when_staging( ).
+      CATCH zcx_abapgit_exception INTO lx_exception.
+        cl_abap_unit_assert=>fail( 'Should not have raised exception' ).
+    ENDTRY.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcl_abapgit_transport_objects.clas.testclasses.abap
+++ b/src/zcl_abapgit_transport_objects.clas.testclasses.abap
@@ -158,10 +158,8 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
       iv_obj_type   = 'CLAS'
       iv_lstate     = zif_abapgit_definitions=>c_state-added ).
 
-        then_it_should_not_raise_excpt( ).
+    then_it_should_not_raise_excpt( ).
 
- "   then_it_should_raise_exception(
- "     iv_with_text = 'Object CL_A_CLASS_NOT_IN_REPO not found in the local repository files' ).
   ENDMETHOD.
 
   METHOD object_not_in_local_files.


### PR DESCRIPTION
When commiting files from the Transport-to-branch option Abapgit tries to commit all objects in the transport request, and if these transports are for some reason ignored (.gitignore, generated SADL-objects for example) the commit fails since not all files to be commited are in the repo.

This change ignores these files, and trusts that the files not in the local repo should not be staged. Not sure if this is something we should trust, but it solves my itch.