### PR TITLE
ENHO: check existence before deletion #2410

### DIFF
--- a/src/objects/zcl_abapgit_object_enho.clas.abap
+++ b/src/objects/zcl_abapgit_object_enho.clas.abap
@@ -116,6 +116,9 @@ CLASS ZCL_ABAPGIT_OBJECT_ENHO IMPLEMENTATION.
     DATA: lv_enh_id     TYPE enhname,
           li_enh_object TYPE REF TO if_enh_object.
 
+    IF zif_abapgit_object~exists( ) = abap_false.
+      RETURN.
+    ENDIF.
 
     lv_enh_id = ms_item-obj_name.
     TRY.


### PR DESCRIPTION
With this commit we add an existence check the delete method
of ENHO serializer because some enhancements, like implicit source code 
enhancements of classes, are deleted implicitly.

#2410