### PR TITLE
Escape slashes in branch overview commit messages

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
@@ -263,6 +263,7 @@ CLASS zcl_abapgit_gui_page_boverview IMPLEMENTATION.
 
     rv_string = iv_string.
 
+    REPLACE ALL OCCURRENCES OF '\' IN rv_string WITH '\\'.
     REPLACE ALL OCCURRENCES OF '"' IN rv_string WITH '\"'.
 
   ENDMETHOD.


### PR DESCRIPTION
I managed to break my branch overview graph by accidentally leaving `\` at the end of a commit message (it's close to enter on many keyboards).

The message is passed into a javascript string with `\` unescaped, where it acts as an escape character to an ending quote and causes a syntax error:
![4lPc9Lmg0P](https://user-images.githubusercontent.com/5097067/54698666-f657b500-4b2f-11e9-8c91-317d1005979c.png)

Here you can see the branch overview page with/without the fix:
![image](https://user-images.githubusercontent.com/5097067/54698397-8812f280-4b2f-11e9-9467-64d1f3cb165b.png)

Test using this repo or any other repo with a `\` in one of its commits.
https://github.com/FreHu/abapgit-branch-overview