### PR TITLE
report name of xml file in case of format error

### DIFF
--- a/src/objects/zcl_abapgit_objects_files.clas.abap
+++ b/src/objects/zcl_abapgit_objects_files.clas.abap
@@ -200,6 +200,25 @@ CLASS ZCL_ABAPGIT_OBJECTS_FILES IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD contains.
+    DATA: lv_filename TYPE string.
+
+    lv_filename = filename( iv_extra = iv_extra
+                            iv_ext   = iv_ext ).
+
+    IF mv_path IS NOT INITIAL.
+      READ TABLE mt_files TRANSPORTING NO FIELDS WITH KEY path     = mv_path
+                                                          filename = lv_filename.
+    ELSE.
+      READ TABLE mt_files TRANSPORTING NO FIELDS WITH KEY filename = lv_filename.
+    ENDIF.
+
+    IF sy-subrc = 0.
+      rv_present = abap_true.
+    ENDIF.
+  ENDMETHOD.
+
+
   METHOD filename.
 
     DATA: lv_obj_name TYPE string.
@@ -343,7 +362,8 @@ CLASS ZCL_ABAPGIT_OBJECTS_FILES IMPLEMENTATION.
 
     CREATE OBJECT ro_xml
       EXPORTING
-        iv_xml = lv_xml.
+        iv_xml      = lv_xml
+        iv_filename = lv_filename.
 
   ENDMETHOD.
 
@@ -351,23 +371,4 @@ CLASS ZCL_ABAPGIT_OBJECTS_FILES IMPLEMENTATION.
   METHOD set_files.
     mt_files = it_files.
   ENDMETHOD.
-
-  METHOD contains.
-    DATA: lv_filename TYPE string.
-
-    lv_filename = filename( iv_extra = iv_extra
-                            iv_ext   = iv_ext ).
-
-    IF mv_path IS NOT INITIAL.
-      READ TABLE mt_files TRANSPORTING NO FIELDS WITH KEY path     = mv_path
-                                                          filename = lv_filename.
-    ELSE.
-      READ TABLE mt_files TRANSPORTING NO FIELDS WITH KEY filename = lv_filename.
-    ENDIF.
-
-    IF sy-subrc = 0.
-      rv_present = abap_true.
-    ENDIF.
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/xml/zcl_abapgit_xml.clas.abap
+++ b/src/xml/zcl_abapgit_xml.clas.abap
@@ -5,12 +5,14 @@ CLASS zcl_abapgit_xml DEFINITION
 
   PUBLIC SECTION.
     METHODS:
-      constructor.
+      constructor
+        IMPORTING iv_filename TYPE string OPTIONAL.
 
   PROTECTED SECTION.
     DATA: mi_ixml     TYPE REF TO if_ixml,
           mi_xml_doc  TYPE REF TO if_ixml_document,
-          ms_metadata TYPE zif_abapgit_definitions=>ty_metadata.
+          ms_metadata TYPE if_abapgit_definitions=>ty_metadata,
+          mv_filename TYPE string.
 
     CONSTANTS: c_abapgit_tag             TYPE string VALUE 'abapGit' ##NO_TEXT,
                c_attr_version            TYPE string VALUE 'version' ##NO_TEXT,
@@ -27,12 +29,12 @@ CLASS zcl_abapgit_xml DEFINITION
       RAISING   zcx_abapgit_exception.
 
   PRIVATE SECTION.
+
     METHODS error
       IMPORTING ii_parser TYPE REF TO if_ixml_parser
       RAISING   zcx_abapgit_exception.
-
-    METHODS display_xml_error
-      RAISING zcx_abapgit_exception.
+    METHODS display_version_mismatch
+      RAISING   zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -42,62 +44,91 @@ CLASS ZCL_ABAPGIT_XML IMPLEMENTATION.
 
 
   METHOD constructor.
-    mi_ixml = cl_ixml=>create( ).
-    mi_xml_doc = mi_ixml->create_document( ).
+    mi_ixml     = cl_ixml=>create( ).
+    mi_xml_doc  = mi_ixml->create_document( ).
+    mv_filename = iv_filename.
   ENDMETHOD.
 
 
