### PR TITLE
Add repo option to force old serializer for CLAS

### DIFF
--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -5,8 +5,9 @@ CLASS zcl_abapgit_object_clas DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
     ALIASES mo_files FOR zif_abapgit_object~mo_files.
     METHODS: constructor
       IMPORTING
-        is_item     TYPE zif_abapgit_definitions=>ty_item
-        iv_language TYPE spras.
+        is_item                 TYPE zif_abapgit_definitions=>ty_item
+        iv_language             TYPE spras
+        iv_force_old_serializer TYPE abap_bool DEFAULT abap_false.
 
   PROTECTED SECTION.
     DATA: mi_object_oriented_object_fct TYPE REF TO zif_abapgit_oo_object_fnc,
@@ -35,16 +36,19 @@ CLASS zcl_abapgit_object_clas DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
       is_class_locked
         RETURNING VALUE(rv_is_class_locked) TYPE abap_bool
         RAISING   zcx_abapgit_exception.
+    DATA:
+      mv_force_old_serializer TYPE abap_bool.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
+CLASS zcl_abapgit_object_clas IMPLEMENTATION.
 
 
   METHOD constructor.
     super->constructor( is_item     = is_item
                         iv_language = iv_language ).
+    mv_force_old_serializer = iv_force_old_serializer.
 
     CREATE OBJECT mi_object_oriented_object_fct TYPE zcl_abapgit_oo_class.
   ENDMETHOD.
@@ -401,7 +405,9 @@ CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
         version = seoc_version_inactive
         force   = seox_true.
 
-    lt_source = mi_object_oriented_object_fct->serialize_abap( ls_class_key ).
+    lt_source = mi_object_oriented_object_fct->serialize_abap(
+      is_class_key            = ls_class_key
+      iv_force_old_serializer = mv_force_old_serializer ).
 
     mo_files->add_abap( lt_source ).
 

--- a/src/objects/zcl_abapgit_oo_base.clas.abap
+++ b/src/objects/zcl_abapgit_oo_base.clas.abap
@@ -22,11 +22,15 @@ CLASS zcl_abapgit_oo_base DEFINITION PUBLIC ABSTRACT.
                 it_source TYPE zif_abapgit_definitions=>ty_string_tt
       RAISING   zcx_abapgit_exception
                 cx_sy_dyn_call_error.
+
+    METHODS get_force_method_order
+      IMPORTING iv_clsname                   TYPE seoclsname
+      RETURNING VALUE(rv_force_method_order) TYPE abap_bool.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OO_BASE IMPLEMENTATION.
+CLASS zcl_abapgit_oo_base IMPLEMENTATION.
 
 
   METHOD convert_attrib_to_vseoattrib.
@@ -304,7 +308,9 @@ CLASS ZCL_ABAPGIT_OO_BASE IMPLEMENTATION.
         rt_source = lo_oo_serializer->serialize_testclasses( is_class_key ).
         mv_skip_test_classes = lo_oo_serializer->are_test_classes_skipped( ).
       WHEN OTHERS.
-        rt_source = lo_oo_serializer->serialize_abap_clif_source( is_class_key ).
+        rt_source = lo_oo_serializer->serialize_abap_clif_source(
+          is_class_key            = is_class_key
+          iv_force_old_serializer = get_force_method_order( is_class_key-clsname ) ).
     ENDCASE.
   ENDMETHOD.
 
@@ -312,5 +318,36 @@ CLASS ZCL_ABAPGIT_OO_BASE IMPLEMENTATION.
   METHOD zif_abapgit_oo_object_fnc~update_descriptions.
     DELETE FROM seocompotx WHERE clsname = is_key-clsname. "#EC CI_SUBRC
     INSERT seocompotx FROM TABLE it_descriptions.         "#EC CI_SUBRC
