### PR TITLE
Avoid DYNPRO_SEND_IN_BACKGROUND while ADT Pull

### DIFF
--- a/src/objects/zcl_abapgit_object_cmpt.clas.abap
+++ b/src/objects/zcl_abapgit_object_cmpt.clas.abap
@@ -120,6 +120,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CMPT IMPLEMENTATION.
         global_lock         = abap_true
         devclass            = iv_package
         master_language     = mv_language
+        suppress_dialog     = abap_true
       EXCEPTIONS
         cancelled           = 1
         permission_failure  = 2

--- a/src/objects/zcl_abapgit_object_cus0.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus0.clas.abap
@@ -89,6 +89,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CUS0 IMPLEMENTATION.
         global_lock         = abap_true
         devclass            = iv_package
         master_language     = sy-langu
+        suppress_dialog     = abap_true
       EXCEPTIONS
         cancelled           = 1
         permission_failure  = 2

--- a/src/objects/zcl_abapgit_object_cus1.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus1.clas.abap
@@ -107,6 +107,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CUS1 IMPLEMENTATION.
         global_lock         = abap_true
         devclass            = iv_package
         master_language     = sy-langu
+        suppress_dialog     = abap_true
       EXCEPTIONS
         cancelled           = 1
         permission_failure  = 2

--- a/src/objects/zcl_abapgit_object_msag.clas.abap
+++ b/src/objects/zcl_abapgit_object_msag.clas.abap
@@ -297,6 +297,7 @@ CLASS ZCL_ABAPGIT_OBJECT_MSAG IMPLEMENTATION.
         object             = lv_message_id
         object_class       = 'MSAG'
         mode               = 'D'
+        suppress_dialog    = abap_true
       EXCEPTIONS
         cancelled          = 01
         permission_failure = 02.

--- a/src/objects/zcl_abapgit_object_para.clas.abap
+++ b/src/objects/zcl_abapgit_object_para.clas.abap
@@ -70,6 +70,7 @@ CLASS ZCL_ABAPGIT_OBJECT_PARA IMPLEMENTATION.
         object              = lv_paramid
         object_class        = 'PARA'
         mode                = 'D'
+        suppress_dialog     = abap_true
       IMPORTING
         transport_key       = ls_transpkey
       EXCEPTIONS
@@ -124,6 +125,7 @@ CLASS ZCL_ABAPGIT_OBJECT_PARA IMPLEMENTATION.
         global_lock         = abap_true
         devclass            = iv_package
         master_language     = mv_language
+        suppress_dialog     = abap_true
       EXCEPTIONS
         cancelled           = 1
         permission_failure  = 2

--- a/src/objects/zcl_abapgit_object_udmo.clas.abap
+++ b/src/objects/zcl_abapgit_object_udmo.clas.abap
@@ -205,6 +205,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UDMO IMPLEMENTATION.
         master_language     = mv_language
         mode                = 'INSERT'
         global_lock         = abap_true
+        suppress_dialog     = abap_true
       EXCEPTIONS
         cancelled           = 1
         permission_failure  = 2

--- a/src/objects/zcl_abapgit_object_vcls.clas.abap
+++ b/src/objects/zcl_abapgit_object_vcls.clas.abap
@@ -104,6 +104,7 @@ CLASS ZCL_ABAPGIT_OBJECT_VCLS IMPLEMENTATION.
         master_language     = mv_language
         mode                = 'INSERT'
         global_lock         = abap_true
+        suppress_dialog     = abap_true
       EXCEPTIONS
         cancelled           = 1
         permission_failure  = 2

--- a/src/objects/zcl_abapgit_objects_generic.clas.abap
+++ b/src/objects/zcl_abapgit_objects_generic.clas.abap
@@ -219,6 +219,7 @@ CLASS ZCL_ABAPGIT_OBJECTS_GENERIC IMPLEMENTATION.
         global_lock         = abap_true
         devclass            = iv_package
         master_language     = sy-langu
+        suppress_dialog     = abap_true
       EXCEPTIONS
         cancelled           = 1
         permission_failure  = 2

--- a/src/objects/zcl_abapgit_objects_saxx_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_saxx_super.clas.abap
@@ -254,6 +254,7 @@ CLASS ZCL_ABAPGIT_OBJECTS_SAXX_SUPER IMPLEMENTATION.
             global_lock         = abap_true
             devclass            = iv_package
             master_language     = mv_language
+            suppress_dialog     = abap_true
           EXCEPTIONS
             cancelled           = 1
             permission_failure  = 2

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -164,7 +164,6 @@ CLASS ZCL_ABAPGIT_OBJECTS_SUPER IMPLEMENTATION.
         devclass            = iv_package
         master_language     = mv_language
         global_lock         = abap_true
-        author              = sy-uname
         mode                = 'I'
         suppress_dialog     = abap_true
       EXCEPTIONS

--- a/src/objects/zcl_abapgit_oo_interface.clas.abap
+++ b/src/objects/zcl_abapgit_oo_interface.clas.abap
@@ -30,6 +30,7 @@ CLASS ZCL_ABAPGIT_OO_INTERFACE IMPLEMENTATION.
       EXPORTING
         devclass        = iv_package
         overwrite       = iv_overwrite
+        suppress_dialog = abap_true
       CHANGING
         interface       = cg_properties
         attributes      = lt_vseoattrib

