### PR TITLE
sfpf: save layout in solo XDP file

### DIFF
--- a/src/objects/zcl_abapgit_object_sfpf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sfpf.clas.abap
@@ -18,6 +18,9 @@ CLASS zcl_abapgit_object_sfpf DEFINITION
         zcx_abapgit_exception .
   PROTECTED SECTION.
   PRIVATE SECTION.
+
+    CONSTANTS c_layout_file_ext TYPE string VALUE 'xdp'.
+
     METHODS:
       load
         RETURNING VALUE(ri_wb_form) TYPE REF TO if_fp_wb_form
@@ -106,18 +109,49 @@ CLASS ZCL_ABAPGIT_OBJECT_SFPF IMPLEMENTATION.
 
   METHOD form_to_xstring.
 
-    DATA: li_fp_form TYPE REF TO if_fp_form,
-          li_wb_form TYPE REF TO if_fp_wb_form.
+    CONSTANTS: lc_empty_data TYPE xstring VALUE ''.
 
+    DATA: li_fp_form     TYPE REF TO if_fp_form,
+          li_wb_form     TYPE REF TO if_fp_wb_form,
+          li_fp_layout   TYPE REF TO if_fp_layout,
+          lx_fp_err      TYPE REF TO cx_fp_api,
+          lx_fp_conv_err TYPE REF TO cx_fp_api,
+          lv_layout_data TYPE xstring.
+
+    li_wb_form = load( ).
+    li_fp_form ?= li_wb_form->get_object( ).
+    li_fp_layout = li_fp_form->get_layout( ).
+    lv_layout_data = li_fp_layout->get_layout_data( ).
+
+    mo_files->add_raw( iv_ext = c_layout_file_ext
+                       iv_data = lv_layout_data ).
 
     TRY.
-        li_wb_form = load( ).
-        li_fp_form ?= li_wb_form->get_object( ).
-        rv_xstr = cl_fp_helper=>convert_form_to_xstring( li_fp_form ).
-      CATCH cx_fp_api.
-        zcx_abapgit_exception=>raise( 'SFPF error, form_to_xstring' ).
+        li_fp_layout->set_layout_data( i_layout_data   = lc_empty_data
+                                       i_set_xliff_ids = abap_false ).
+      CATCH cx_fp_api INTO lx_fp_err.
+        zcx_abapgit_exception=>raise( |SFPF remove layout: { lx_fp_err->get_text( ) }| ).
     ENDTRY.
 
+    TRY.
+        rv_xstr = cl_fp_helper=>convert_form_to_xstring( li_fp_form ).
+      CATCH cx_fp_api INTO lx_fp_conv_err.
+        " Pass - the exception is handled below!
+    ENDTRY.
+
+    TRY.
+        li_fp_layout->set_layout_data( i_layout_data   = lv_layout_data
+                                       i_set_xliff_ids = abap_false ).
+      CATCH cx_fp_api INTO lx_fp_err.
+        " Be aware that there might be another exception
+        " raised by cl_fp_helper=>convert_form_to_xstring( )
+        zcx_abapgit_exception=>raise( |SFPF recover layout: { lx_fp_err->get_text( ) }| ).
+    ENDTRY.
+
+    IF lx_fp_conv_err IS BOUND.
+      " This statement handles the exception raised from cl_fp_helper=>convert_form_to_xstring( )
+      zcx_abapgit_exception=>raise( |SFPF convert_form_to_xstring: { lx_fp_conv_err->get_text( ) }| ).
+    ENDIF.
   ENDMETHOD.
 
 
@@ -178,6 +212,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SFPF IMPLEMENTATION.
   METHOD zif_abapgit_object~deserialize.
 
     DATA: lv_xstr      TYPE xstring,
+          lv_layout    TYPE xstring,
           lv_name      TYPE fpname,
           li_wb_object TYPE REF TO if_fp_wb_form,
           li_form      TYPE REF TO if_fp_form.
@@ -188,6 +223,11 @@ CLASS ZCL_ABAPGIT_OBJECT_SFPF IMPLEMENTATION.
 
     TRY.
         li_form = cl_fp_helper=>convert_xstring_to_form( lv_xstr ).
+
+        IF mo_files->contains( c_layout_file_ext ) = abap_true.
+          lv_layout = mo_files->read_raw( c_layout_file_ext ).
+          li_form->get_layout( )->set_layout_data( lv_layout ).
+        ENDIF.
 
         IF zif_abapgit_object~exists( ) = abap_true.
           cl_fp_wb_form=>delete( lv_name ).

--- a/src/objects/zcl_abapgit_objects_files.clas.abap
+++ b/src/objects/zcl_abapgit_objects_files.clas.abap
@@ -79,6 +79,12 @@ CLASS zcl_abapgit_objects_files DEFINITION
     METHODS get_accessed_files
       RETURNING
         VALUE(rt_files) TYPE zif_abapgit_definitions=>ty_file_signatures_tt .
+    METHODS contains
+      IMPORTING
+        !iv_extra TYPE clike OPTIONAL
+        !iv_ext   TYPE string
+      RETURNING
+        VALUE(rv_present) TYPE abap_bool.
   PROTECTED SECTION.
 
     METHODS read_file
@@ -345,4 +351,23 @@ CLASS ZCL_ABAPGIT_OBJECTS_FILES IMPLEMENTATION.
   METHOD set_files.
     mt_files = it_files.
   ENDMETHOD.
+
+  METHOD contains.
+    DATA: lv_filename TYPE string.
+
+    lv_filename = filename( iv_extra = iv_extra
+                            iv_ext   = iv_ext ).
+
+    IF mv_path IS NOT INITIAL.
+      READ TABLE mt_files TRANSPORTING NO FIELDS WITH KEY path     = mv_path
+                                                          filename = lv_filename.
+    ELSE.
+      READ TABLE mt_files TRANSPORTING NO FIELDS WITH KEY filename = lv_filename.
+    ENDIF.
+
+    IF sy-subrc = 0.
+      rv_present = abap_true.
+    ENDIF.
+  ENDMETHOD.
+
 ENDCLASS.


### PR DESCRIPTION
Manually tested pushing and pulling but it still might cause some
problems.

This commit adds a new file with the suffix XDP for every XFPF object.
The new file contains the form layout which can be edited in Adobe
LiveCycle Designer. During debugging I learned that we put layouts in
all supported languages to the serialized SFPF XML file but the new
layout file contains only the layout of the Form's language.

I am not sure if removing the layout data make sense because thelayout
object contains layout data for all supported languages and the call
set_layout_data changes only the form's language.

Closes #2554