### PR TITLE
GUI: free, go_page, ext error handler

### DIFF
--- a/src/ui/zcl_abapgit_ui_factory.clas.abap
+++ b/src/ui/zcl_abapgit_ui_factory.clas.abap
@@ -61,6 +61,8 @@ CLASS ZCL_ABAPGIT_UI_FACTORY IMPLEMENTATION.
       li_router    TYPE REF TO zif_abapgit_gui_event_handler,
       li_asset_man TYPE REF TO zif_abapgit_gui_asset_manager.
 
+    DATA lo_error_handler TYPE REF TO lcl_gui_error_handler.
+
     IF go_gui IS INITIAL.
       li_asset_man ?= init_asset_manager( ).
       CREATE OBJECT li_router TYPE zcl_abapgit_gui_router.
@@ -68,6 +70,8 @@ CLASS ZCL_ABAPGIT_UI_FACTORY IMPLEMENTATION.
         EXPORTING
           io_component = li_router
           ii_asset_man = li_asset_man.
+      CREATE OBJECT lo_error_handler.
+      SET HANDLER lo_error_handler->on_gui_error FOR go_gui.
     ENDIF.
     ro_gui = go_gui.
 

--- a/src/ui/zcl_abapgit_ui_factory.clas.locals_imp.abap
+++ b/src/ui/zcl_abapgit_ui_factory.clas.locals_imp.abap
@@ -1,0 +1,13 @@
+CLASS lcl_gui_error_handler DEFINITION.
+  PUBLIC SECTION.
+    METHODS on_gui_error FOR EVENT on_handle_error OF zcl_abapgit_gui
+      IMPORTING
+        io_exception.
+ENDCLASS.
+
+CLASS lcl_gui_error_handler IMPLEMENTATION.
+  METHOD on_gui_error.
+    ROLLBACK WORK.
+    MESSAGE io_exception TYPE 'S' DISPLAY LIKE 'E'.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/zabapgit_forms.prog.abap
+++ b/src/zabapgit_forms.prog.abap
@@ -128,7 +128,9 @@ ENDFORM.
 FORM exit RAISING zcx_abapgit_exception.
   CASE sy-ucomm.
     WHEN 'CBAC'.  "Back
-      IF zcl_abapgit_ui_factory=>get_gui( )->back( ) IS INITIAL.
+      IF zcl_abapgit_ui_factory=>get_gui( )->back( ) = abap_true. " end of stack
+        zcl_abapgit_ui_factory=>get_gui( )->free( ). " Graceful shutdown
+      ELSE.
         LEAVE TO SCREEN 1001.
       ENDIF.
   ENDCASE.


### PR DESCRIPTION
to #2525, part 5

This one is about some minor tweaks towards re-usabilty.
- free - graceful disconnection of html GUI
- go_page - direct go navigation to a  page object
- error_handler - the idea was to remove exception processing from GUI itself. But ended a bit hacky imho ... need an opinion