### PR TITLE
Hotkeys no longer depend on abapGit installation #2629 

### DIFF
--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -84,7 +84,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
+CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
 
 
   METHOD render_branch_span.
@@ -155,30 +155,30 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
 
   METHOD render_hotkey_overview.
 
-    DATA: lv_hint     TYPE string,
-          lt_hotkeys  TYPE zif_abapgit_definitions=>tty_hotkey,
-          lt_actions  TYPE zif_abapgit_gui_page_hotkey=>tty_hotkey_action,
-          lo_settings TYPE REF TO zcl_abapgit_settings.
+    DATA: lv_hint                 TYPE string,
+          lt_user_defined_hotkeys TYPE zif_abapgit_definitions=>tty_hotkey,
+          lt_hotkeys_for_page     TYPE zif_abapgit_gui_page_hotkey=>tty_hotkey_with_name,
+          lo_settings             TYPE REF TO zcl_abapgit_settings.
 
     FIELD-SYMBOLS: <ls_hotkey> TYPE zif_abapgit_definitions=>ty_hotkey,
-                   <ls_action> LIKE LINE OF lt_actions.
+                   <ls_action> LIKE LINE OF lt_hotkeys_for_page.
 
-    lo_settings = zcl_abapgit_persist_settings=>get_instance( )->read( ).
-    lt_hotkeys  = lo_settings->get_hotkeys( ).
-    lt_actions  = zcl_abapgit_hotkeys=>get_default_hotkeys_from_pages( io_page ).
+    lo_settings             = zcl_abapgit_persist_settings=>get_instance( )->read( ).
+    lt_user_defined_hotkeys = lo_settings->get_hotkeys( ).
+    lt_hotkeys_for_page     = zcl_abapgit_hotkeys=>get_all_default_hotkeys( io_page ).
 
     CREATE OBJECT ro_html.
 
     " Render hotkeys
     ro_html->add( '<ul class="hotkeys">' ).
-    LOOP AT lt_hotkeys ASSIGNING <ls_hotkey>.
+    LOOP AT lt_user_defined_hotkeys ASSIGNING <ls_hotkey>.
 
-      READ TABLE lt_actions ASSIGNING <ls_action>
-                            WITH TABLE KEY action
-                            COMPONENTS action = <ls_hotkey>-action.
+      READ TABLE lt_hotkeys_for_page ASSIGNING <ls_action>
+                                     WITH TABLE KEY action
+                                     COMPONENTS action = <ls_hotkey>-action.
       IF sy-subrc = 0.
         ro_html->add( |<li>|
-          && |<span class="key-id">{ <ls_hotkey>-sequence }</span>|
+          && |<span class="key-id">{ <ls_hotkey>-hotkey }</span>|
           && |<span class="key-descr">{ <ls_action>-name }</span>|
           && |</li>| ).
       ENDIF.
@@ -187,10 +187,11 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
     ro_html->add( '</ul>' ).
 
     " Wrap
-    READ TABLE lt_hotkeys ASSIGNING <ls_hotkey>
-      WITH KEY action = zcl_abapgit_gui_page=>c_global_page_action-showhotkeys.
+    READ TABLE lt_user_defined_hotkeys ASSIGNING <ls_hotkey>
+      WITH TABLE KEY action
+      COMPONENTS action = zcl_abapgit_gui_page=>c_global_page_action-showhotkeys.
     IF sy-subrc = 0.