+  ENDMETHOD.
+
+  METHOD get_force_method_order.
+    DATA: lv_object_package TYPE devclass,
+          lt_packages       TYPE zif_abapgit_sap_package=>ty_devclass_tt,
+          lv_obj_name       TYPE sobj_name,
+          lo_repo           TYPE REF TO zcl_abapgit_repo.
+
+    lv_obj_name = iv_clsname.
+    rv_force_method_order = abap_false.
+    ##TODO.
+    " get_repo_by_object or get_repo_by_package would be nice...
+    TRY.
+        lv_object_package = zcl_abapgit_factory=>get_tadir( )->get_object_package(
+          iv_object   = 'CLAS'
+          iv_obj_name = lv_obj_name ).
+        IF lv_object_package IS INITIAL.
+          RETURN. " This will happen for INTF
+        ENDIF.
+        lt_packages = zcl_abapgit_factory=>get_sap_package( lv_object_package )->list_superpackages( ).
+        LOOP AT zcl_abapgit_repo_srv=>get_instance( )->list( ) INTO lo_repo.
+          LOOP AT lt_packages TRANSPORTING NO FIELDS WHERE table_line = lo_repo->get_package( ).
+            EXIT.
+          ENDLOOP.
+          IF sy-subrc = 0.
+            rv_force_method_order = lo_repo->get_dot_abapgit( )->get_force_method_order( ).
+            RETURN.
+          ENDIF.
+        ENDLOOP.
+      CATCH zcx_abapgit_exception ##NO_HANDLER.
+    ENDTRY.
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_oo_serializer.clas.abap
+++ b/src/objects/zcl_abapgit_oo_serializer.clas.abap
@@ -6,9 +6,10 @@ CLASS zcl_abapgit_oo_serializer DEFINITION
 
     METHODS serialize_abap_clif_source
       IMPORTING
-        !is_class_key    TYPE seoclskey
+        !is_class_key           TYPE seoclskey
+        iv_force_old_serializer TYPE abap_bool DEFAULT abap_false
       RETURNING
-        VALUE(rt_source) TYPE zif_abapgit_definitions=>ty_string_tt
+        VALUE(rt_source)        TYPE zif_abapgit_definitions=>ty_string_tt
       RAISING
         zcx_abapgit_exception
         cx_sy_dyn_call_error .
@@ -84,7 +85,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OO_SERIALIZER IMPLEMENTATION.
+CLASS zcl_abapgit_oo_serializer IMPLEMENTATION.
 
 
   METHOD are_test_classes_skipped.
@@ -206,6 +207,11 @@ CLASS ZCL_ABAPGIT_OO_SERIALIZER IMPLEMENTATION.
 
 
   METHOD serialize_abap_clif_source.
+    IF iv_force_old_serializer = abap_true.
+      rt_source = serialize_abap_old( is_class_key ).
+      RETURN.
+    ENDIF.
+
     TRY.
         rt_source = serialize_abap_new( is_class_key ).
       CATCH cx_sy_dyn_call_error.

--- a/src/objects/zif_abapgit_oo_object_fnc.intf.abap
+++ b/src/objects/zif_abapgit_oo_object_fnc.intf.abap
@@ -75,10 +75,11 @@ INTERFACE zif_abapgit_oo_object_fnc PUBLIC.
         VALUE(rv_exists) TYPE abap_bool,
     serialize_abap
       IMPORTING
-        is_class_key     TYPE seoclskey
-        iv_type          TYPE seop_include_ext_app OPTIONAL
+        is_class_key            TYPE seoclskey
+        iv_type                 TYPE seop_include_ext_app OPTIONAL
+        iv_force_old_serializer TYPE abap_bool DEFAULT abap_false
       RETURNING
-        VALUE(rt_source) TYPE zif_abapgit_definitions=>ty_string_tt
+        VALUE(rt_source)        TYPE zif_abapgit_definitions=>ty_string_tt
       RAISING
         zcx_abapgit_exception
         cx_sy_dyn_call_error,

--- a/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
@@ -60,7 +60,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_repo_sett IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -104,7 +104,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
           lv_selected          TYPE string,
           lt_folder_logic      TYPE stringtab,
           lv_req_index         TYPE i,
-          lv_requirement_count TYPE i.
+          lv_requirement_count TYPE i,
+          lv_checked           TYPE string.
 
     FIELD-SYMBOLS: <lv_folder_logic> TYPE LINE OF stringtab,
                    <ls_requirement>  TYPE zif_abapgit_dot_abapgit=>ty_requirement.
@@ -147,6 +148,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
     io_html->add( 'Starting folder: <input name="starting_folder" type="text" size="10" value="' &&
       ls_dot-starting_folder && '">' ).
     io_html->add( '<br>' ).
