### PR TITLE
RS_CUA_INTERNAL_WRITE another fix

### DIFF
--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -196,7 +196,8 @@ CLASS ZCL_ABAPGIT_OBJECTS_PROGRAM IMPLEMENTATION.
       <ls_act> TYPE rsmpe_act,
       <ls_men> TYPE rsmpe_men.
 
-    IF cs_adm IS NOT INITIAL.
+    IF cs_adm IS NOT INITIAL
+    AND cs_adm-actcode <> 'X'. "Fix 26-04-2019 : somehow an 'X' value is found in ACTCODE and has to be fixed by this method, the RS_CUA_INTERNAL_WRITE fail with sy-subrc = 2
       RETURN.
     ENDIF.
 

--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -197,7 +197,7 @@ CLASS ZCL_ABAPGIT_OBJECTS_PROGRAM IMPLEMENTATION.
       <ls_men> TYPE rsmpe_men.
 
     IF cs_adm IS NOT INITIAL
-    AND cs_adm-actcode <> 'X'. "Fix 26-04-2019 : somehow an 'X' value is found in ACTCODE and has to be fixed by this method, the RS_CUA_INTERNAL_WRITE fail with sy-subrc = 2
+    AND cs_adm-actcode <> 'X'. "Allow 'X' values to be fixed as well
       RETURN.
     ENDIF.
 

--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -191,30 +191,37 @@ CLASS ZCL_ABAPGIT_OBJECTS_PROGRAM IMPLEMENTATION.
 
   METHOD auto_correct_cua_adm.
     " issue #1807 automatic correction of CUA interfaces saved incorrectly in the past (ADM was not saved in the XML)
+
+    CONSTANTS:
+      lc_num_n_space TYPE string VALUE ' 0123456789',
+      lc_num_only    TYPE string VALUE '0123456789'.
+
     FIELD-SYMBOLS:
       <ls_pfk> TYPE rsmpe_pfk,
       <ls_act> TYPE rsmpe_act,
       <ls_men> TYPE rsmpe_men.
 
     IF cs_adm IS NOT INITIAL
-    AND cs_adm-actcode <> 'X'. "Allow 'X' values to be fixed as well
+    AND (     cs_adm-actcode CO lc_num_n_space
+          AND cs_adm-mencode CO lc_num_n_space
+          AND cs_adm-pfkcode CO lc_num_n_space ). "Check performed in form check_adm of include LSMPIF03
       RETURN.
     ENDIF.
 
     LOOP AT is_cua-act ASSIGNING <ls_act>.
-      IF <ls_act>-code+6(14) IS INITIAL AND <ls_act>-code(6) CO '0123456789'.
+      IF <ls_act>-code+6(14) IS INITIAL AND <ls_act>-code(6) CO lc_num_only.
         cs_adm-actcode = <ls_act>-code.
       ENDIF.
     ENDLOOP.
 
     LOOP AT is_cua-men ASSIGNING <ls_men>.
-      IF <ls_men>-code+6(14) IS INITIAL AND <ls_men>-code(6) CO '0123456789'.
+      IF <ls_men>-code+6(14) IS INITIAL AND <ls_men>-code(6) CO lc_num_only.
         cs_adm-mencode = <ls_men>-code.
       ENDIF.
     ENDLOOP.
 
     LOOP AT is_cua-pfk ASSIGNING <ls_pfk>.
-      IF <ls_pfk>-code+6(14) IS INITIAL AND <ls_pfk>-code(6) CO '0123456789'.
+      IF <ls_pfk>-code+6(14) IS INITIAL AND <ls_pfk>-code(6) CO lc_num_only.
         cs_adm-pfkcode = <ls_pfk>-code.
       ENDIF.
     ENDLOOP.


### PR DESCRIPTION
Hi !

I encountered a situation on my project where on pulling code from a zip file, the error RS_CUA_INTERNAL_WRITE sy-subrc = 2 was raised
The error was due to the content of XML file exported : <CUA><ADM>ACTCODE was containing an 'X' value for a single file. I corrected the file putting it blank and it worked. But it's a fastidious task so I fixed the method ZCL_ABAPGIT_OBJECTS_PROGRAM->auto_correct_cua_adm in order to fix this field also when it contains only an 'X'. Tested ok on my system so I propose this small change.