### PR TITLE
Add docs on debugging

### DIFF
--- a/docs/collections/_development/debugging.md
+++ b/docs/collections/_development/debugging.md
@@ -1,0 +1,10 @@
+---
+title: Debugging
+order: 75
+---
+
+*******************************
+
+How to use the IE Debugger in abapGit:
+
+[https://blogs.sap.com/2019/03/22/obscure-productivity-tips-debug-javascript-running-within-sapgui-browser/](https://blogs.sap.com/2019/03/22/obscure-productivity-tips-debug-javascript-running-within-sapgui-browser/)


### PR DESCRIPTION
#2562 

I haven't used github pages before, but based on the other pages, I'm assuming creating a new file is enough and the menu link is autogenerated?