+
+    IF ls_dot-force_method_order = abap_true.
+      lv_checked = | checked|.
+    ENDIF.
+    io_html->add( |Force alphabetical method order <input name="force_meth_order" type="checkbox"{ lv_checked }><br>| ).
 
     io_html->add( '<h3>Requirements</h3>' ).
     io_html->add( '<table class="repo_tab" id="requirement-tab" style="max-width: 300px;">' ).
@@ -253,6 +259,13 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
     READ TABLE it_post_fields INTO ls_post_field WITH KEY name = 'starting_folder'.
     ASSERT sy-subrc = 0.
     lo_dot->set_starting_folder( ls_post_field-value ).
+
+    READ TABLE it_post_fields INTO ls_post_field WITH KEY name = 'force_meth_order' value = 'on'.
+    IF sy-subrc = 0.
+      lo_dot->set_force_method_order( abap_true ).
+    ELSE.
+      lo_dot->set_force_method_order( abap_false ).
+    ENDIF.
 
     lo_requirements = lcl_requirements=>new( ).
     LOOP AT it_post_fields INTO ls_post_field WHERE name CP 'req_*'.

--- a/src/zabapgit_parallel.fugr.xml
+++ b/src/zabapgit_parallel.fugr.xml
@@ -33,6 +33,12 @@
        <PARAMETER>IV_PATH</PARAMETER>
        <TYP>STRING</TYP>
       </RSIMP>
+      <RSIMP>
+       <PARAMETER>IV_FORCE_OLD_SERIALIZER_CLAS</PARAMETER>
+       <DEFAULT>ABAP_FALSE</DEFAULT>
+       <OPTIONAL>X</OPTIONAL>
+       <TYP>XFELD</TYP>
+      </RSIMP>
      </IMPORT>
      <EXPORT>
       <RSEXP>
@@ -80,19 +86,24 @@
        <INDEX> 005</INDEX>
       </RSFDO>
       <RSFDO>
-       <PARAMETER>EV_RESULT</PARAMETER>
+       <PARAMETER>IV_FORCE_OLD_SERIALIZER_CLAS</PARAMETER>
        <KIND>P</KIND>
        <INDEX> 006</INDEX>
       </RSFDO>
       <RSFDO>
-       <PARAMETER>EV_PATH</PARAMETER>
+       <PARAMETER>EV_RESULT</PARAMETER>
        <KIND>P</KIND>
        <INDEX> 007</INDEX>
       </RSFDO>
       <RSFDO>
+       <PARAMETER>EV_PATH</PARAMETER>
+       <KIND>P</KIND>
+       <INDEX> 008</INDEX>
+      </RSFDO>
+      <RSFDO>
        <PARAMETER>ERROR</PARAMETER>
        <KIND>X</KIND>
-       <INDEX> 008</INDEX>
+       <INDEX> 009</INDEX>
       </RSFDO>
      </DOCUMENTATION>
     </item>

--- a/src/zabapgit_parallel.fugr.z_abapgit_serialize_parallel.abap
+++ b/src/zabapgit_parallel.fugr.z_abapgit_serialize_parallel.abap
@@ -1,4 +1,4 @@
-FUNCTION z_abapgit_serialize_parallel.
+FUNCTION Z_ABAPGIT_SERIALIZE_PARALLEL.
 *"----------------------------------------------------------------------
 *"*"Local Interface:
 *"  IMPORTING
@@ -7,13 +7,14 @@ FUNCTION z_abapgit_serialize_parallel.
 *"     VALUE(IV_DEVCLASS) TYPE  TADIR-DEVCLASS
 *"     VALUE(IV_LANGUAGE) TYPE  SY-LANGU
 *"     VALUE(IV_PATH) TYPE  STRING
+*"     VALUE(IV_FORCE_OLD_SERIALIZER_CLAS) TYPE  XFELD DEFAULT
+*"       ABAP_FALSE
 *"  EXPORTING
 *"     VALUE(EV_RESULT) TYPE  XSTRING
 *"     VALUE(EV_PATH) TYPE  STRING
 *"  EXCEPTIONS
 *"      ERROR
 *"----------------------------------------------------------------------
-
   DATA: ls_item  TYPE zif_abapgit_definitions=>ty_item,
         lx_error TYPE REF TO zcx_abapgit_exception,
         lv_text  TYPE c LENGTH 200,

