### PR TITLE
Fix filename construction: Add extension only if not initial #2425

### DIFF
--- a/src/objects/zcl_abapgit_objects_files.clas.abap
+++ b/src/objects/zcl_abapgit_objects_files.clas.abap
@@ -204,11 +204,16 @@ CLASS ZCL_ABAPGIT_OBJECTS_FILES IMPLEMENTATION.
     ENDIF.
 
     IF iv_extra IS INITIAL.
-      CONCATENATE lv_obj_name '.' ms_item-obj_type '.' iv_ext
+      CONCATENATE lv_obj_name '.' ms_item-obj_type
         INTO rv_filename.                                   "#EC NOTEXT
     ELSE.
-      CONCATENATE lv_obj_name '.' ms_item-obj_type '.' iv_extra '.' iv_ext
+      CONCATENATE lv_obj_name '.' ms_item-obj_type '.' iv_extra
         INTO rv_filename.                                   "#EC NOTEXT
+    ENDIF.
+
+    IF iv_ext IS NOT INITIAL.
+      CONCATENATE rv_filename '.' iv_ext
+        INTO rv_filename.
     ENDIF.
 
 * handle namespaces


### PR DESCRIPTION
With this commit we fix the filename construction so that for
objects without file extension the correct filename is constructed.
Before this commit is applied these objects create file names with
an additional dot at the end.

#2425