### PR TITLE
Allow access to private repos when using ADT

### DIFF
--- a/src/ui/zcl_abapgit_password_dialog.clas.abap
+++ b/src/ui/zcl_abapgit_password_dialog.clas.abap
@@ -32,7 +32,12 @@ CLASS ZCL_ABAPGIT_PASSWORD_DIALOG IMPLEMENTATION.
         USING iv_repo_url
         CHANGING cv_user cv_pass.
     ELSE.
-      "check if ZCL_ABAPGIT_DEFAULT_AUTH_INFO exists (part of ADT_Backend project)
+      "Extract user credentials from the environment...
+      "Class ZCL_ABAPGIT_DEFAULT_AUTH_INFO is part of https://github.com/abapGit/ADT_Backend.
+      "It stores the credentials of a private repository as long as the session exists.
+      "Usually this class should belong to abapGit core and a refactoring is recommended.
+      "As a temporary solution - and to avoid a DYNPRO_SEND_IN_BACKGROUND dump - a generic
+      "call of the getter methods for username and password is implemented by PR#2635.
       TRY.
           CALL METHOD ('ZCL_ABAPGIT_DEFAULT_AUTH_INFO')=>('GET_USER')
             RECEIVING

--- a/src/ui/zcl_abapgit_password_dialog.clas.abap
+++ b/src/ui/zcl_abapgit_password_dialog.clas.abap
@@ -22,10 +22,39 @@ CLASS ZCL_ABAPGIT_PASSWORD_DIALOG IMPLEMENTATION.
 
   METHOD popup.
 
-    PERFORM password_popup
-      IN PROGRAM (sy-cprog)
-      USING iv_repo_url
-      CHANGING cv_user cv_pass.
+    DATA lv_gui_is_available TYPE abap_bool.
+
+    lv_gui_is_available = zcl_abapgit_ui_factory=>get_gui_functions( )->gui_is_available( ).
+
+    IF lv_gui_is_available = abap_true.
+      PERFORM password_popup
+        IN PROGRAM (sy-cprog)
+        USING iv_repo_url
+        CHANGING cv_user cv_pass.
+    ELSE.
+      "check if ZCL_ABAPGIT_DEFAULT_AUTH_INFO exists (part of ADT_Backend project)
+      TRY.
+          CALL METHOD ('ZCL_ABAPGIT_DEFAULT_AUTH_INFO')=>('GET_USER')
+            RECEIVING
+              rv_user = cv_user.
+        CATCH cx_root.
+          RETURN.
+      ENDTRY.
+      TRY.
+          CALL METHOD ('ZCL_ABAPGIT_DEFAULT_AUTH_INFO')=>('GET_PASSWORD')
+            RECEIVING
+              rv_password = cv_pass.
+        CATCH cx_root.
+          "check if old version with typo in method name exists
+          TRY.
+              CALL METHOD ('ZCL_ABAPGIT_DEFAULT_AUTH_INFO')=>('GET_PASSOWORD')
+                RECEIVING
+                  rv_password = cv_pass.
+            CATCH cx_root.
+              RETURN.
+          ENDTRY.
+      ENDTRY.
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
In case of using a private repository in ADT (aka ABAP in Eclipse), username and password are passed to the backend system. The ADT backend coding currently handles this via class ZCL_ABAPGIT_DEFAULT_AUTH_INFO. To avoid sending a password dialog in the backend system, class CL_ABAPGIT_PASSWORD_DIALOG needs to be adjusted to take over user/pw from ZCL_ABAPGIT_DEFAULT_AUTH_INFO in a generic way. I know this is not nice and it would be better to have ZCL_ABAPGIT_DEFAULT_AUTH_INFO in ZABAPGIT. Even the best solution would be to re-use ZCL_ABAPGIT_LOGIN_MANAGER instead, but I would recommend to refactor this in a new pull request later on...
This fixes an addition to #2634 because it might not cause a DYNPRO_SEND_IN_BACKGROUND dump