### PR TITLE
2 unit tests in ZCL_ABAPGIT_GUI_PAGE_DIFF failing

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_diff.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_gui_page_diff.clas.testclasses.abap
@@ -25,7 +25,7 @@ CLASS ltcl_patch IMPLEMENTATION.
 
     zcl_abapgit_gui_page_diff=>get_patch_data(
       EXPORTING
-        iv_patch      = |add_patch_zcl_test_git_add_p.clas.abap_19|
+        iv_patch      = |patch_line_add_zcl_test_git_add_p.clas.abap_0_19|
         iv_action     = |add|
       IMPORTING
         ev_filename   = lv_file_name
@@ -48,7 +48,7 @@ CLASS ltcl_patch IMPLEMENTATION.
 
     zcl_abapgit_gui_page_diff=>get_patch_data(
       EXPORTING
-        iv_patch      = |remove_patch_ztest_patch.prog.abap_39|
+        iv_patch      = |patch_line_remove_ztest_patch.prog.abap_0_39|
         iv_action     = |remove|
       IMPORTING
         ev_filename   = lv_file_name


### PR DESCRIPTION
#2498 Two unit tests in ZCL_ABAPGIT_GUI_PAGE_DIFF failing

It concerns two test methods which test zcl_abapgit_gui_page_diff%3D>get_patch_data. The parameter IV_PATCH is passed with an incorrect value.

This issue is due to commit 389512f690344ab6438e6d117fdc0b79fc271560 on Feb 26, 2019

Correction of method get_patch_data_add: 
- Before: |add_patch_zcl_test_git_add_p.clas.abap_19| 
- After: |patch_line_add_zcl_test_git_add_p.clas.abap_0_19| 

Correction of method get_patch_data_remove:
- Before: |remove_patch_ztest_patch.prog.abap_39| 
- After: |patch_line_remove_ztest_patch.prog.abap_0_39|