### PR TITLE
ci: make travis die on abapmerge errors

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-abapmerge -f src/zabapgit.prog.abap > ../zabapgit.abap
+abapmerge -f src/zabapgit.prog.abap > ../zabapgit.abap || exit 1
 wc -l ../zabapgit.abap
 cd ..
 git clone https://github.com/abapGit/build.git


### PR DESCRIPTION
Closes #2544 
Requires https://github.com/larshp/abapmerge/pull/82 otherwise the error is not visible.