--- a/src/zcl_abapgit_dot_abapgit.clas.abap
+++ b/src/zcl_abapgit_dot_abapgit.clas.abap
@@ -71,6 +71,11 @@ CLASS zcl_abapgit_dot_abapgit DEFINITION
     METHODS set_requirements
       IMPORTING
         it_requirements TYPE zif_abapgit_dot_abapgit=>ty_requirement_tt.
+    METHODS set_force_method_order
+      IMPORTING
+        iv_force_method_order TYPE abap_bool.
+    METHODS get_force_method_order
+      RETURNING VALUE(rv_force_method_order) TYPE abap_bool.
   PROTECTED SECTION.
   PRIVATE SECTION.
     DATA: ms_data TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit.
@@ -88,7 +93,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_DOT_ABAPGIT IMPLEMENTATION.
+CLASS zcl_abapgit_dot_abapgit IMPLEMENTATION.
 
 
   METHOD add_ignore.
@@ -298,5 +303,13 @@ CLASS ZCL_ABAPGIT_DOT_ABAPGIT IMPLEMENTATION.
       WITH '<?xml version="1.0" encoding="utf-8"?>'.
     ASSERT sy-subrc = 0.
 
+  ENDMETHOD.
+
+  METHOD get_force_method_order.
+    rv_force_method_order = ms_data-force_method_order.
+  ENDMETHOD.
+
+  METHOD set_force_method_order.
+    ms_data-force_method_order = iv_force_method_order.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -164,7 +164,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
+CLASS zcl_abapgit_repo IMPLEMENTATION.
 
 
   METHOD apply_filter.
@@ -357,9 +357,10 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
     CREATE OBJECT lo_serialize.
 
     lt_found = lo_serialize->serialize(
-      it_tadir    = lt_tadir
-      iv_language = get_dot_abapgit( )->get_master_language( )
-      io_log      = io_log ).
+      it_tadir                     = lt_tadir
+      iv_language                  = get_dot_abapgit( )->get_master_language( )
+      io_log                       = io_log
+      iv_force_old_serializer_clas = get_dot_abapgit( )->get_force_method_order( ) ).
     APPEND LINES OF lt_found TO rt_files.
 
     mt_local                 = rt_files.

--- a/src/zcl_abapgit_serialize.clas.abap
+++ b/src/zcl_abapgit_serialize.clas.abap
@@ -10,12 +10,13 @@ CLASS zcl_abapgit_serialize DEFINITION
         !p_task TYPE clike .
     METHODS serialize
       IMPORTING
-        !it_tadir            TYPE zif_abapgit_definitions=>ty_tadir_tt
-        !iv_language         TYPE langu DEFAULT sy-langu
-        !io_log              TYPE REF TO zcl_abapgit_log OPTIONAL
-        !iv_force_sequential TYPE abap_bool DEFAULT abap_false
+        !it_tadir                    TYPE zif_abapgit_definitions=>ty_tadir_tt
+        !iv_language                 TYPE langu DEFAULT sy-langu
+        !io_log                      TYPE REF TO zcl_abapgit_log OPTIONAL
+        !iv_force_sequential         TYPE abap_bool DEFAULT abap_false
+        iv_force_old_serializer_clas TYPE abap_bool DEFAULT abap_false
       RETURNING
-        VALUE(rt_files)      TYPE zif_abapgit_definitions=>ty_files_item_tt
+        VALUE(rt_files)              TYPE zif_abapgit_definitions=>ty_files_item_tt
       RAISING
         zcx_abapgit_exception .
 
@@ -32,16 +33,18 @@ CLASS zcl_abapgit_serialize DEFINITION
         !is_fils_item TYPE zcl_abapgit_objects=>ty_serialization .
     METHODS run_parallel
       IMPORTING
-        !iv_group    TYPE rzlli_apcl
-        !is_tadir    TYPE zif_abapgit_definitions=>ty_tadir
-        !iv_language TYPE langu
-        !iv_task     TYPE sychar32
+        !iv_group                    TYPE rzlli_apcl
+        !is_tadir                    TYPE zif_abapgit_definitions=>ty_tadir
+        !iv_language                 TYPE langu
+        !iv_task                     TYPE sychar32
+        iv_force_old_serializer_clas TYPE abap_bool DEFAULT abap_false
       RAISING
         zcx_abapgit_exception .
     METHODS run_sequential
       IMPORTING
