### PR TITLE
GUI, asset manager refactoring

### DIFF
--- a/src/ui/zcl_abapgit_gui.clas.abap
+++ b/src/ui/zcl_abapgit_gui.clas.abap
@@ -314,7 +314,7 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
         parent               = cl_gui_container=>screen0.
 
     lt_assets = mi_asset_man->get_all_assets( ).
-    LOOP AT lt_assets ASSIGNING <ls_asset>.
+    LOOP AT lt_assets ASSIGNING <ls_asset> WHERE is_cacheable = abap_true.
       cache_asset( iv_xdata   = <ls_asset>-content
                    iv_url     = <ls_asset>-url
                    iv_type    = <ls_asset>-type

--- a/src/ui/zcl_abapgit_gui_asset_manager.clas.abap
+++ b/src/ui/zcl_abapgit_gui_asset_manager.clas.abap
@@ -7,7 +7,7 @@ CLASS zcl_abapgit_gui_asset_manager DEFINITION PUBLIC FINAL CREATE PUBLIC .
     TYPES:
       BEGIN OF ty_asset_entry.
         INCLUDE TYPE zif_abapgit_gui_asset_manager~ty_web_asset.
-        TYPES:  mime_name TYPE wwwdatatab-objid,
+      TYPES:  mime_name TYPE wwwdatatab-objid,
       END OF ty_asset_entry ,
       tt_asset_register TYPE STANDARD TABLE OF ty_asset_entry WITH KEY url .
 
@@ -126,15 +126,15 @@ CLASS ZCL_ABAPGIT_GUI_ASSET_MANAGER IMPLEMENTATION.
 
     APPEND ls_asset TO mt_asset_register.
 
-  endmethod.
+  ENDMETHOD.
 
 
   METHOD zif_abapgit_gui_asset_manager~get_all_assets.
 
-    FIELD-SYMBOLS <a> LIKE LINE OF mt_asset_register.
+    FIELD-SYMBOLS <ls_a> LIKE LINE OF mt_asset_register.
 
-    LOOP AT mt_asset_register ASSIGNING <a>.
-      APPEND load_asset( <a> ) TO rt_assets.
+    LOOP AT mt_asset_register ASSIGNING <ls_a>.
+      APPEND load_asset( <ls_a> ) TO rt_assets.
     ENDLOOP.
 
   ENDMETHOD.
@@ -142,13 +142,13 @@ CLASS ZCL_ABAPGIT_GUI_ASSET_MANAGER IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_asset_manager~get_asset.
 
-    FIELD-SYMBOLS <a> LIKE LINE of mt_asset_register.
+    FIELD-SYMBOLS <ls_a> LIKE LINE of mt_asset_register.
 
-    READ TABLE mt_asset_register WITH KEY url = iv_url ASSIGNING <a>.
-    IF <a> IS NOT ASSIGNED.
+    READ TABLE mt_asset_register WITH KEY url = iv_url ASSIGNING <ls_a>.
+    IF <ls_a> IS NOT ASSIGNED.
       zcx_abapgit_exception=>raise( |Cannot find GUI asset: { iv_url }| ).
     ENDIF.
-    rs_asset = load_asset( <a> ).
+    rs_asset = load_asset( <ls_a> ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_asset_manager.clas.abap
+++ b/src/ui/zcl_abapgit_gui_asset_manager.clas.abap
@@ -4,16 +4,26 @@ CLASS zcl_abapgit_gui_asset_manager DEFINITION PUBLIC FINAL CREATE PUBLIC .
 
     INTERFACES zif_abapgit_gui_asset_manager.
 
+  TYPES:
+    BEGIN OF ty_asset_entry.
+      INCLUDE TYPE zif_abapgit_gui_asset_manager~ty_web_asset.
+      TYPES:  mime_name TYPE wwwdatatab-objid,
+    END OF ty_asset_entry,
+    tt_asset_register TYPE STANDARD TABLE OF ty_asset_entry WITH KEY url.
+
+  METHODS register_asset
+    IMPORTING
+      iv_url       TYPE string
+      iv_type      TYPE string
+      iv_cachable  TYPE abap_bool DEFAULT abap_true
+      iv_mime_name TYPE wwwdatatab-objid OPTIONAL
+      iv_base64    TYPE string OPTIONAL
+      iv_inline    TYPE string OPTIONAL.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
 
-    METHODS get_textlike_asset
-      IMPORTING
-        iv_asset_url    TYPE string
-      RETURNING
-        VALUE(rs_asset) TYPE zif_abapgit_gui_asset_manager=>ty_web_asset
-      RAISING
-        zcx_abapgit_exception.
+    DATA mt_asset_register TYPE tt_asset_register.
 
     METHODS get_mime_asset
       IMPORTING
@@ -23,110 +33,19 @@ CLASS zcl_abapgit_gui_asset_manager DEFINITION PUBLIC FINAL CREATE PUBLIC .
       RAISING
         zcx_abapgit_exception.
 
-    METHODS get_inline_images
-      RETURNING VALUE(rt_images) TYPE zif_abapgit_gui_asset_manager=>tt_web_assets.
+    METHODS load_asset
+      IMPORTING
+        is_asset_entry TYPE ty_asset_entry
+      RETURNING
+        VALUE(rs_asset) TYPE zif_abapgit_gui_asset_manager~ty_web_asset
+      RAISING
+        zcx_abapgit_exception.
 
 ENDCLASS.
 
 
 
 CLASS ZCL_ABAPGIT_GUI_ASSET_MANAGER IMPLEMENTATION.
-
-
-  METHOD get_inline_images.
-
-    DATA:
-      lv_base64 TYPE string,
-      ls_image  LIKE LINE OF rt_images.
-
-* see https://github.com/larshp/abapGit/issues/201 for source SVG
-    ls_image-url     = 'img/logo' ##NO_TEXT.
-    ls_image-type    = 'image'.
-    ls_image-subtype = 'pmg'.
-    lv_base64 =
-         'iVBORw0KGgoAAAANSUhEUgAAAKMAAAAoCAYAAACSG0qbAAAABHNCSVQICAgIfAhkiAAA'
-      && 'AAlwSFlzAAAEJQAABCUBprHeCQAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9y'
-      && 'Z5vuPBoAAA8VSURBVHic7Zx7cJzVeYef31nJAtvYko1JjM3FYHlXimwZkLWyLEMcwIGQ'
-      && 'cEkDJWmTltLStGkoDCkzwBAuCemUlksDNCkhJTTTljJpZhIuBQxxAWPvyuYiW7UkG8Il'
-      && 'UByIsS1sLEu75+0fu5JXu9/etAJz0TOzM/rOec85765+37m+3yczY8w0NU3qrwv9npfa'
-      && 'Hfx02pPPd469sgk+7misYnyjpWXy5IOG7kd8ZjjNjEtr13TdOm7eTfCxwo2lUJAQASRu'
-      && '2dnRfMn4uDbBx42yxZhPiMNMCHKCsVK2GGuqqqoQUwrZTAhygrFQshjfaGmZ/M7yxQtm'
-      && 'xGL9/qDqzwLxQvYTgpygXEoS4/DQ7LE1O05atLBu1YZdE4KcYLwpupoOmCO+5Z2dXPfE'
-      && 'xk07Tm2ZroGhBwX1wAygKqiOiVX2Rw9Jam/gyH0wuGGzvTEudRYSY4HFyogghxN2n7Sw'
-      && 'IendvcCioLoOtCCXNeqohOf0oDwPq9f3Wt/77dOHlWhYzUj/BRybTnrGEnZO5wv2m0rq'
-      && 'DezJoOiqeZbzegzpk6TVPPWJTT39y5svMogF1ZcesjlQgkwYp4F+EJQXwv4E+MiLUZJa'
-      && 'F7AIcRq4hWZ2mMRhQD/oZcErXv7FScaja3rt/wpU9E/sFyLACQq57wB/XIl/gWIstn2T'
-      && 'xpHVre7ZW71p8sFDeQscSEHKu3pTBadNH2Lq61VT57iwNazLgaNSqYaUaWXLDZCJIbBo'
-      && 'g3tK2A2xHns0oMrm3CRrqdTPnAVMiUIEmLlz2XGLMxNmH7YrifFcoUIHalHj8f8p6UfA'
-      && 'O+932weStno1zghps6Q7GBFiUYRxopkeaZ2vIwLyfxtQ4vV8lbWHNScacf+T/vwqn90o'
-      && 'MZYhRADJ+bv725vmj6Q8tHWffPKUD6IgO/tsfawneRHYd97Pdg8kSyJaZiGtBY4pYPYO'
-      && 'kH84C0Cyv8tKSiK7OZ99EpYAJ2V8AhkRY5lCHGaxhaq+BLCzY/EXd5y0aOG0td1vf1AF'
-      && 'CWCw7/1u80DQEtahQvcB03MyjQfM7Hwnmxfv9dPivX5SssqOwuzPSqk71mN3ymw5ZtdK'
-      && 'dmVIdly8xx7JZ29yy0qptwrGLMRRCA6T1w93nLTo5Lq13Zv625tOMRd6DLF4v0lWmQO8'
-      && 'qPko45y7TWaHZyUnwa6M99mN2fYbuu1V4K5oxF1B4Z4UgFifrQHWFLNbvkh1QheV5DNN'
-      && 'TZMqFWIGs5zX48M95PTqGa3TZ4erzbvj8/WUErf0L2++uNyGJLn2Js1oDeuYlkbNbmlR'
-      && 'deXup2hq0qS2es2VlHMDFaOlRdXL5uuwlnodG23QTEljCkbJV3d7WHOK+dXWqHqZnZeb'
-      && 'Y1fGe3OFOArRU5GTGbSHNWdwUL8Epo1qIQ9V/bXu3HES4jCznNfjb7e1zZ8Ri/UD1MLz'
-      && 'u05s/huMx4IKGNy4+8Tj/2Pqk8++Vaji86TQqxEuNNM5rWGtSCaokSDkgd0QjbidoPvN'
-      && '+5s7t9jz5TgdbdBMvLsG2cop6FgLUdUaZk804jYKuyrWa6vzlT2+XrOqQnxd6KwQOj5R'
-      && 'hULpL9Yaxkcj7g3QT6zK397ZbdtGtbtAZ+B0U3adkt0c67E7OyI6fFDuSpktC6HGpJjU'
-      && 'GmZ3NOI2mdnVnX32eHZZ7903hGXfBG8mp3J7sd/B0DPCTgUmBf9O7lmMybk56or3Jn8f'
-      && 'oLVB7Q5dZ9Iy4OBsw2jYbUUk96fwQrzHf955iBZzsDA+aL9k1owZ20fNzaY/tfFXwK48'
-      && 'ldQkSZ5YqJXmZk15JaJfmOmfgdOAmgCzWrCvyum5aIO+Uor3AIbOx7QV2TeBMPu3vKYA'
-      && 'Sw091hbWt4PKRhu0oDqkmND1wAnk3vkOmAN2lRLa2hrWMVm5Tek2R3286YzWiK4eQltk'
-      && '9g1gMfsFMhVYKunR1obQddk+SXZqwLe8acMGe7fYb9HZk7wm3utrBmpsqiXsyClHMHK6'
-      && '0hLWoRjHBfmLbP9K3bPYjFPIFWLaQeZnlZ8H4JyFflrMwcK4wG63v3/ycZnXOzqalxE0'
-      && 'mU7x9rvvVv93oVZqBtzNGGeU7Jbp9pZGzS7ReiVQVyDfmXRda4PaA9p5mBLmWGmmSron'
-      && 'M0FytUGGgjPTAi8UIeVk9u1og5YOJ0QbNBOjIac+Y22JPgLQ1WV7Ol+w36xebYnhtGpj'
-      && 'FjBYTj3l4KY9/dx6My4d74pN/Ki/Y9HpSG5HR/Nyh/1DHtO9OM6dvWFDwbtWslOykt6U'
-      && 's5VWZbOFnQtsyMqvc56Ty3T7NeBhLGAfDZDpe5nX6V5uXpbZ43K2NGQ2V9glwLas/I62'
-      && 'hfrE8EWsJ3mFsGYs+OQqze+A1cBLgbmma4f/9AmOJGBe5vKVLYN1W6wnOWSHmdkVhexM'
-      && 'PG6yC0x2AbmjoQ3njdh4uwrSw1Htmq5bd3Y0I3FLpQ5n0GTSQ7s6Fva70RPYTPbi+Pz0'
-      && 'J7ryboRC+m5PnRfsJjVEAfp5bLNflTb52dKIBj36RWY5ZyX2WCLukvbX67ZYHFLHZtGw'
-      && '+1fD/jDL8qQljWpav9m6Uw3wKYzXgUNJTxsk+0Fssw0L6x+j4dCx6eF/BEtwDBkbx7Fe'
-      && '29gWCa0yrC2rvXXO26WZfrWG3V2kji8zWbm0QUev67GX5ZgZ8A0H121hXIIZNrxou9oW'
-      && '6m4b4m/z2aTP+fsAohF3PaNHROvssZ8ElRs5DnyPBAkovxDFF4oJESDeY9tJD4Ur5umg'
-      && 'PSFm1Uy23Zk2SaM7e43p5Y4uxUMzu2f4H56+tuZmff2gfTqHrGEy5DkW6Abo7LH7gfsB'
-      && '2uo1LQGzBmoYFSwg57vNcjqqo4F1JXh2S7Zfx83TZZNqdD6MXkQkU369jONgcmfxe83M'
-      && 'B7XQEdEhg1B0HzDk2ZHpy3vBqLPpMQhyi/f2AIA3WyPZG6KkeVpKiE925awEi7H6JRsA'
-      && 'cqJDfIi9oayfW8ZB5dY/TFeX7YlGQg+RmgJkcnSQfWyr9QP92enmGcgeNCvx67mXbGdb'
-      && 'xD1hjI5AklJ+ydgTUGz6iiZNXd09+gYGGIRlQgXn6wDesZYSRFsJOYES5QjSw7fqnu7q'
-      && 'Bqh7uqu7f3nzdw3uKFJszEIcpqVRs12SRuAYiTrJ1YXMzSGgS6iQnHmWyQWe70pySz/F'
-      && 'MZagMWnMlaiTuTqTTih7s7IIHm1T1ncVI37l3BAAA4McAYF7iAvG17uxExi1U6Igd9XN'
-      && 'Dj+UmZA8qPrf3MDQbeSPIN8Ldub0JzeWLcT2I3Swn8JFhr4VQnMze5uKnv0ugOHfUXa3'
-      && 'ZhySedkR0eGDuMtbw/rTZCI1pA9PF0yWf4e3MnJ7YKXm0pOr6H03QRIIZeYnUj1njhid'
-      && '8aaRscKX/VGWSRLsCjnK2rcdC3njGUsQ5PSdv92yqJaMk5WBoRMpJsSnNgZufBdCkmsN'
-      && '60FgRbllK8PNzOlttT/qpz2sOUnpeWGHvq9ewcyc28/7XQCru213NOL+l6wgZ0kXAjnD'
-      && 'cazP7gXuTdu41rCyxbgr3mt/P16+F6LgUVXtmq5bC237yNsNu5YtPBZgx4kLFznZ1XlM'
-      && 'BzB/1liECBAN801yhfiq0HflbKXz1ojZ4qCylSBsbm6q/93wX0n0Q1Ir6UzWYXaZyZaF'
-      && 'qqxeZn813n4ZlhPWJWXMo00P5OTDF5c0qmm8fRlPip6bFhHk6Ti3ddfy5i3OXBemJQE2'
-      && 'A5g/c/qaTasC8krC0KdzE+3qWG/y6thmW7Vui/UkQ7w51vqDaGnRZFInPdlshNQ2C8oJ'
-      && 'h0oqaefF++zmzh5bu7bbXrBxjp88bp5qgZzNdyfWD/9t+B+TO4GW8/p+R0SHcGBxLWEF'
-      && 'jiQlHeIXEaRIPZAVRMVCTDcQCUh8LfOyaqjgCcr+YpY7NRFa2VY/egsqtNtdw8ie5gjJ'
-      && 'oUTqicjofOYA2f/YgcR03s5MMBF4wlIa7rMr5mnUyru6xl0LZAeFvDG3l83DF5199muk'
-      && 'oJO1FUMoviSi8Nh9Kg+Ru7qvUvCqPO+cMZsxbPsM4HXW9KcrEyKApTa7s9BVSyLaF3Ik'
-      && 'SbLSQros18RyInkkV2u5q+6zLaS+aCT0oJl/QVI78IWcsvDos1vtLYCE551QKNuCKW63'
-      && '+157g36cMOYI9yWhC3K+j4KDEHKxC9+t0altDaFHwL/kvVZIBJw761/uM5/MTJlU7S/Z'
-      && 'N6hTBNlhZA0OPReNuGdM6nL4jR4G5ZnRusAtKmVHwg1Slcxe11nODZJKh1fJ6kwM3dQa'
-      && 'VgOw3omjkGuL9/o/L/vFTzs7mi8pQZBpIT4f9PxE2bRFQncY9pdjKDoExDH7ebzPbgFo'
-      && 'bQjdng48KBfvzZau77ORN61FI66PsW2N7ARiZnZTZ589BtAWCV1v5J1zF+JNVdui2CbL'
-      && 'OcJsq1ejD2lVgCDL4e14r58J0N6k+cmEu0HYIssdrbxgnaGeeG9yJEg32hC6GbOix81y'
-      && 'trTsWLtiixpgQNLZ4yVEgCT++xSP0H7C0N1ZadVAh6SR3kRm2WfJO0H/XqTuQcn+IlOI'
-      && 'AFjRVaZhus3g2az0WuA0wcIi5QP3DDNIIPtakBABYltts7AO4OEi9eTFYGCksSRzwM4L'
-      && 'ECKAM1gG9tVR5UP+RkqZN5s7a0yBnwUEOSDp7GlPPp83BH0srO+1PmQrDIIen9wOdnln'
-      && 'n31G5n9ZtDLL6ck2x3uTf6DUee8rASX6vNnyWI/dmZ0R77O7LNXLBkWy9CE7Pd6XvNih'
-      && 'QkEQeZHZl9PBFtsDstebtyWFwv0B4r32UrzXn+6xDtBdwIslNL0N+JnMvravxiraFO/s'
-      && 'tm0y+xzQlcfkddCNCe/vGfP7GQH6lzdfbHAjqSCBHZK+PN5CzESSlixgnhMLzXAeXp+3'
-      && 'hWfuM0sWL10abQv1CdtHixzvmtiYPhcvSFOTJk1NEPEQkWdPUry4oc96y2o3YJiWs5Wx'
-      && 'zbYq83THHHu9Y1N2kG45tDRqdsgzxxuznKPOGbsTsN2M7d6zfXhePJ5Ici1h6mUcAcw0'
-      && '8Zo5fp35NoqKxAjwTrRhZmLSpPY9ySmPzV27dm+lTn9cKSTGA+XT+03Jq+l8HBLv2Q7c'
-      && 'X9K+ygQTFGDcHhaaoGJyouDNV7JH+eGj4mF6gspoC+tzJt1ObsT4MDsF2zxs886+Ml5v'
-      && '/PogUvEwPUGFiE+SX4gAtQa1gkhV7onQR4oJMR5oxC6stDeghd7Dh6E+CPw/HL4vVO2f'
-      && 'cpUAAAAASUVORK5CYII='.
-    ls_image-content = zcl_abapgit_string_utils=>base64_to_xstring( lv_base64 ).
-    APPEND ls_image TO rt_images.
-
-  ENDMETHOD.
 
 
   METHOD get_mime_asset.
@@ -177,83 +96,71 @@ CLASS ZCL_ABAPGIT_GUI_ASSET_MANAGER IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD get_textlike_asset.
+  METHOD load_asset.
 
-* used by abapmerge
-    DEFINE _inline.
-      APPEND &1 TO lt_data.
-    END-OF-DEFINITION.
-
-    DATA:
-          lt_data      TYPE string_table,
-          lv_mime_name TYPE wwwdatatab-objid,
-          lv_str       TYPE string.
-
-    CASE iv_asset_url.
-      WHEN 'css/common.css'.
-        rs_asset-url     = iv_asset_url.
-        rs_asset-type    = 'text'.
-        rs_asset-subtype = 'css'.
-        lv_mime_name     = 'ZABAPGIT_CSS_COMMON'.
-        " @@abapmerge include zabapgit_css_common.w3mi.data.css > _inline '$$'.
-      WHEN 'js/common.js'.
-        rs_asset-url     = iv_asset_url.
-        rs_asset-type    = 'text'.
-        rs_asset-subtype = 'javascript'.
-        lv_mime_name     = 'ZABAPGIT_JS_COMMON'.
-        " @@abapmerge include zabapgit_js_common.w3mi.data.js > _inline '$$'.
-      WHEN 'css/ag-icons.css'.
-        rs_asset-url     = iv_asset_url.
-        rs_asset-type    = 'text'.
-        rs_asset-subtype = 'css'.
-        lv_mime_name     = 'ZABAPGIT_ICON_FONT_CSS'.
-        " @@abapmerge include zabapgit_icon_font_css.w3mi.data.css > _inline '$$'.
-      WHEN 'font/ag-icons.woff'.
-        rs_asset-url     = iv_asset_url.
-        rs_asset-type    = 'font'.
-        rs_asset-subtype = 'woff'.
-        lv_mime_name     = 'ZABAPGIT_ICON_FONT'.
-        " @@abapmerge include-base64 zabapgit_icon_font.w3mi.data.woff > _inline '$$'.
-      WHEN OTHERS.
-        zcx_abapgit_exception=>raise( |No inline resource: { iv_asset_url }| ).
-    ENDCASE.
-
-    IF lt_data IS NOT INITIAL.
-      IF rs_asset-type = 'text'. " TODO refactor
-        CONCATENATE LINES OF lt_data INTO lv_str SEPARATED BY zif_abapgit_definitions=>c_newline.
-        rs_asset-content = zcl_abapgit_string_utils=>string_to_xstring( lv_str ).
-      ELSE.
-        CONCATENATE LINES OF lt_data INTO lv_str.
-        rs_asset-content = zcl_abapgit_string_utils=>base64_to_xstring( lv_str ).
-      ENDIF.
-    ELSE.
-      rs_asset-content = get_mime_asset( lv_mime_name ).
+    MOVE-CORRESPONDING is_asset_entry TO rs_asset.
+    IF rs_asset-content IS INITIAL AND is_asset_entry-mime_name IS NOT INITIAL.
+      " inline content has the priority
+      rs_asset-content = get_mime_asset( is_asset_entry-mime_name ).
     ENDIF.
-
     IF rs_asset-content IS INITIAL.
-      zcx_abapgit_exception=>raise( |Failed to get GUI resource: { iv_asset_url }| ).
+      zcx_abapgit_exception=>raise( |failed to load GUI asset: { is_asset_entry-url }| ).
     ENDIF.
 
   ENDMETHOD.
 
 
+  METHOD register_asset.
+
+    DATA ls_asset LIKE LINE OF mt_asset_register.
+
+    SPLIT iv_type AT '/' INTO ls_asset-type ls_asset-subtype.
+    ls_asset-url          = iv_url.
+    ls_asset-mime_name    = iv_mime_name.
+    ls_asset-is_cacheable = iv_cachable.
+    IF iv_base64 IS NOT INITIAL.
+      ls_asset-content = zcl_abapgit_string_utils=>base64_to_xstring( iv_base64 ).
+    ELSEIF iv_inline IS NOT INITIAL.
+      ls_asset-content = zcl_abapgit_string_utils=>string_to_xstring( iv_inline ).
+    ENDIF.
+
+    APPEND ls_asset TO mt_asset_register.
+
+  endmethod.
+
+
   METHOD zif_abapgit_gui_asset_manager~get_all_assets.
 
-    DATA:
-          lt_assets TYPE zif_abapgit_gui_asset_manager=>tt_web_assets,
-          ls_asset  LIKE LINE OF lt_assets.
+    FIELD-SYMBOLS <a> LIKE LINE OF mt_asset_register.
 
-    ls_asset = get_textlike_asset( 'css/common.css' ).
-    APPEND ls_asset TO rt_assets.
-    ls_asset = get_textlike_asset( 'js/common.js' ).
-    APPEND ls_asset TO rt_assets.
-    ls_asset = get_textlike_asset( 'css/ag-icons.css' ).
-    APPEND ls_asset TO rt_assets.
-    ls_asset = get_textlike_asset( 'font/ag-icons.woff' ).
-    APPEND ls_asset TO rt_assets.
+    LOOP AT mt_asset_register ASSIGNING <a>.
+      APPEND load_asset( <a> ) TO rt_assets.
+    ENDLOOP.
 
-    lt_assets = get_inline_images( ).
-    APPEND LINES OF lt_assets TO rt_assets.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_asset_manager~get_asset.
+
+    FIELD-SYMBOLS <a> LIKE LINE of mt_asset_register.
+
+    READ TABLE mt_asset_register WITH KEY url = iv_url ASSIGNING <a>.
+    IF <a> IS NOT ASSIGNED.
+      zcx_abapgit_exception=>raise( |Cannot find GUI asset: { iv_url }| ).
+    ENDIF.
+    rs_asset = load_asset( <a> ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_asset_manager~get_text_asset.
+
+    DATA ls_asset TYPE zif_abapgit_gui_asset_manager~ty_web_asset.
+    ls_asset = me->zif_abapgit_gui_asset_manager~get_asset( iv_url ).
+
+    rv_asset = cl_bcs_convert=>xstring_to_string(
+      iv_xstr = ls_asset-content
+      iv_cp   = '4110' ). " UTF8
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_asset_manager.clas.abap
+++ b/src/ui/zcl_abapgit_gui_asset_manager.clas.abap
@@ -4,21 +4,21 @@ CLASS zcl_abapgit_gui_asset_manager DEFINITION PUBLIC FINAL CREATE PUBLIC .
 
     INTERFACES zif_abapgit_gui_asset_manager.
 
-  TYPES:
-    BEGIN OF ty_asset_entry.
-      INCLUDE TYPE zif_abapgit_gui_asset_manager~ty_web_asset.
-      TYPES:  mime_name TYPE wwwdatatab-objid,
-    END OF ty_asset_entry,
-    tt_asset_register TYPE STANDARD TABLE OF ty_asset_entry WITH KEY url.
+    TYPES:
+      BEGIN OF ty_asset_entry.
+        INCLUDE TYPE zif_abapgit_gui_asset_manager~ty_web_asset.
+        TYPES:  mime_name TYPE wwwdatatab-objid,
+      END OF ty_asset_entry ,
+      tt_asset_register TYPE STANDARD TABLE OF ty_asset_entry WITH KEY url .
 
-  METHODS register_asset
-    IMPORTING
-      iv_url       TYPE string
-      iv_type      TYPE string
-      iv_cachable  TYPE abap_bool DEFAULT abap_true
-      iv_mime_name TYPE wwwdatatab-objid OPTIONAL
-      iv_base64    TYPE string OPTIONAL
-      iv_inline    TYPE string OPTIONAL.
+    METHODS register_asset
+      IMPORTING
+        !iv_url TYPE string
+        !iv_type TYPE string
+        !iv_cachable TYPE abap_bool DEFAULT abap_true
+        !iv_mime_name TYPE wwwdatatab-objid OPTIONAL
+        !iv_base64 TYPE string OPTIONAL
+        !iv_inline TYPE string OPTIONAL .
 
   PROTECTED SECTION.
   PRIVATE SECTION.

--- a/src/ui/zcl_abapgit_gui_asset_manager.clas.abap
+++ b/src/ui/zcl_abapgit_gui_asset_manager.clas.abap
@@ -7,7 +7,7 @@ CLASS zcl_abapgit_gui_asset_manager DEFINITION PUBLIC FINAL CREATE PUBLIC .
     TYPES:
       BEGIN OF ty_asset_entry.
         INCLUDE TYPE zif_abapgit_gui_asset_manager~ty_web_asset.
-      TYPES:  mime_name TYPE wwwdatatab-objid,
+    TYPES:  mime_name TYPE wwwdatatab-objid,
       END OF ty_asset_entry ,
       tt_asset_register TYPE STANDARD TABLE OF ty_asset_entry WITH KEY url .
 

--- a/src/ui/zcl_abapgit_gui_asset_manager.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_gui_asset_manager.clas.testclasses.abap
@@ -1,0 +1,110 @@
+CLASS ltcl_abapgit_gui_asset_manager DEFINITION
+  FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+
+    METHODS get_inline_asset FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS get_text_asset FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS get_mime_asset FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS get_base64_asset FOR TESTING RAISING zcx_abapgit_exception.
+    METHODS get_all FOR TESTING RAISING zcx_abapgit_exception.
+ENDCLASS.
+
+CLASS ltcl_abapgit_gui_asset_manager IMPLEMENTATION.
+
+  METHOD get_inline_asset.
+
+    DATA lo_assetman TYPE REF TO zcl_abapgit_gui_asset_manager.
+    DATA ls_asset TYPE zif_abapgit_gui_asset_manager=>ty_web_asset.
+
+    CREATE OBJECT lo_assetman.
+
+    lo_assetman->register_asset(
+      iv_url       = 'css/common.css'
+      iv_type      = 'text/css'
+      iv_inline    = 'ABC' ).
+
+    ls_asset = lo_assetman->zif_abapgit_gui_asset_manager~get_asset( 'css/common.css' ).
+
+    cl_abap_unit_assert=>assert_equals( act = ls_asset-type    exp = 'text' ).
+    cl_abap_unit_assert=>assert_equals( act = ls_asset-subtype exp = 'css' ).
+    cl_abap_unit_assert=>assert_equals(
+      act = cl_bcs_convert=>xstring_to_string(
+        iv_xstr = ls_asset-content
+        iv_cp   = '4110' )
+      exp = 'ABC' ).
+
+  ENDMETHOD.
+
+  METHOD get_text_asset.
+
+    DATA lo_assetman TYPE REF TO zcl_abapgit_gui_asset_manager.
+    CREATE OBJECT lo_assetman.
+
+    lo_assetman->register_asset(
+      iv_url       = 'css/common.css'
+      iv_type      = 'text/css'
+      iv_inline    = 'ABC' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_assetman->zif_abapgit_gui_asset_manager~get_text_asset( 'css/common.css' )
+      exp = 'ABC' ).
+
+  ENDMETHOD.
+
+  METHOD get_mime_asset.
+
+    DATA lo_assetman TYPE REF TO zcl_abapgit_gui_asset_manager.
+    CREATE OBJECT lo_assetman.
+
+    lo_assetman->register_asset(
+      iv_url       = 'css/common.css'
+      iv_type      = 'text/css'
+      iv_mime_name = 'ZABAPGIT_CSS_COMMON' ).
+
+    cl_abap_unit_assert=>assert_char_cp(
+      act = lo_assetman->zif_abapgit_gui_asset_manager~get_text_asset( 'css/common.css' )
+      exp = '*ABAPGIT COMMON CSS*' ).
+
+  ENDMETHOD.
+
+  METHOD get_base64_asset.
+
+    DATA lo_assetman TYPE REF TO zcl_abapgit_gui_asset_manager.
+    CREATE OBJECT lo_assetman.
+
+    lo_assetman->register_asset(
+      iv_url    = 'css/common.css'
+      iv_type   = 'text/css'
+      iv_base64 = 'QEE=' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_assetman->zif_abapgit_gui_asset_manager~get_text_asset( 'css/common.css' )
+      exp = '@A' ).
+
+  ENDMETHOD.
+
+  METHOD get_all.
+
+    DATA lo_assetman TYPE REF TO zcl_abapgit_gui_asset_manager.
+    CREATE OBJECT lo_assetman.
+
+    lo_assetman->register_asset(
+      iv_url    = 'css/common.css'
+      iv_type   = 'text/css'
+      iv_base64 = 'QEE=' ).
+
+    lo_assetman->register_asset(
+      iv_url    = 'css/common.css'
+      iv_type   = 'text/css'
+      iv_inline = 'ABC' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lines( lo_assetman->zif_abapgit_gui_asset_manager~get_all_assets( ) )
+      exp = 2 ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_asset_manager.clas.xml
+++ b/src/ui/zcl_abapgit_gui_asset_manager.clas.xml
@@ -11,6 +11,7 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>

--- a/src/ui/zcl_abapgit_ui_factory.clas.abap
+++ b/src/ui/zcl_abapgit_ui_factory.clas.abap
@@ -30,6 +30,13 @@ CLASS zcl_abapgit_ui_factory DEFINITION
     CLASS-DATA gi_gui_functions TYPE REF TO zif_abapgit_gui_functions .
     CLASS-DATA go_gui TYPE REF TO zcl_abapgit_gui .
     CLASS-DATA gi_fe_services TYPE REF TO zif_abapgit_frontend_services .
+
+    CLASS-METHODS init_asset_manager
+      RETURNING
+        VALUE(ro_asset_man) TYPE REF TO zcl_abapgit_gui_asset_manager
+      RAISING
+        zcx_abapgit_exception.
+
 ENDCLASS.
 
 
@@ -55,8 +62,8 @@ CLASS ZCL_ABAPGIT_UI_FACTORY IMPLEMENTATION.
       li_asset_man TYPE REF TO zif_abapgit_gui_asset_manager.
 
     IF go_gui IS INITIAL.
+      li_asset_man ?= init_asset_manager( ).
       CREATE OBJECT li_router TYPE zcl_abapgit_gui_router.
-      CREATE OBJECT li_asset_man TYPE zcl_abapgit_gui_asset_manager.
       CREATE OBJECT go_gui
         EXPORTING
           ii_router    = li_router
@@ -96,6 +103,136 @@ CLASS ZCL_ABAPGIT_UI_FACTORY IMPLEMENTATION.
     ENDIF.
 
     ri_tag_popups = gi_tag_popups.
+
+  ENDMETHOD.
+
+
+  METHOD init_asset_manager.
+    " used by abapmerge
+    DEFINE _inline.
+      APPEND &1 TO lt_inline.
+    END-OF-DEFINITION.
+
+    DATA lt_inline TYPE string_table.
+
+    CREATE OBJECT ro_asset_man.
+
+    CLEAR lt_inline.
+    " @@abapmerge include zabapgit_css_common.w3mi.data.css > _inline '$$'.
+    ro_asset_man->register_asset(
+      iv_url       = 'css/common.css'
+      iv_type      = 'text/css'
+      iv_mime_name = 'ZABAPGIT_CSS_COMMON'
+      iv_inline    = concat_lines_of( table = lt_inline sep = cl_abap_char_utilities=>newline ) ).
+
+    CLEAR lt_inline.
+    " @@abapmerge include zabapgit_js_common.w3mi.data.js > _inline '$$'.
+    ro_asset_man->register_asset(
+      iv_url       = 'js/common.js'
+      iv_type      = 'text/javascript'
+      iv_mime_name = 'ZABAPGIT_JS_COMMON'
+      iv_inline    = concat_lines_of( table = lt_inline sep = cl_abap_char_utilities=>newline ) ).
+
+    CLEAR lt_inline.
+    " @@abapmerge include zabapgit_icon_font_css.w3mi.data.css > _inline '$$'.
+    ro_asset_man->register_asset(
+      iv_url       = 'css/ag-icons.css'
+      iv_type      = 'text/css'
+      iv_mime_name = 'ZABAPGIT_ICON_FONT_CSS'
+      iv_inline    = concat_lines_of( table = lt_inline sep = cl_abap_char_utilities=>newline ) ).
+
+    CLEAR lt_inline.
+    " @@abapmerge include-base64 zabapgit_icon_font.w3mi.data.woff > _inline '$$'.
+    ro_asset_man->register_asset(
+      iv_url       = 'font/ag-icons.woff'
+      iv_type      = 'font/woff'
+      iv_mime_name = 'ZABAPGIT_ICON_FONT'
+      iv_base64    = concat_lines_of( table = lt_inline ) ).
+
+    " see https://github.com/larshp/abapGit/issues/201 for source SVG
+    ro_asset_man->register_asset(
+      iv_url       = 'img/logo'
+      iv_type      = 'image/png'
+      iv_base64    =
+           'iVBORw0KGgoAAAANSUhEUgAAAKMAAAAoCAYAAACSG0qbAAAABHNCSVQICAgIfAhkiAAA'
+        && 'AAlwSFlzAAAEJQAABCUBprHeCQAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9y'
+        && 'Z5vuPBoAAA8VSURBVHic7Zx7cJzVeYef31nJAtvYko1JjM3FYHlXimwZkLWyLEMcwIGQ'
+        && 'cEkDJWmTltLStGkoDCkzwBAuCemUlksDNCkhJTTTljJpZhIuBQxxAWPvyuYiW7UkG8Il'
+        && 'UByIsS1sLEu75+0fu5JXu9/etAJz0TOzM/rOec85765+37m+3yczY8w0NU3qrwv9npfa'
+        && 'Hfx02pPPd469sgk+7misYnyjpWXy5IOG7kd8ZjjNjEtr13TdOm7eTfCxwo2lUJAQASRu'
+        && '2dnRfMn4uDbBx42yxZhPiMNMCHKCsVK2GGuqqqoQUwrZTAhygrFQshjfaGmZ/M7yxQtm'
+        && 'xGL9/qDqzwLxQvYTgpygXEoS4/DQ7LE1O05atLBu1YZdE4KcYLwpupoOmCO+5Z2dXPfE'
+        && 'xk07Tm2ZroGhBwX1wAygKqiOiVX2Rw9Jam/gyH0wuGGzvTEudRYSY4HFyogghxN2n7Sw'
+        && 'IendvcCioLoOtCCXNeqohOf0oDwPq9f3Wt/77dOHlWhYzUj/BRybTnrGEnZO5wv2m0rq'
+        && 'DezJoOiqeZbzegzpk6TVPPWJTT39y5svMogF1ZcesjlQgkwYp4F+EJQXwv4E+MiLUZJa'
+        && 'F7AIcRq4hWZ2mMRhQD/oZcErXv7FScaja3rt/wpU9E/sFyLACQq57wB/XIl/gWIstn2T'
+        && 'xpHVre7ZW71p8sFDeQscSEHKu3pTBadNH2Lq61VT57iwNazLgaNSqYaUaWXLDZCJIbBo'
+        && 'g3tK2A2xHns0oMrm3CRrqdTPnAVMiUIEmLlz2XGLMxNmH7YrifFcoUIHalHj8f8p6UfA'
+        && 'O+932weStno1zghps6Q7GBFiUYRxopkeaZ2vIwLyfxtQ4vV8lbWHNScacf+T/vwqn90o'
+        && 'MZYhRADJ+bv725vmj6Q8tHWffPKUD6IgO/tsfawneRHYd97Pdg8kSyJaZiGtBY4pYPYO'
+        && 'kH84C0Cyv8tKSiK7OZ99EpYAJ2V8AhkRY5lCHGaxhaq+BLCzY/EXd5y0aOG0td1vf1AF'
+        && 'CWCw7/1u80DQEtahQvcB03MyjQfM7Hwnmxfv9dPivX5SssqOwuzPSqk71mN3ymw5ZtdK'
+        && 'dmVIdly8xx7JZ29yy0qptwrGLMRRCA6T1w93nLTo5Lq13Zv625tOMRd6DLF4v0lWmQO8'
+        && 'qPko45y7TWaHZyUnwa6M99mN2fYbuu1V4K5oxF1B4Z4UgFifrQHWFLNbvkh1QheV5DNN'
+        && 'TZMqFWIGs5zX48M95PTqGa3TZ4erzbvj8/WUErf0L2++uNyGJLn2Js1oDeuYlkbNbmlR'
+        && 'deXup2hq0qS2es2VlHMDFaOlRdXL5uuwlnodG23QTEljCkbJV3d7WHOK+dXWqHqZnZeb'
+        && 'Y1fGe3OFOArRU5GTGbSHNWdwUL8Epo1qIQ9V/bXu3HES4jCznNfjb7e1zZ8Ri/UD1MLz'
+        && 'u05s/huMx4IKGNy4+8Tj/2Pqk8++Vaji86TQqxEuNNM5rWGtSCaokSDkgd0QjbidoPvN'
+        && '+5s7t9jz5TgdbdBMvLsG2cop6FgLUdUaZk804jYKuyrWa6vzlT2+XrOqQnxd6KwQOj5R'
+        && 'hULpL9Yaxkcj7g3QT6zK397ZbdtGtbtAZ+B0U3adkt0c67E7OyI6fFDuSpktC6HGpJjU'
+        && 'GmZ3NOI2mdnVnX32eHZZ7903hGXfBG8mp3J7sd/B0DPCTgUmBf9O7lmMybk56or3Jn8f'
+        && 'oLVB7Q5dZ9Iy4OBsw2jYbUUk96fwQrzHf955iBZzsDA+aL9k1owZ20fNzaY/tfFXwK48'
+        && 'ldQkSZ5YqJXmZk15JaJfmOmfgdOAmgCzWrCvyum5aIO+Uor3AIbOx7QV2TeBMPu3vKYA'
+        && 'Sw091hbWt4PKRhu0oDqkmND1wAnk3vkOmAN2lRLa2hrWMVm5Tek2R3286YzWiK4eQltk'
+        && '9g1gMfsFMhVYKunR1obQddk+SXZqwLe8acMGe7fYb9HZk7wm3utrBmpsqiXsyClHMHK6'
+        && '0hLWoRjHBfmLbP9K3bPYjFPIFWLaQeZnlZ8H4JyFflrMwcK4wG63v3/ycZnXOzqalxE0'
+        && 'mU7x9rvvVv93oVZqBtzNGGeU7Jbp9pZGzS7ReiVQVyDfmXRda4PaA9p5mBLmWGmmSron'
+        && 'M0FytUGGgjPTAi8UIeVk9u1og5YOJ0QbNBOjIac+Y22JPgLQ1WV7Ol+w36xebYnhtGpj'
+        && 'FjBYTj3l4KY9/dx6My4d74pN/Ki/Y9HpSG5HR/Nyh/1DHtO9OM6dvWFDwbtWslOykt6U'
+        && 's5VWZbOFnQtsyMqvc56Ty3T7NeBhLGAfDZDpe5nX6V5uXpbZ43K2NGQ2V9glwLas/I62'
+        && 'hfrE8EWsJ3mFsGYs+OQqze+A1cBLgbmma4f/9AmOJGBe5vKVLYN1W6wnOWSHmdkVhexM'
+        && 'PG6yC0x2AbmjoQ3njdh4uwrSw1Htmq5bd3Y0I3FLpQ5n0GTSQ7s6Fva70RPYTPbi+Pz0'
+        && 'J7ryboRC+m5PnRfsJjVEAfp5bLNflTb52dKIBj36RWY5ZyX2WCLukvbX67ZYHFLHZtGw'
+        && '+1fD/jDL8qQljWpav9m6Uw3wKYzXgUNJTxsk+0Fssw0L6x+j4dCx6eF/BEtwDBkbx7Fe'
+        && '29gWCa0yrC2rvXXO26WZfrWG3V2kji8zWbm0QUev67GX5ZgZ8A0H121hXIIZNrxou9oW'
+        && '6m4b4m/z2aTP+fsAohF3PaNHROvssZ8ElRs5DnyPBAkovxDFF4oJESDeY9tJD4Ur5umg'
+        && 'PSFm1Uy23Zk2SaM7e43p5Y4uxUMzu2f4H56+tuZmff2gfTqHrGEy5DkW6Abo7LH7gfsB'
+        && '2uo1LQGzBmoYFSwg57vNcjqqo4F1JXh2S7Zfx83TZZNqdD6MXkQkU369jONgcmfxe83M'
+        && 'B7XQEdEhg1B0HzDk2ZHpy3vBqLPpMQhyi/f2AIA3WyPZG6KkeVpKiE925awEi7H6JRsA'
+        && 'cqJDfIi9oayfW8ZB5dY/TFeX7YlGQg+RmgJkcnSQfWyr9QP92enmGcgeNCvx67mXbGdb'
+        && 'xD1hjI5AklJ+ydgTUGz6iiZNXd09+gYGGIRlQgXn6wDesZYSRFsJOYES5QjSw7fqnu7q'
+        && 'Bqh7uqu7f3nzdw3uKFJszEIcpqVRs12SRuAYiTrJ1YXMzSGgS6iQnHmWyQWe70pySz/F'
+        && 'MZagMWnMlaiTuTqTTih7s7IIHm1T1ncVI37l3BAAA4McAYF7iAvG17uxExi1U6Igd9XN'
+        && 'Dj+UmZA8qPrf3MDQbeSPIN8Ldub0JzeWLcT2I3Swn8JFhr4VQnMze5uKnv0ugOHfUXa3'
+        && 'ZhySedkR0eGDuMtbw/rTZCI1pA9PF0yWf4e3MnJ7YKXm0pOr6H03QRIIZeYnUj1njhid'
+        && '8aaRscKX/VGWSRLsCjnK2rcdC3njGUsQ5PSdv92yqJaMk5WBoRMpJsSnNgZufBdCkmsN'
+        && '60FgRbllK8PNzOlttT/qpz2sOUnpeWGHvq9ewcyc28/7XQCru213NOL+l6wgZ0kXAjnD'
+        && 'cazP7gXuTdu41rCyxbgr3mt/P16+F6LgUVXtmq5bC237yNsNu5YtPBZgx4kLFznZ1XlM'
+        && 'BzB/1liECBAN801yhfiq0HflbKXz1ojZ4qCylSBsbm6q/93wX0n0Q1Ir6UzWYXaZyZaF'
+        && 'qqxeZn813n4ZlhPWJWXMo00P5OTDF5c0qmm8fRlPip6bFhHk6Ti3ddfy5i3OXBemJQE2'
+        && 'A5g/c/qaTasC8krC0KdzE+3qWG/y6thmW7Vui/UkQ7w51vqDaGnRZFInPdlshNQ2C8oJ'
+        && 'h0oqaefF++zmzh5bu7bbXrBxjp88bp5qgZzNdyfWD/9t+B+TO4GW8/p+R0SHcGBxLWEF'
+        && 'jiQlHeIXEaRIPZAVRMVCTDcQCUh8LfOyaqjgCcr+YpY7NRFa2VY/egsqtNtdw8ie5gjJ'
+        && 'oUTqicjofOYA2f/YgcR03s5MMBF4wlIa7rMr5mnUyru6xl0LZAeFvDG3l83DF5199muk'
+        && 'oJO1FUMoviSi8Nh9Kg+Ru7qvUvCqPO+cMZsxbPsM4HXW9KcrEyKApTa7s9BVSyLaF3Ik'
+        && 'SbLSQros18RyInkkV2u5q+6zLaS+aCT0oJl/QVI78IWcsvDos1vtLYCE551QKNuCKW63'
+        && '+157g36cMOYI9yWhC3K+j4KDEHKxC9+t0altDaFHwL/kvVZIBJw761/uM5/MTJlU7S/Z'
+        && 'N6hTBNlhZA0OPReNuGdM6nL4jR4G5ZnRusAtKmVHwg1Slcxe11nODZJKh1fJ6kwM3dQa'
+        && 'VgOw3omjkGuL9/o/L/vFTzs7mi8pQZBpIT4f9PxE2bRFQncY9pdjKDoExDH7ebzPbgFo'
+        && 'bQjdng48KBfvzZau77ORN61FI66PsW2N7ARiZnZTZ589BtAWCV1v5J1zF+JNVdui2CbL'
+        && 'OcJsq1ejD2lVgCDL4e14r58J0N6k+cmEu0HYIssdrbxgnaGeeG9yJEg32hC6GbOix81y'
+        && 'trTsWLtiixpgQNLZ4yVEgCT++xSP0H7C0N1ZadVAh6SR3kRm2WfJO0H/XqTuQcn+IlOI'
+        && 'AFjRVaZhus3g2az0WuA0wcIi5QP3DDNIIPtakBABYltts7AO4OEi9eTFYGCksSRzwM4L'
+        && 'ECKAM1gG9tVR5UP+RkqZN5s7a0yBnwUEOSDp7GlPPp83BH0srO+1PmQrDIIen9wOdnln'
+        && 'n31G5n9ZtDLL6ck2x3uTf6DUee8rASX6vNnyWI/dmZ0R77O7LNXLBkWy9CE7Pd6XvNih'
+        && 'QkEQeZHZl9PBFtsDstebtyWFwv0B4r32UrzXn+6xDtBdwIslNL0N+JnMvravxiraFO/s'
+        && 'tm0y+xzQlcfkddCNCe/vGfP7GQH6lzdfbHAjqSCBHZK+PN5CzESSlixgnhMLzXAeXp+3'
+        && 'hWfuM0sWL10abQv1CdtHixzvmtiYPhcvSFOTJk1NEPEQkWdPUry4oc96y2o3YJiWs5Wx'
+        && 'zbYq83THHHu9Y1N2kG45tDRqdsgzxxuznKPOGbsTsN2M7d6zfXhePJ5Ici1h6mUcAcw0'
+        && '8Zo5fp35NoqKxAjwTrRhZmLSpPY9ySmPzV27dm+lTn9cKSTGA+XT+03Jq+l8HBLv2Q7c'
+        && 'X9K+ygQTFGDcHhaaoGJyouDNV7JH+eGj4mF6gspoC+tzJt1ObsT4MDsF2zxs886+Ml5v'
+        && '/PogUvEwPUGFiE+SX4gAtQa1gkhV7onQR4oJMR5oxC6stDeghd7Dh6E+CPw/HL4vVO2f'
+        && 'cpUAAAAASUVORK5CYII=' ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/zif_abapgit_gui_asset_manager.intf.abap
+++ b/src/ui/zif_abapgit_gui_asset_manager.intf.abap
@@ -3,10 +3,11 @@ INTERFACE zif_abapgit_gui_asset_manager
 
   TYPES:
     BEGIN OF ty_web_asset,
-      url     TYPE w3url,
-      type    TYPE char50,
-      subtype TYPE char50,
-      content TYPE xstring,
+      url          TYPE w3url,
+      type         TYPE char50,
+      subtype      TYPE char50,
+      content      TYPE xstring,
+      is_cacheable TYPE abap_bool,
     END OF ty_web_asset .
   TYPES:
     tt_web_assets TYPE STANDARD TABLE OF ty_web_asset WITH DEFAULT KEY .
@@ -14,6 +15,22 @@ INTERFACE zif_abapgit_gui_asset_manager
   METHODS get_all_assets
     RETURNING
       VALUE(rt_assets) TYPE tt_web_assets
+    RAISING
+      zcx_abapgit_exception.
+
+  METHODS get_asset
+    IMPORTING
+      iv_url          TYPE string
+    RETURNING
+      VALUE(rs_asset) TYPE ty_web_asset
+    RAISING
+      zcx_abapgit_exception.
+
+  METHODS get_text_asset
+    IMPORTING
+      iv_url          TYPE string
+    RETURNING
+      VALUE(rv_asset) TYPE string
     RAISING
       zcx_abapgit_exception.
 


### PR DESCRIPTION
to #2525, part 2

Mainly: make asset manager code more abstract.
Assets are now defined in `zcl_abapgit_ui_factory`, asset manager is responsible for MIME extraction and caching.