-  METHOD display_xml_error.
+  METHOD display_version_mismatch.
 
     DATA: lv_version TYPE string.
+    DATA: lv_file    TYPE string.
 
-
-    lv_version = |abapGit version: { zif_abapgit_version=>gc_abap_version }|.
+    lv_version = |abapGit version: { zif_abapgit_version=>gc_abap_version }|. "#EC NOTEXT
+    IF mv_filename IS NOT INITIAL.
+      lv_file = |File: { mv_filename }|.  "#EC NOTEXT
+    ENDIF.
 
     CALL FUNCTION 'POPUP_TO_INFORM'
       EXPORTING
-        titel = 'abapGit XML version mismatch'
-        txt1  = 'abapGit XML version mismatch'
-        txt2  = 'See http://larshp.github.io/abapGit/other-xml-mismatch.html'
-        txt3  = lv_version.                                 "#EC NOTEXT
+        titel = 'abapGit XML version mismatch'  "#EC NOTEXT
+        txt1  = 'abapGit XML version mismatch'  "#EC NOTEXT
+        txt2  = 'See http://larshp.github.io/abapGit/other-xml-mismatch.html' "#EC NOTEXT
+        txt3  = lv_version
+        txt4  = lv_file.
 
-    zcx_abapgit_exception=>raise( 'XML error' ).
+    IF mv_filename IS INITIAL.
+      zcx_abapgit_exception=>raise( 'abapGit XML version mismatch' ). "#EC NOTEXT
+    ELSE.
+      zcx_abapgit_exception=>raise( |abapGit XML version mismatch in file { mv_filename }| ). "#EC NOTEXT
+    ENDIF.
 
   ENDMETHOD.
 
 
   METHOD error.
 
-    DATA: lv_error TYPE i,
-          lv_txt1  TYPE string,
-          lv_txt2  TYPE string,
-          lv_txt3  TYPE string,
-          lv_times TYPE i,
-          li_error TYPE REF TO if_ixml_parse_error.
-
+    DATA: lv_error  TYPE i,
+          lv_column TYPE string,
+          lv_line   TYPE string,
+          lv_reason TYPE string,
+          lv_txt1   TYPE string,
+          lv_txt2   TYPE string,
+          lv_txt3   TYPE string,
+          lv_txt4   TYPE string,
+          lv_times  TYPE i,
+          li_error  TYPE REF TO if_ixml_parse_error.
 
     IF ii_parser->num_errors( ) <> 0.
       lv_times = ii_parser->num_errors( ).
+
       DO lv_times TIMES.
         lv_error = sy-index - 1.
         li_error = ii_parser->get_error( lv_error ).
 
-        lv_txt1 = li_error->get_column( ).
-        CONCATENATE 'Column:' lv_txt1 INTO lv_txt1.         "#EC NOTEXT
-        lv_txt2 = li_error->get_line( ).
-        CONCATENATE 'Line:' lv_txt2 INTO lv_txt2.           "#EC NOTEXT
-        lv_txt3 = li_error->get_reason( ).
+        lv_column = li_error->get_column( ).
+        lv_line   = li_error->get_line( ).
+        lv_reason = li_error->get_reason( ).
+
+        IF mv_filename IS NOT INITIAL.
+          lv_txt1 = |File: { mv_filename }|.  "#EC NOTEXT
+          lv_txt2 = |Column: { lv_column }|.  "#EC NOTEXT
+          lv_txt3 = |Line: { lv_line }|.      "#EC NOTEXT
+          lv_txt4 = lv_reason.
+        ELSE.
+          lv_txt1 = |Column: { lv_column }|.  "#EC NOTEXT
+          lv_txt2 = |Line: { lv_line }|.      "#EC NOTEXT
+          lv_txt3 = lv_reason.
+          CLEAR lv_txt4.
+        ENDIF.
 
         CALL FUNCTION 'POPUP_TO_INFORM'
           EXPORTING
-            titel = 'Error from XML parser'                 "#EC NOTEXT
+            titel = |Error from XML parser|   "#EC NOTEXT
             txt1  = lv_txt1
             txt2  = lv_txt2
