### PR TITLE
#2577 shortdump ENHO object with new type

### DIFF
--- a/src/objects/zcl_abapgit_object_enho_clif.clas.abap
+++ b/src/objects/zcl_abapgit_object_enho_clif.clas.abap
@@ -92,10 +92,11 @@ CLASS zcl_abapgit_object_enho_clif IMPLEMENTATION.
     ENDLOOP.
 
     LOOP AT lt_tab_types ASSIGNING <ls_type>.
-      CLEAR: <ls_attr>-author,
-             <ls_attr>-createdon,
-             <ls_attr>-changedby,
-             <ls_attr>-changedon.
+      CLEAR: <ls_type>-author,
+             <ls_type>-createdon,
+             <ls_type>-changedby,
+             <ls_type>-changedon,
+             <ls_type>-descript_id.
     ENDLOOP.
 
     LOOP AT lt_tab_methods ASSIGNING <ls_meth>.


### PR DESCRIPTION
Short dump GETWA_NOT_ASSIGNED because of stupid copy/paste error in method SERIALIZE of ZCL_ABAPGIT_OBJECT_ENHO_CLIF:

    LOOP AT lt_tab_types ASSIGNING <ls_type>.
      CLEAR: <ls_attr>-author,
             <ls_attr>-createdon,
             <ls_attr>-changedby,
             <ls_attr>-changedon.
    ENDLOOP.

Replace all <ls_attr> with <ls_type>.

Also clearing of <ls_type>-descript_id (OTR text ID) so that the DIFF ignores this field (new OTR texts, with new IDs, are always created while pulling so the ID must not be compared).