### PR TITLE
ux: help users to get that package is versioned

### DIFF
--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -388,7 +388,12 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
   METHOD zif_abapgit_repo_srv~validate_package.
 
     DATA: lv_as4user TYPE tdevc-as4user,
-          lt_repos   TYPE zif_abapgit_persistence=>tt_repo.
+          lt_repos   TYPE zif_abapgit_persistence=>tt_repo,
+          lv_name    TYPE zif_abapgit_persistence=>ty_local_settings-display_name,
+          lv_owner   TYPE zif_abapgit_persistence=>ty_local_settings-display_name.
+
+    FIELD-SYMBOLS:
+          <ls_repo>  LIKE LINE OF lt_repos.
 
     IF iv_package IS INITIAL.
       zcx_abapgit_exception=>raise( 'add, package empty' ).
@@ -411,9 +416,11 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
 
     " make sure its not already in use for a different repository
     lt_repos = zcl_abapgit_persist_factory=>get_repo( )->list( ).
-    READ TABLE lt_repos WITH KEY package = iv_package TRANSPORTING NO FIELDS.
+    READ TABLE lt_repos WITH KEY package = iv_package ASSIGNING <ls_repo>.
     IF sy-subrc = 0.
-      zcx_abapgit_exception=>raise( |Package { iv_package } already in use| ).
+      lv_name = zcl_abapgit_repo_srv=>get_instance( )->get( <ls_repo>-key )->get_name( ).
+      lv_owner = <ls_repo>-created_by.
+      zcx_abapgit_exception=>raise( |Package { iv_package } already versioned as { lv_name } by { lv_owner }| ).
     ENDIF.
 
     validate_sub_super_packages(


### PR DESCRIPTION
I was approached by a colleague of mine who was not sure how to deal
with the message:

- 'Package $FOO_BAR already in use'

I thought it was caused by the fact that some super or sub-package was
already watched by abapgit but whenI found the message in source codes I
figured out that there is already a repo for that package.

This patch should make the message easier to understand, so the new
version is:

- 'Package $FOO_BAR already versioned as FOO by DEVELOPER'