### PR TITLE
Floating save buttons

### DIFF
--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -1065,6 +1065,7 @@ table.commit tr .title {
   border-width: 1px;
   border-style: solid;
   box-shadow: 2px 2px 6px 0px #ccc;
+  cursor: pointer;
 }
 .blue-set {
   border-color: #abc3e3;

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -1053,3 +1053,26 @@ table.commit tr .title {
 .ci-result li span {
   display: block;
 }
+
+/* Floating buttons and color sets */
+
+.floating-button {
+  position: fixed;
+  top: 6em;
+  right: 2.8em;
+  padding: 1em 1.8em;
+  border-radius: 4px;
+  border-width: 1px;
+  border-style: solid;
+  box-shadow: 2px 2px 6px 0px #ccc;
+}
+.blue-set {
+  border-color: #abc3e3;
+  color: #5e8dc9;
+  background-color: #d9e4f2;
+}
+.grey-set {
+  border-color: #c7c7c7;
+  color: #808080;
+  background-color: #e6e6e6;
+}

--- a/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
@@ -90,7 +90,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
     render_dot_abapgit( ro_html ).
     render_local_settings( ro_html ).
 
-    ro_html->add( '<br><input type="submit" value="Save" class="submit">' ).
+    ro_html->add( '<br><input type="submit" value="Save" class="floating-button blue-set emphasis">' ).
     ro_html->add( '</form>' ).
     ro_html->add( '</div>' ).
 
@@ -334,11 +334,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
-
-  ENDMETHOD.
-
-
   METHOD zif_abapgit_gui_event_handler~on_event.
 
     CASE iv_action.
@@ -346,6 +341,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
         save( it_postdata ).
         ev_state = zcl_abapgit_gui=>c_event_state-go_back.
     ENDCASE.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_settings.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_settings.clas.abap
@@ -473,7 +473,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETTINGS IMPLEMENTATION.
   METHOD render_form_end.
 
     CREATE OBJECT ro_html.
-    ro_html->add( '<input type="submit" value="Save" class="submit">' ).
+    ro_html->add( '<input type="submit" value="Save" class="floating-button blue-set emphasis">' ).
     ro_html->add( '</form>' ).
     ro_html->add( '</div>' ).
 


### PR DESCRIPTION
Issue: save buttons are at the very end of settings, need to scroll, small to target.
Solution: Make it bigger and floating

Some doubts:
- stupid IE does not support CSS position sticky which does exactly what is needed, instead position fixed to the screen is used and it has issues
- initially made the button at the bottom, but the problem that it goes beyond the end of the content div which is not very nice ... and what's more, it is initially below repo settings which are smaller
- So i move it to the top
- which is more consistent, in term of AG UI which usually has controls on top, also DB util (which should be probably also move to the new approach ??)
- disadvantage, after scrolling from the top, the button looks misplaced, well ... but accessible from everywhere
- any ideas appreciated :))

**Pls someone check how this is displayed in your computer - I have specific scaling so may look differently in usual display settings**

First attempt (bottom)
<img width="814" alt="2019-03-31_19h59_45" src="https://user-images.githubusercontent.com/15635498/55292939-3acd3580-53f9-11e9-9401-09b2e09072cf.png">
Final version (top)
<img width="814" alt="2019-03-31_20h01_54" src="https://user-images.githubusercontent.com/15635498/55292940-3acd3580-53f9-11e9-8b74-0a7c7ef0f12f.png">
... but looks misplaced in the middle
<img width="814" alt="2019-03-31_20h01_58" src="https://user-images.githubusercontent.com/15635498/55292941-3b65cc00-53f9-11e9-8992-e0650b8c215a.png">
though consistent with other UI (maybe change DB util to the floating ???)
<img width="814" alt="2019-03-31_20h02_22" src="https://user-images.githubusercontent.com/15635498/55292942-3b65cc00-53f9-11e9-9151-45b24694a1e8.png">