-            txt3  = lv_txt3.
+            txt3  = lv_txt3
+            txt4  = lv_txt4.
       ENDDO.
     ENDIF.
 
-    zcx_abapgit_exception=>raise( 'Error while parsing XML' ).
+    IF mv_filename IS INITIAL.
+      zcx_abapgit_exception=>raise( |Error while parsing XML| ). "#EC NOTEXT
+    ELSE.
+      zcx_abapgit_exception=>raise( |Error while parsing XML file { mv_filename }| ). "#EC NOTEXT
+    ENDIF.
+
   ENDMETHOD.
 
 
@@ -129,7 +160,7 @@ CLASS ZCL_ABAPGIT_XML IMPLEMENTATION.
     li_version = li_element->if_ixml_node~get_attributes(
       )->get_named_item_ns( c_attr_version ) ##no_text.
     IF li_version->get_value( ) <> zif_abapgit_version=>gc_xml_version.
-      display_xml_error( ).
+      display_version_mismatch( ).
     ENDIF.
 
 * buffer serializer metadata. Git node will be removed lateron

--- a/src/xml/zcl_abapgit_xml_input.clas.abap
+++ b/src/xml/zcl_abapgit_xml_input.clas.abap
@@ -7,7 +7,8 @@ CLASS zcl_abapgit_xml_input DEFINITION
 
     METHODS constructor
       IMPORTING
-        !iv_xml TYPE clike
+        !iv_xml      TYPE clike
+        !iv_filename TYPE string OPTIONAL
       RAISING
         zcx_abapgit_exception .
     METHODS read
@@ -24,6 +25,7 @@ CLASS zcl_abapgit_xml_input DEFINITION
     METHODS get_metadata
       RETURNING
         VALUE(rs_metadata) TYPE zif_abapgit_definitions=>ty_metadata .
+protected section.
   PRIVATE SECTION.
     METHODS: fix_xml.
 
@@ -36,7 +38,7 @@ CLASS ZCL_ABAPGIT_XML_INPUT IMPLEMENTATION.
 
   METHOD constructor.
 
-    super->constructor( ).
+    super->constructor( iv_filename ).
     parse( iv_xml ).
     fix_xml( ).
 
@@ -89,7 +91,11 @@ CLASS ZCL_ABAPGIT_XML_INPUT IMPLEMENTATION.
           SOURCE XML mi_xml_doc
           RESULT (lt_rtab) ##no_text.
       CATCH cx_transformation_error INTO lx_error.
-        zcx_abapgit_exception=>raise( lx_error->if_message~get_text( ) ).
+        IF mv_filename IS INITIAL.
+          zcx_abapgit_exception=>raise( lx_error->if_message~get_text( ) ).
+        ELSE.
+          zcx_abapgit_exception=>raise( |File { mv_filename }: { lx_error->if_message~get_text( ) }| ).
+        ENDIF.
     ENDTRY.
 
   ENDMETHOD.

--- a/src/xml/zcl_abapgit_xml_input.clas.abap
+++ b/src/xml/zcl_abapgit_xml_input.clas.abap
@@ -25,7 +25,7 @@ CLASS zcl_abapgit_xml_input DEFINITION
     METHODS get_metadata
       RETURNING
         VALUE(rs_metadata) TYPE zif_abapgit_definitions=>ty_metadata .
-protected section.
+
   PRIVATE SECTION.
     METHODS: fix_xml.
 

--- a/src/zcl_abapgit_objects.clas.abap
+++ b/src/zcl_abapgit_objects.clas.abap
@@ -362,7 +362,8 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
       CREATE OBJECT lo_remote_version
         EXPORTING
-          iv_xml = zcl_abapgit_convert=>xstring_to_string_utf8( ls_remote_file-data ).
+          iv_xml      = zcl_abapgit_convert=>xstring_to_string_utf8( ls_remote_file-data )
+          iv_filename = ls_remote_file-filename.
 
       ls_result = li_comparator->compare( lo_remote_version ).
       IF ls_result-text IS INITIAL.


### PR DESCRIPTION
In case of an error in the XML file, for support reason I want to know which file causes the error. The file name is mentioned if the XML itself is corrupt or if there is an XML version mismatch.
This PR fixes issue #2619.