### PR TITLE
Add exit for CLAS CLIF source serialization

### DIFF
--- a/docs/ref-exits.md
+++ b/docs/ref-exits.md
@@ -45,4 +45,5 @@ Can be used to skip certian objects, or force a different object setup than curr
 Possibility to change the default `ANONYM` ssl id to something system specific
 
 ### CUSTOM_SERIALIZE_ABAP_CLIF
-Allows for a custom serializer to be used for global classes' CLIF sources. See [#2321](https://github.com/larshp/abapGit/issues/2321) and [#2491](https://github.com/larshp/abapGit/pull/2491) for use cases.
+Allows for a custom serializer to be used for global classes' CLIF sources. See [#2321](https://github.com/larshp/abapGit/issues/2321) and [#2491](https://github.com/larshp/abapGit/pull/2491) for use cases.  
+This [example implementation](https://gist.github.com/flaiker/999c8165b89131608b05cd371529fef5) forces the old class serializer to be used for specific packages.

--- a/docs/ref-exits.md
+++ b/docs/ref-exits.md
@@ -43,3 +43,6 @@ Can be used to skip certian objects, or force a different object setup than curr
 
 ### GET_SSL_ID
 Possibility to change the default `ANONYM` ssl id to something system specific
+
+### CUSTOM_SERIALIZE_ABAP_CLIF
+Allows for a custom serializer to be used for global classes' CLIF sources. See [#2321](https://github.com/larshp/abapGit/issues/2321) and [#2491](https://github.com/larshp/abapGit/pull/2491) for use cases.

--- a/src/objects/zcl_abapgit_oo_serializer.clas.abap
+++ b/src/objects/zcl_abapgit_oo_serializer.clas.abap
@@ -206,6 +206,11 @@ CLASS ZCL_ABAPGIT_OO_SERIALIZER IMPLEMENTATION.
 
 
   METHOD serialize_abap_clif_source.
+    rt_source = zcl_abapgit_exit=>get_instance( )->custom_serialize_abap_clif( is_class_key ).
+    IF rt_source IS NOT INITIAL.
+      RETURN.
+    ENDIF.
+
     TRY.
         rt_source = serialize_abap_new( is_class_key ).
       CATCH cx_sy_dyn_call_error.

--- a/src/zcl_abapgit_exit.clas.abap
+++ b/src/zcl_abapgit_exit.clas.abap
@@ -15,7 +15,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_EXIT IMPLEMENTATION.
+CLASS zcl_abapgit_exit IMPLEMENTATION.
 
 
   METHOD get_instance.
@@ -142,5 +142,12 @@ CLASS ZCL_ABAPGIT_EXIT IMPLEMENTATION.
       CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
     ENDTRY.
 
+  ENDMETHOD.
+
+  METHOD zif_abapgit_exit~custom_serialize_abap_clif.
+    TRY.
+        rt_source = gi_exit->custom_serialize_abap_clif( is_class_key ).
+      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+    ENDTRY.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zif_abapgit_exit.intf.abap
+++ b/src/zif_abapgit_exit.intf.abap
@@ -46,4 +46,11 @@ INTERFACE zif_abapgit_exit
   METHODS get_ssl_id
     RETURNING
       VALUE(rv_ssl_id) TYPE ssfapplssl .
+  METHODS custom_serialize_abap_clif
+    IMPORTING
+      is_class_key     TYPE seoclskey
+    RETURNING
+      VALUE(rt_source) TYPE zif_abapgit_definitions=>ty_string_tt
+    RAISING
+      zcx_abapgit_exception.
 ENDINTERFACE.


### PR DESCRIPTION
As discussed in #2491.
Fixes #2321 if implemented.

Not too keen on the exit name, if there are any better suggestions...