-        !is_tadir    TYPE zif_abapgit_definitions=>ty_tadir
-        !iv_language TYPE langu
+        !is_tadir                    TYPE zif_abapgit_definitions=>ty_tadir
+        !iv_language                 TYPE langu
+        iv_force_old_serializer_clas TYPE abap_bool DEFAULT abap_false
       RAISING
         zcx_abapgit_exception .
     METHODS determine_max_threads
@@ -210,16 +213,17 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
         DESTINATION IN GROUP iv_group
         CALLING on_end_of_task ON END OF TASK
         EXPORTING
-          iv_obj_type           = is_tadir-object
-          iv_obj_name           = is_tadir-obj_name
-          iv_devclass           = is_tadir-devclass
-          iv_language           = iv_language
-          iv_path               = is_tadir-path
+          iv_obj_type                  = is_tadir-object
+          iv_obj_name                  = is_tadir-obj_name
+          iv_devclass                  = is_tadir-devclass
+          iv_language                  = iv_language
+          iv_path                      = is_tadir-path
+          iv_force_old_serializer_clas = iv_force_old_serializer_clas
         EXCEPTIONS
-          system_failure        = 1 MESSAGE lv_msg
-          communication_failure = 2 MESSAGE lv_msg
-          resource_failure      = 3
-          OTHERS                = 4.
+          system_failure               = 1 MESSAGE lv_msg
+          communication_failure        = 2 MESSAGE lv_msg
+          resource_failure             = 3
+          OTHERS                       = 4.
       IF sy-subrc = 3.
         lv_free = mv_free.
         WAIT UNTIL mv_free <> lv_free UP TO 1 SECONDS.
@@ -247,8 +251,9 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
 
     TRY.
         ls_fils_item = zcl_abapgit_objects=>serialize(
-          is_item     = ls_fils_item-item
-          iv_language = iv_language ).
+          is_item                      = ls_fils_item-item
+          iv_language                  = iv_language
+          iv_force_old_serializer_clas = iv_force_old_serializer_clas ).
 
         add_to_return( is_fils_item = ls_fils_item
                        iv_path      = is_tadir-path ).
@@ -285,8 +290,9 @@ CLASS zcl_abapgit_serialize IMPLEMENTATION.
 
       IF lv_max = 1.
         run_sequential(
-          is_tadir    = <ls_tadir>
-          iv_language = iv_language ).
+          is_tadir                     = <ls_tadir>
+          iv_language                  = iv_language
+          iv_force_old_serializer_clas = iv_force_old_serializer_clas ).
       ELSE.
         run_parallel(
           iv_group    = 'parallel_generators'    " todo

--- a/src/zif_abapgit_dot_abapgit.intf.abap
+++ b/src/zif_abapgit_dot_abapgit.intf.abap
@@ -10,11 +10,12 @@ INTERFACE zif_abapgit_dot_abapgit PUBLIC.
     ty_requirement_tt TYPE STANDARD TABLE OF ty_requirement WITH DEFAULT KEY .
   TYPES:
     BEGIN OF ty_dot_abapgit,
-      master_language              TYPE spras,
-      starting_folder              TYPE string,
-      folder_logic                 TYPE string,
-      ignore                       TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
-      requirements                 TYPE ty_requirement_tt,
+      master_language    TYPE spras,
+      starting_folder    TYPE string,
+      folder_logic       TYPE string,
+      ignore             TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
+      requirements       TYPE ty_requirement_tt,
+      force_method_order TYPE abap_bool,
     END OF ty_dot_abapgit .
 
   CONSTANTS:


### PR DESCRIPTION
Fixes #2321

I would still like to have this option available to prevent conflicts when using branches (i. e. transport = branch). Mainly to prevent [this](https://streamable.com/ee369) bug to have any effect in abapGit (#756).

I noticed that the "old" serializer seems to create the result when stuff gets rearranged in ADT, which is already used by abapGit as a fallback if the new one is not available. So I just added an option to always use it instead for CLAS.

The approach I chose to inject the read access to the repo setting in ZCL_ABAPGIT_OO_BASE is not very pretty. I could not find any existing dependencies from OBJECT_* classes to REPO so I am not sure how to handle it in a nice way.