### PR TITLE
DIFF shown after pull ENHO of implicit enh. #2579

### DIFF
--- a/src/objects/zcl_abapgit_object_enho_hook.clas.abap
+++ b/src/objects/zcl_abapgit_object_enho_hook.clas.abap
@@ -45,6 +45,8 @@ CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
           lt_spaces          TYPE ty_spaces_tt,
           lt_enhancements    TYPE enh_hook_impl_it.
 
+    FIELD-SYMBOLS: <ls_enhancement> LIKE LINE OF lt_enhancements.
+
 
     lo_hook_impl ?= ii_enh_tool.
 
@@ -59,6 +61,11 @@ CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
         program   = ls_original_object-programname ).
     ls_original_object-include_bound = lo_hook_impl->get_include_bound( ).
     lt_enhancements = lo_hook_impl->get_hook_impls( ).
+
+    LOOP AT lt_enhancements ASSIGNING <ls_enhancement>.
+      CLEAR: <ls_enhancement>-extid,
+             <ls_enhancement>-id.
+    ENDLOOP.
 
     hook_impl_serialize(
       IMPORTING et_spaces = lt_spaces


### PR DESCRIPTION
Issue #2579: diff still shown after pull of ENHO hooks (implicit enhancements i.e. code added at start/end of existing methods, etc.)

Reason: if the author has created and deleted implicit enhancements in the original system, the numbering doesn't start from 1 (this is the numbering we can see for the statement ENHANCEMENT, for instance ENHANCEMENT 1. ... ENDENHANCEMENT.) When pulling in another system, the numbering will start from 1, so it will differ from the source. As this enhancement number is serialized by abapGit in the XML, it will detect a difference.

Correction: the method SERIALIZE of class ZCL_ABAPGIT_OBJECT_ENHO_HOOK is changed so that to not serialize the enhancement number.