--- a/src/ui/zcl_abapgit_password_dialog.clas.abap
+++ b/src/ui/zcl_abapgit_password_dialog.clas.abap
@@ -37,8 +37,8 @@ CLASS ZCL_ABAPGIT_PASSWORD_DIALOG IMPLEMENTATION.
           CALL METHOD ('ZCL_ABAPGIT_DEFAULT_AUTH_INFO')=>('GET_USER')
             RECEIVING
               rv_user = cv_user.
-          CATCH cx_root.
-            RETURN.
+        CATCH cx_root.
+          RETURN.
       ENDTRY.
       TRY.
           CALL METHOD ('ZCL_ABAPGIT_DEFAULT_AUTH_INFO')=>('GET_PASSWORD')

--- a/src/ui/zcl_abapgit_password_dialog.clas.abap
+++ b/src/ui/zcl_abapgit_password_dialog.clas.abap
@@ -22,10 +22,39 @@ CLASS ZCL_ABAPGIT_PASSWORD_DIALOG IMPLEMENTATION.
 
   METHOD popup.
 
-    PERFORM password_popup
-      IN PROGRAM (sy-cprog)
-      USING iv_repo_url
-      CHANGING cv_user cv_pass.
+    DATA lv_gui_is_available TYPE abap_bool.
+
+    lv_gui_is_available = zcl_abapgit_ui_factory=>get_gui_functions( )->gui_is_available( ).
+
+    IF lv_gui_is_available = abap_true.
+      PERFORM password_popup
+        IN PROGRAM (sy-cprog)
+        USING iv_repo_url
+        CHANGING cv_user cv_pass.
+    ELSE.
+      "check if ZCL_ABAPGIT_DEFAULT_AUTH_INFO exists (part of ADT_Backend project)
+      TRY.
+          CALL METHOD ('ZCL_ABAPGIT_DEFAULT_AUTH_INFO')=>('GET_USER')
+            RECEIVING
+              rv_user = cv_user.
+          CATCH cx_root.
+            RETURN.
+      ENDTRY.
+      TRY.
+          CALL METHOD ('ZCL_ABAPGIT_DEFAULT_AUTH_INFO')=>('GET_PASSWORD')
+            RECEIVING
+              rv_password = cv_pass.
+        CATCH cx_root.
+          "check if old version with typo in method name exists
+          TRY.
+              CALL METHOD ('ZCL_ABAPGIT_DEFAULT_AUTH_INFO')=>('GET_PASSOWORD')
+                RECEIVING
+                  rv_password = cv_pass.
+            CATCH cx_root.
+              RETURN.
+          ENDTRY.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/zcl_abapgit_password_dialog.clas.abap
+++ b/src/ui/zcl_abapgit_password_dialog.clas.abap
@@ -22,39 +22,10 @@ CLASS ZCL_ABAPGIT_PASSWORD_DIALOG IMPLEMENTATION.
 
   METHOD popup.
 
-    DATA lv_gui_is_available TYPE abap_bool.
-
-    lv_gui_is_available = zcl_abapgit_ui_factory=>get_gui_functions( )->gui_is_available( ).
-
-    IF lv_gui_is_available = abap_true.
-      PERFORM password_popup
-        IN PROGRAM (sy-cprog)
-        USING iv_repo_url
-        CHANGING cv_user cv_pass.
-    ELSE.
-      "check if ZCL_ABAPGIT_DEFAULT_AUTH_INFO exists (part of ADT_Backend project)
-      TRY.
-          CALL METHOD ('ZCL_ABAPGIT_DEFAULT_AUTH_INFO')=>('GET_USER')
-            RECEIVING
-              rv_user = cv_user.
-        CATCH cx_root.
-          RETURN.
-      ENDTRY.
-      TRY.
-          CALL METHOD ('ZCL_ABAPGIT_DEFAULT_AUTH_INFO')=>('GET_PASSWORD')
-            RECEIVING
-              rv_password = cv_pass.
-        CATCH cx_root.
-          "check if old version with typo in method name exists
-          TRY.
-              CALL METHOD ('ZCL_ABAPGIT_DEFAULT_AUTH_INFO')=>('GET_PASSOWORD')
-                RECEIVING
-                  rv_password = cv_pass.
-            CATCH cx_root.
-              RETURN.
-          ENDTRY.
-      ENDTRY.
-    ENDIF.
+    PERFORM password_popup
+      IN PROGRAM (sy-cprog)
+      USING iv_repo_url
+      CHANGING cv_user cv_pass.
 
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
When ADT (aka ABAP in Eclipse) is used to trigger a pull request, there is no SAPGUI available in the backend system. Whenever a dynpro is called, a DYNPRO_SEND_IN_BACKGROUND short dump occurs.
This commit fixes issue #2632.

Additional remark: In case of a private repository, username and password are passed to the backend system. The ADT backend coding currently handles this via class ZCL_ABAPGIT_DEFAULT_AUTH_INFO. To avoid sending a password dialog in the backend system, class CL_ABAPGIT_PASSWORD_DIALOG needs to be adjusted to take over user/pw from ZCL_ABAPGIT_DEFAULT_AUTH_INFO in a generic way. I know this is not nice and it would be better to have ZCL_ABAPGIT_DEFAULT_AUTH_INFO in ZABAPGIT. Even the best solution would be to re-use ZCL_ABAPGIT_LOGIN_MANAGER instead, but I would recommend to refactor this in a new pull request later on...