-      lv_hint = |Close window with '{ <ls_hotkey>-sequence }' or upper right corner 'X'|.
+      lv_hint = |Close window with '{ <ls_hotkey>-hotkey }' or upper right corner 'X'|.
     ENDIF.
 
     ro_html = render_infopanel(
@@ -203,7 +204,7 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
 
     IF <ls_hotkey> IS ASSIGNED AND zcl_abapgit_hotkeys=>should_show_hint( ) = abap_true.
       ro_html->add( |<div id="hotkeys-hint" class="corner-hint">|
-        && |Press '{ <ls_hotkey>-sequence }' to get keyboard shortcuts list|
+        && |Press '{ <ls_hotkey>-hotkey }' to get keyboard shortcuts list|
         && |</div>| ).
     ENDIF.
 

--- a/src/ui/zcl_abapgit_gui_page_code_insp.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_code_insp.clas.abap
@@ -232,14 +232,14 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CODE_INSP IMPLEMENTATION.
 
     DATA: ls_hotkey_action LIKE LINE OF rt_hotkey_actions.
 
-    ls_hotkey_action-name           = |Stage|.
-    ls_hotkey_action-action         = c_actions-stage.
-    ls_hotkey_action-default_hotkey = |s|.
+    ls_hotkey_action-name   = |Stage|.
+    ls_hotkey_action-action = c_actions-stage.
+    ls_hotkey_action-hotkey = |s|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name           = |Re-Run|.
-    ls_hotkey_action-action         = c_actions-rerun.
-    ls_hotkey_action-default_hotkey = |r|.
+    ls_hotkey_action-name   = |Re-Run|.
+    ls_hotkey_action-action = c_actions-rerun.
+    ls_hotkey_action-hotkey = |r|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_diff.clas.abap
@@ -1068,9 +1068,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
 
     DATA: ls_hotkey_action LIKE LINE OF rt_hotkey_actions.
 
-    ls_hotkey_action-name           = |Stage changes|.
-    ls_hotkey_action-action         = |stagePatch|.
-    ls_hotkey_action-default_hotkey = |s|.
+    ls_hotkey_action-name   = |Stage changes|.
+    ls_hotkey_action-action = |stagePatch|.
+    ls_hotkey_action-hotkey = |s|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -44,7 +44,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_main IMPLEMENTATION.
 
 
   METHOD build_main_menu.
@@ -309,56 +309,56 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
 
-    DATA: ls_hotkey_action TYPE zif_abapgit_gui_page_hotkey=>ty_hotkey_action.
+    DATA: ls_hotkey_action TYPE zif_abapgit_gui_page_hotkey=>ty_hotkey_with_name.
 
-    ls_hotkey_action-name           = |abapGit settings|.
-    ls_hotkey_action-action         = zif_abapgit_definitions=>c_action-go_settings.
-    ls_hotkey_action-default_hotkey = |x|.
+    ls_hotkey_action-name   = |abapGit settings|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-go_settings.
+    ls_hotkey_action-hotkey = |x|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name           = |Stage changes|.
-    ls_hotkey_action-action         = zif_abapgit_definitions=>c_action-go_stage.
-    ls_hotkey_action-default_hotkey = |s|.
+    ls_hotkey_action-name   = |Stage changes|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-go_stage.
+    ls_hotkey_action-hotkey = |s|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name           = |Switch branch|.
-    ls_hotkey_action-action         = zif_abapgit_definitions=>c_action-git_branch_switch.
-    ls_hotkey_action-default_hotkey = |b|.
+    ls_hotkey_action-name   = |Switch branch|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-git_branch_switch.
+    ls_hotkey_action-hotkey = |b|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name           = |Installed repo list|.
-    ls_hotkey_action-action         = zif_abapgit_definitions=>c_action-go_repo_overview.
-    ls_hotkey_action-default_hotkey = |o|.
+    ls_hotkey_action-name   = |Installed repo list|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-go_repo_overview.
+    ls_hotkey_action-hotkey = |o|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name           = |Refresh repository|.
-    ls_hotkey_action-action         = zif_abapgit_definitions=>c_action-repo_refresh.
-    ls_hotkey_action-default_hotkey = |r|.
+    ls_hotkey_action-name   = |Refresh repository|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-repo_refresh.
+    ls_hotkey_action-hotkey = |r|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name           = |Pull|.
-    ls_hotkey_action-action         = zif_abapgit_definitions=>c_action-git_pull.
-    ls_hotkey_action-default_hotkey = |p|.
+    ls_hotkey_action-name   = |Pull|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-git_pull.
+    ls_hotkey_action-hotkey = |p|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name           = |Add online repository|.
-    ls_hotkey_action-action         = zif_abapgit_definitions=>c_action-repo_newonline.
-    ls_hotkey_action-default_hotkey = |n|.
+    ls_hotkey_action-name   = |Add online repository|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-repo_newonline.
+    ls_hotkey_action-hotkey = |n|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name           = |Uninstall repository|.
-    ls_hotkey_action-action         = zif_abapgit_definitions=>c_action-repo_purge.
-    ls_hotkey_action-default_hotkey = |u|.
+    ls_hotkey_action-name   = |Uninstall repository|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-repo_purge.
+    ls_hotkey_action-hotkey = |u|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name           = |Show diffs|.
-    ls_hotkey_action-action         = zif_abapgit_definitions=>c_action-go_diff.
-    ls_hotkey_action-default_hotkey = |d|.
+    ls_hotkey_action-name   = |Show diffs|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-go_diff.
+    ls_hotkey_action-hotkey = |d|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-    ls_hotkey_action-name           = |Run code inspector|.
-    ls_hotkey_action-action         = zif_abapgit_definitions=>c_action-repo_code_inspector.
-    ls_hotkey_action-default_hotkey = |i|.
+    ls_hotkey_action-name   = |Run code inspector|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-repo_code_inspector.
+    ls_hotkey_action-hotkey = |i|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -489,11 +489,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
 
-    DATA: ls_hotkey_action TYPE zif_abapgit_gui_page_hotkey=>ty_hotkey_action.
+    DATA: ls_hotkey_action TYPE zif_abapgit_gui_page_hotkey=>ty_hotkey_with_name.
 
-    ls_hotkey_action-name           = |Patch|.
-    ls_hotkey_action-action         = zif_abapgit_definitions=>c_action-go_patch.
-    ls_hotkey_action-default_hotkey = |p|.
+    ls_hotkey_action-name   = |Patch|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-go_patch.
+    ls_hotkey_action-hotkey = |p|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_hotkeys.clas.abap
+++ b/src/ui/zcl_abapgit_hotkeys.clas.abap
@@ -13,12 +13,41 @@ CLASS zcl_abapgit_hotkeys DEFINITION
         RAISING
           zcx_abapgit_exception.
 
-    CLASS-METHODS should_show_hint
-      RETURNING
-        VALUE(rv_yes) TYPE abap_bool.
+    CLASS-METHODS:
+      should_show_hint
+        RETURNING
+          VALUE(rv_yes) TYPE abap_bool.
 
   PRIVATE SECTION.
-    CLASS-DATA gv_hint_was_shown TYPE abap_bool.
+    CONSTANTS:
+      mc_hotkey_interface TYPE string VALUE `ZIF_ABAPGIT_GUI_PAGE_HOTKEY` ##NO_TEXT.
+
+    CLASS-DATA:
+      gv_hint_was_shown            TYPE abap_bool,
+      gt_interface_implementations TYPE saboo_iimpt.
+
+    CLASS-METHODS:
+      get_hotkeys_from_global_intf
+        IMPORTING
+          io_page           TYPE REF TO zcl_abapgit_gui_page
+        RETURNING
+          VALUE(rt_hotkeys) TYPE zif_abapgit_gui_page_hotkey=>tty_hotkey_with_name
+        RAISING
+          cx_class_not_existent,
+
+      get_hotkeys_from_local_intf
+        IMPORTING
+          io_page           TYPE REF TO zcl_abapgit_gui_page
+        RETURNING
+          VALUE(rt_hotkeys) TYPE zif_abapgit_gui_page_hotkey=>tty_hotkey_with_name
+        RAISING
+          zcx_abapgit_exception,
+
+      get_local_intf_implementations
+        RETURNING
+          VALUE(rt_interface_implementations) TYPE saboo_iimpt
+        RAISING
+          zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -29,39 +58,15 @@ CLASS zcl_abapgit_hotkeys IMPLEMENTATION.
 
   METHOD get_all_default_hotkeys.
 
-    DATA: lt_hotkey_actions TYPE zif_abapgit_gui_page_hotkey=>tty_hotkey_with_name,
-          lo_interface      TYPE REF TO cl_oo_interface,
-          lv_class_name     TYPE abap_abstypename,
-          lt_classes        TYPE seo_relkeys,
-          lv_where          TYPE string.
-
-    FIELD-SYMBOLS: <ls_class> TYPE seorelkey.
-
     TRY.
-        lo_interface ?= cl_oo_class=>get_instance( |ZIF_ABAPGIT_GUI_PAGE_HOTKEY| ).
+        rt_hotkey_actions = get_hotkeys_from_global_intf( io_page ).
 
       CATCH cx_class_not_existent.
-        " hotkeys are only available with installed abapGit repository
-        RETURN.
+
+        " abapGit repo isn't installed
+        rt_hotkey_actions = get_hotkeys_from_local_intf( io_page ).
+
     ENDTRY.
-
-    lt_classes = lo_interface->get_implementing_classes( ).
-    IF io_page IS BOUND.
-      lv_class_name = cl_abap_classdescr=>get_class_name( io_page ).
-      SHIFT lv_class_name LEFT DELETING LEADING '\CLASS='.
-      lv_where = |CLSNAME = LV_CLASS_NAME|.
-    ENDIF.
-
-    LOOP AT lt_classes ASSIGNING <ls_class>
-                       WHERE (lv_where).
-
-      CALL METHOD (<ls_class>-clsname)=>zif_abapgit_gui_page_hotkey~get_hotkey_actions
-        RECEIVING
-          rt_hotkey_actions = lt_hotkey_actions.
-
-      INSERT LINES OF lt_hotkey_actions INTO TABLE rt_hotkey_actions.
-
-    ENDLOOP.
 
     " the global shortcuts are defined in the base class
     INSERT LINES OF zcl_abapgit_gui_page=>get_global_hotkeys( ) INTO TABLE rt_hotkey_actions.
@@ -77,4 +82,108 @@ CLASS zcl_abapgit_hotkeys IMPLEMENTATION.
       gv_hint_was_shown = abap_true.
     ENDIF.
   ENDMETHOD.
+
+
+  METHOD get_hotkeys_from_global_intf.
+
+    DATA: lt_hotkey_actions TYPE zif_abapgit_gui_page_hotkey=>tty_hotkey_with_name,
+          lo_interface      TYPE REF TO cl_oo_interface,
+          lv_class_name     TYPE abap_abstypename,
+          lt_classes        TYPE seo_relkeys,
+          lv_where_clause   TYPE string.
+
+    FIELD-SYMBOLS: <ls_class> LIKE LINE OF lt_classes.
+
+    lo_interface ?= cl_oo_class=>get_instance( |{ mc_hotkey_interface }| ).
+    lt_classes = lo_interface->get_implementing_classes( ).
+
+    IF io_page IS BOUND.
+      lv_class_name = cl_abap_classdescr=>get_class_name( io_page ).
+      lv_class_name = substring_after( val   = lv_class_name
+                                       regex = '^\\CLASS=' ).
+      lv_where_clause = |CLSNAME = LV_CLASS_NAME|.
+    ENDIF.
+
+    LOOP AT lt_classes ASSIGNING <ls_class>
+                       WHERE (lv_where_clause).
+
+      CALL METHOD (<ls_class>-clsname)=>zif_abapgit_gui_page_hotkey~get_hotkey_actions
+        RECEIVING
+          rt_hotkey_actions = lt_hotkey_actions.
+
+      INSERT LINES OF lt_hotkey_actions INTO TABLE rt_hotkeys.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD get_hotkeys_from_local_intf.
+
+    DATA: lt_hotkey_actions            TYPE zif_abapgit_gui_page_hotkey=>tty_hotkey_with_name,
+          lv_where_clause              TYPE string,
+          lv_class_name                TYPE abap_abstypename,
+          lt_interface_implementations TYPE saboo_iimpt.
+
+    FIELD-SYMBOLS: <ls_intf_implementation> TYPE vseoimplem.
+
+    lt_interface_implementations = get_local_intf_implementations( ).
+
+    lv_where_clause = |REFCLSNAME = MC_HOTKEY_INTERFACE|.
+
+    IF io_page IS BOUND.
+      lv_class_name = cl_abap_classdescr=>get_class_name( io_page ).
+      lv_class_name = substring_after( val   = lv_class_name
+                                       regex = `^\\PROGRAM=` && sy-cprog && `\\CLASS=` ).
+      lv_where_clause = |{ lv_where_clause } AND CLSNAME = LV_CLASS_NAME|.
+    ENDIF.
+
+    LOOP AT lt_interface_implementations ASSIGNING <ls_intf_implementation>
+                                         WHERE (lv_where_clause).
+
+      CALL METHOD (<ls_intf_implementation>-clsname)=>zif_abapgit_gui_page_hotkey~get_hotkey_actions
+        RECEIVING
+          rt_hotkey_actions = lt_hotkey_actions.
+
+      INSERT LINES OF lt_hotkey_actions INTO TABLE rt_hotkeys.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD get_local_intf_implementations.
+
+    DATA: lt_type_infos             TYPE saboo_vseot,
+          lt_method_implementations TYPE saboo_method_impl_tab,
+          lt_source                 TYPE saboo_sourt.
+
+    IF gt_interface_implementations IS INITIAL.
+
+      READ REPORT sy-cprog INTO lt_source.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise( |Cannot read { sy-cprog }| ).
+      ENDIF.
+
+      CALL FUNCTION 'SCAN_ABAP_OBJECTS_CLASSES'
+        CHANGING
+          vseo_tabs                   = lt_type_infos
+          method_impls                = lt_method_implementations
+          sourc_tab                   = lt_source
+        EXCEPTIONS
+          scan_abap_source_error      = 1
+          scan_abap_src_line_too_long = 2
+          OTHERS                      = 3.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise_t100( ).
+      ENDIF.
+
+      gt_interface_implementations = lt_type_infos-iimpl_tab.
+
+    ENDIF.
+
+    rt_interface_implementations = gt_interface_implementations.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/ui/zif_abapgit_gui_page_hotkey.intf.abap
+++ b/src/ui/zif_abapgit_gui_page_hotkey.intf.abap
@@ -2,19 +2,19 @@ INTERFACE zif_abapgit_gui_page_hotkey
   PUBLIC.
 
   TYPES:
-    BEGIN OF ty_hotkey_action,
-      name           TYPE string,
-      action         TYPE string,
-      default_hotkey TYPE string,
-    END OF ty_hotkey_action,
-    tty_hotkey_action TYPE STANDARD TABLE OF ty_hotkey_action
-                           WITH NON-UNIQUE DEFAULT KEY
-                           WITH NON-UNIQUE SORTED KEY action
-                                COMPONENTS action.
+    BEGIN OF ty_hotkey_with_name.
+      INCLUDE TYPE zif_abapgit_definitions=>ty_hotkey.
+  TYPES:
+    name TYPE string,
+    END OF ty_hotkey_with_name,
+    tty_hotkey_with_name TYPE STANDARD TABLE OF ty_hotkey_with_name
+                              WITH NON-UNIQUE DEFAULT KEY
+                              WITH NON-UNIQUE SORTED KEY action
+                                   COMPONENTS action.
 
-  CLASS-METHODS
+  CLASS-METHODS:
     get_hotkey_actions
       RETURNING
-        VALUE(rt_hotkey_actions) TYPE tty_hotkey_action.
+        VALUE(rt_hotkey_actions) TYPE tty_hotkey_with_name.
 
 ENDINTERFACE.

--- a/src/zcl_abapgit_environment.clas.abap
+++ b/src/zcl_abapgit_environment.clas.abap
@@ -7,15 +7,20 @@ CLASS zcl_abapgit_environment DEFINITION
     CLASS-METHODS is_sap_cloud_platform
       RETURNING
         VALUE(rv_cloud) TYPE abap_bool .
+
+    CLASS-METHODS is_merged
+      RETURNING
+        VALUE(rv_is_merged) TYPE abap_bool .
   PROTECTED SECTION.
 
     CLASS-DATA gv_cloud TYPE abap_bool VALUE abap_undefined ##NO_TEXT.
+    CLASS-DATA gv_is_merged TYPE abap_bool VALUE abap_undefined ##NO_TEXT.
   PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_ENVIRONMENT IMPLEMENTATION.
+CLASS zcl_abapgit_environment IMPLEMENTATION.
 
 
   METHOD is_sap_cloud_platform.
@@ -33,4 +38,25 @@ CLASS ZCL_ABAPGIT_ENVIRONMENT IMPLEMENTATION.
     rv_cloud = gv_cloud.
 
   ENDMETHOD.
+
+
+  METHOD is_merged.
+
+    DATA lo_marker TYPE REF TO data ##NEEDED.
+
+    IF gv_is_merged = abap_undefined.
+      TRY.
+          CREATE DATA lo_marker TYPE REF TO ('LIF_ABAPMERGE_MARKER')  ##no_text.
+          "No exception --> marker found
+          gv_is_merged = abap_true.
+
+        CATCH cx_sy_create_data_error.
+          gv_is_merged = abap_false.
+      ENDTRY.
+    ENDIF.
+
+    rv_is_merged = gv_is_merged.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/zcl_abapgit_serialize.clas.abap
+++ b/src/zcl_abapgit_serialize.clas.abap
@@ -10,12 +10,12 @@ CLASS zcl_abapgit_serialize DEFINITION
         !p_task TYPE clike .
     METHODS serialize
       IMPORTING
-        !it_tadir            TYPE zif_abapgit_definitions=>ty_tadir_tt
-        !iv_language         TYPE langu DEFAULT sy-langu
-        !ii_log              TYPE REF TO zif_abapgit_log OPTIONAL
-        !iv_force_sequential TYPE abap_bool DEFAULT abap_false
+        it_tadir            TYPE zif_abapgit_definitions=>ty_tadir_tt
+        iv_language         TYPE langu DEFAULT sy-langu
+        ii_log              TYPE REF TO zif_abapgit_log OPTIONAL
+        iv_force_sequential TYPE abap_bool DEFAULT abap_false
       RETURNING
-        VALUE(rt_files)      TYPE zif_abapgit_definitions=>ty_files_item_tt
+        VALUE(rt_files)     TYPE zif_abapgit_definitions=>ty_files_item_tt
       RAISING
         zcx_abapgit_exception .
 
@@ -53,14 +53,12 @@ CLASS zcl_abapgit_serialize DEFINITION
         zcx_abapgit_exception .
   PRIVATE SECTION.
 
-    METHODS is_merged
-      RETURNING
-        VALUE(rv_result) TYPE abap_bool .
+
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_SERIALIZE IMPLEMENTATION.
+CLASS zcl_abapgit_serialize IMPLEMENTATION.
 
 
   METHOD add_to_return.
@@ -85,7 +83,7 @@ CLASS ZCL_ABAPGIT_SERIALIZE IMPLEMENTATION.
 
     lo_settings = zcl_abapgit_persist_settings=>get_instance( )->read( ).
 
-    IF is_merged( ) = abap_true
+    IF zcl_abapgit_environment=>is_merged( ) = abap_true
         OR lo_settings->get_parallel_proc_disabled( ) = abap_true.
       gv_max_threads = 1.
     ENDIF.
@@ -151,21 +149,6 @@ CLASS ZCL_ABAPGIT_SERIALIZE IMPLEMENTATION.
     ENDIF.
 
     rv_threads = gv_max_threads.
-
-  ENDMETHOD.
-
-
-  METHOD is_merged.
-
-    DATA lo_marker TYPE REF TO data ##NEEDED.
-
-    TRY.
-        CREATE DATA lo_marker TYPE REF TO ('LIF_ABAPMERGE_MARKER')  ##no_text.
-        "No exception --> marker found
-        rv_result = abap_true.
-
-      CATCH cx_sy_create_data_error  ##no_handler.
-    ENDTRY.
 
   ENDMETHOD.
 

--- a/src/zcl_abapgit_settings.clas.abap
+++ b/src/zcl_abapgit_settings.clas.abap
@@ -152,7 +152,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_SETTINGS IMPLEMENTATION.
+CLASS zcl_abapgit_settings IMPLEMENTATION.
 
 
   METHOD get_adt_jump_enabled.
@@ -176,31 +176,7 @@ CLASS ZCL_ABAPGIT_SETTINGS IMPLEMENTATION.
 
 
   METHOD get_hotkeys.
-
-    DATA: lt_default_hotkeys TYPE zif_abapgit_gui_page_hotkey=>tty_hotkey_action,
-          ls_hotkey          LIKE LINE OF rt_hotkeys.
-
-    FIELD-SYMBOLS: <ls_default_hotkey> LIKE LINE OF lt_default_hotkeys.
-
-    IF lines( ms_user_settings-hotkeys ) > 0.
-
-      rt_hotkeys = ms_user_settings-hotkeys.
-
-    ELSE.
-
-      " provide default hotkeys
-      lt_default_hotkeys = zcl_abapgit_hotkeys=>get_default_hotkeys_from_pages( ).
-
-      LOOP AT lt_default_hotkeys ASSIGNING <ls_default_hotkey>.
-
-        ls_hotkey-action   = <ls_default_hotkey>-action.
-        ls_hotkey-sequence = <ls_default_hotkey>-default_hotkey.
-        INSERT ls_hotkey INTO TABLE rt_hotkeys.
-
-      ENDLOOP.
-
-    ENDIF.
-
+    rt_hotkeys = ms_user_settings-hotkeys.
   ENDMETHOD.
 
 

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -24,7 +24,7 @@ INTERFACE zif_abapgit_definitions
            ty_file_signature WITH UNIQUE KEY path filename .
   TYPES:
     BEGIN OF ty_file.
-          INCLUDE TYPE ty_file_signature.
+      INCLUDE TYPE ty_file_signature.
   TYPES: data TYPE xstring,
          END OF ty_file .
   TYPES:
@@ -60,12 +60,14 @@ INTERFACE zif_abapgit_definitions
     ty_git_tag_list_tt TYPE STANDARD TABLE OF ty_git_tag WITH DEFAULT KEY .
   TYPES:
     BEGIN OF ty_hotkey,
-      sequence TYPE string,
-      action   TYPE string,
+      action TYPE string,
+      hotkey TYPE string,
     END OF ty_hotkey .
   TYPES:
     tty_hotkey TYPE STANDARD TABLE OF ty_hotkey
-                    WITH NON-UNIQUE DEFAULT KEY .
+                    WITH NON-UNIQUE DEFAULT KEY
+                    WITH NON-UNIQUE SORTED KEY action
+                         COMPONENTS action.
   TYPES:
     BEGIN OF ty_git_user,
       name  TYPE string,
@@ -99,7 +101,7 @@ INTERFACE zif_abapgit_definitions
     ty_yes_no TYPE c LENGTH 1 .
   TYPES:
     BEGIN OF ty_overwrite.
-          INCLUDE TYPE ty_item.
+      INCLUDE TYPE ty_item.
   TYPES: decision TYPE ty_yes_no,
          END OF ty_overwrite .
   TYPES:
@@ -202,7 +204,7 @@ INTERFACE zif_abapgit_definitions
     ty_seocompotx_tt TYPE STANDARD TABLE OF seocompotx WITH DEFAULT KEY .
   TYPES:
     BEGIN OF ty_tpool.
-          INCLUDE TYPE textpool.
+      INCLUDE TYPE textpool.
   TYPES:   split TYPE c LENGTH 8.
   TYPES: END OF ty_tpool .
   TYPES:


### PR DESCRIPTION
When this commit is applied hotkeys also work with
the single abapGit report. ~~Limitation is still that users
only can override hotkeys with the installed abapGit repo.~~

#2629 