### PR TITLE
Change behavior of second back button to go home

### DIFF
--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -265,6 +265,7 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
     DATA ls_stack LIKE LINE OF mt_stack.
 
     IF mi_router IS BOUND.
+      CLEAR mt_stack.
       on_event( action = |{ c_action-go_home }| ). " doesn't accept strings directly
     ELSE.
       IF lines( mt_stack ) > 0.

--- a/src/zabapgit_forms.prog.abap
+++ b/src/zabapgit_forms.prog.abap
@@ -124,17 +124,9 @@ FORM exit RAISING zcx_abapgit_exception.
         LEAVE TO SCREEN 1001.
       ENDIF.
     WHEN 'CEND'.
-      PERFORM on_exit_pressed.
+      zcl_abapgit_ui_factory=>get_gui( )->go_home( ).
+      LEAVE TO SCREEN 1001.
   ENDCASE.
-ENDFORM.
-
-FORM on_exit_pressed RAISING zcx_abapgit_exception.
-  IF zcl_abapgit_persist_settings=>get_instance( )->read( )->get_show_default_repo( ) = abap_false.
-    " Don't show the last seen repo at startup
-    zcl_abapgit_persistence_user=>get_instance( )->set_repo_show( || ).
-  ENDIF.
-  zcl_abapgit_ui_factory=>get_gui( )->go_home( ).
-  LEAVE TO SCREEN 1001.
 ENDFORM.
 
 FORM password_popup

--- a/src/zabapgit_forms.prog.abap
+++ b/src/zabapgit_forms.prog.abap
@@ -123,9 +123,18 @@ FORM exit RAISING zcx_abapgit_exception.
       ELSE.
         LEAVE TO SCREEN 1001.
       ENDIF.
-    WHEN 'CEND'. "Exit
-      PERFORM open_gui.
+    WHEN 'CEND'.
+      PERFORM on_exit_pressed.
   ENDCASE.
+ENDFORM.
+
+FORM on_exit_pressed RAISING zcx_abapgit_exception.
+  IF zcl_abapgit_persist_settings=>get_instance( )->read( )->get_show_default_repo( ) = abap_false.
+    " Don't show the last seen repo at startup
+    zcl_abapgit_persistence_user=>get_instance( )->set_repo_show( || ).
+  ENDIF.
+  zcl_abapgit_ui_factory=>get_gui( )->go_home( ).
+  LEAVE TO SCREEN 1001.
 ENDFORM.
 
 FORM password_popup

--- a/src/zabapgit_forms.prog.abap
+++ b/src/zabapgit_forms.prog.abap
@@ -124,7 +124,9 @@ FORM exit RAISING zcx_abapgit_exception.
         LEAVE TO SCREEN 1001.
       ENDIF.
     WHEN 'CEND'.
-      zcl_abapgit_ui_factory=>get_gui( )->go_home( ).
+      DATA li_page TYPE REF TO zif_abapgit_gui_renderable.
+      CREATE OBJECT li_page TYPE zcl_abapgit_gui_page_main.
+      zcl_abapgit_ui_factory=>get_gui( )->go_page( li_page ).
       LEAVE TO SCREEN 1001.
   ENDCASE.
 ENDFORM.

--- a/src/zabapgit_forms.prog.abap
+++ b/src/zabapgit_forms.prog.abap
@@ -116,6 +116,7 @@ FORM output.
 ENDFORM.
 
 FORM exit RAISING zcx_abapgit_exception.
+  DATA li_page TYPE REF TO zif_abapgit_gui_renderable.
   CASE sy-ucomm.
     WHEN 'CBAC'.  "Back
       IF zcl_abapgit_ui_factory=>get_gui( )->back( ) = abap_true. " end of stack
@@ -124,7 +125,6 @@ FORM exit RAISING zcx_abapgit_exception.
         LEAVE TO SCREEN 1001.
       ENDIF.
     WHEN 'CEND'.
-      DATA li_page TYPE REF TO zif_abapgit_gui_renderable.
       CREATE OBJECT li_page TYPE zcl_abapgit_gui_page_main.
       zcl_abapgit_ui_factory=>get_gui( )->go_page( li_page ).
       LEAVE TO SCREEN 1001.

--- a/src/zabapgit_forms.prog.abap
+++ b/src/zabapgit_forms.prog.abap
@@ -123,6 +123,8 @@ FORM exit RAISING zcx_abapgit_exception.
       ELSE.
         LEAVE TO SCREEN 1001.
       ENDIF.
+    WHEN 'CEND'. "Exit
+      PERFORM open_gui.
   ENDCASE.
 ENDFORM.
 


### PR DESCRIPTION
Mentioned in #2615 .

Although the button says exit, there's no reason to have two of them. Now the buttons do `back`, `home`, `exit`.
Respects the `show last repo` setting.