### PR TITLE
TABL: Simplify control flow

### DIFF
--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -169,6 +169,7 @@ CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
     DATA lv_result              LIKE sy-subrc.
 
     IF is_idoc_segment( ) = abap_false.
+      rv_deleted = abap_false.
       RETURN. "previous XML version or no IDoc segment
     ENDIF.
 

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -46,10 +46,10 @@ CLASS zcl_abapgit_object_tabl DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
       CHANGING
         !ct_dd03p TYPE ty_dd03p_tt .
     "! Check if structure is an IDoc segment
-    "! @raising zcx_abapgit_exception | It's not an IDoc segment
-    METHODS check_is_idoc_segment
-      RAISING
-        zcx_abapgit_exception .
+    "! @parameter rv_is_idoc_segment | It's an IDoc segment or not
+    METHODS is_idoc_segment
+      RETURNING
+        VALUE(rv_is_idoc_segment) TYPE abap_bool.
     METHODS clear_dd03p_fields_common
       CHANGING
         !cs_dd03p TYPE dd03p .
@@ -60,10 +60,10 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
+CLASS zcl_abapgit_object_tabl IMPLEMENTATION.
 
 
-  METHOD check_is_idoc_segment.
+  METHOD is_idoc_segment.
 
     DATA lv_segment_type TYPE edilsegtyp.
 
@@ -73,9 +73,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
            FROM edisegment
            INTO lv_segment_type
            WHERE segtyp = lv_segment_type.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'No IDoc segment' ).
-    ENDIF.
+    rv_is_idoc_segment = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.
 
@@ -170,13 +168,9 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
     DATA lv_segment_type        TYPE edilsegtyp.
     DATA lv_result              LIKE sy-subrc.
 
-    TRY.
-        check_is_idoc_segment( ).
-
-      CATCH zcx_abapgit_exception ##no_handler.
-        rv_deleted = abap_false.
-        RETURN. "previous XML version or no IDoc segment
-    ENDTRY.
+    IF is_idoc_segment( ) = abap_false.
+      RETURN. "previous XML version or no IDoc segment
+    ENDIF.
 
     rv_deleted = abap_true.
     lv_segment_type = ms_item-obj_name.
@@ -300,59 +294,56 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
     DATA lt_segment_definitions TYPE ty_segment_definitions.
     FIELD-SYMBOLS: <ls_segemtndefinition> TYPE edisegmdef.
 
-    TRY.
-        check_is_idoc_segment( ).
+    IF is_idoc_segment( ) = abap_false.
+      RETURN.
+    ENDIF.
 
-        lv_segment_type = ms_item-obj_name.
-        CALL FUNCTION 'SEGMENT_READ'
-          EXPORTING
-            segmenttyp        = lv_segment_type
-          IMPORTING
-            result            = lv_result
-          TABLES
-            segmentdefinition = lt_segmentdefinitions
-          EXCEPTIONS
-            OTHERS            = 1.
-        IF sy-subrc <> 0 OR lv_result <> 0.
-          zcx_abapgit_exception=>raise_t100( ).
-        ENDIF.
+    lv_segment_type = ms_item-obj_name.
+    CALL FUNCTION 'SEGMENT_READ'
+      EXPORTING
+        segmenttyp        = lv_segment_type
+      IMPORTING
+        result            = lv_result
+      TABLES
+        segmentdefinition = lt_segmentdefinitions
+      EXCEPTIONS
+        OTHERS            = 1.
+    IF sy-subrc <> 0 OR lv_result <> 0.
+      zcx_abapgit_exception=>raise_t100( ).
+    ENDIF.
 
-        LOOP AT lt_segmentdefinitions ASSIGNING <ls_segemtndefinition>.
-          CLEAR ls_segment_definition.
-          CALL FUNCTION 'SEGMENTDEFINITION_READ'
-            EXPORTING
-              segmenttyp           = <ls_segemtndefinition>-segtyp
-            IMPORTING
-              result               = lv_result
-              devclass             = lv_devclass
-              segmentheader        = ls_segment_definition-segmentheader
-              segmentdefinition    = ls_segment_definition-segmentdefinition
-            TABLES
-              segmentstructure     = ls_segment_definition-segmentstructures
-            CHANGING
-              version              = <ls_segemtndefinition>-version
-            EXCEPTIONS
-              no_authority         = 1
-              segment_not_existing = 2
-              OTHERS               = 3.
-          IF sy-subrc <> 0 OR lv_result <> 0.
-            zcx_abapgit_exception=>raise_t100( ).
-          ENDIF.
+    LOOP AT lt_segmentdefinitions ASSIGNING <ls_segemtndefinition>.
+      CLEAR ls_segment_definition.
+      CALL FUNCTION 'SEGMENTDEFINITION_READ'
+        EXPORTING
+          segmenttyp           = <ls_segemtndefinition>-segtyp
+        IMPORTING
+          result               = lv_result
+          devclass             = lv_devclass
+          segmentheader        = ls_segment_definition-segmentheader
+          segmentdefinition    = ls_segment_definition-segmentdefinition
+        TABLES
+          segmentstructure     = ls_segment_definition-segmentstructures
+        CHANGING
+          version              = <ls_segemtndefinition>-version
+        EXCEPTIONS
+          no_authority         = 1
+          segment_not_existing = 2
+          OTHERS               = 3.
+      IF sy-subrc <> 0 OR lv_result <> 0.
+        zcx_abapgit_exception=>raise_t100( ).
+      ENDIF.
 
-          zcl_abapgit_object_idoc=>clear_idoc_segement_fields(
-                                     CHANGING cs_structure = ls_segment_definition-segmentdefinition ).
-          zcl_abapgit_object_idoc=>clear_idoc_segement_fields(
-                                     CHANGING cs_structure = ls_segment_definition-segmentheader ).
+      zcl_abapgit_object_idoc=>clear_idoc_segement_fields(
+                                 CHANGING cs_structure = ls_segment_definition-segmentdefinition ).
+      zcl_abapgit_object_idoc=>clear_idoc_segement_fields(
+                                 CHANGING cs_structure = ls_segment_definition-segmentheader ).
 
-          APPEND ls_segment_definition TO lt_segment_definitions.
-        ENDLOOP.
+      APPEND ls_segment_definition TO lt_segment_definitions.
+    ENDLOOP.
 
-        io_xml->add( iv_name = c_s_dataname-segment_definition
-                     ig_data = lt_segment_definitions ).
-
-      CATCH zcx_abapgit_exception ##no_handler.
-        "ok, no Idoc segment
-    ENDTRY.
+    io_xml->add( iv_name = c_s_dataname-segment_definition
+                 ig_data = lt_segment_definitions ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
When this commit is applied the control flow in object serializer TABL is eased. The idoc check returns now a boolean instead of raising an exception. Main purpose is to ease debugging due to reducing the use of zcx_abapgit_exception=>raise.