### PR TITLE
Patch: replace links with checkboxes #2673

### DIFF
--- a/src/ui/core/zcl_abapgit_html.clas.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.abap
@@ -24,6 +24,7 @@ CLASS zcl_abapgit_html DEFINITION
         !iv_class TYPE string OPTIONAL .
   PROTECTED SECTION.
   PRIVATE SECTION.
+    CONSTANTS: co_span_link_hint TYPE string VALUE `<span class="tooltiptext hidden"></span>`.
     CLASS-DATA: go_single_tags_re TYPE REF TO cl_abap_regex.
 
     DATA: mt_buffer TYPE string_table.
@@ -203,8 +204,7 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
           lv_href  TYPE string,
           lv_click TYPE string,
           lv_id    TYPE string,
-          lv_style TYPE string,
-          lv_span  TYPE string.
+          lv_style TYPE string.
 
     lv_class = iv_class.
 
@@ -245,9 +245,7 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
       lv_style = | style="{ iv_style }"|.
     ENDIF.
 
-    lv_span = |<span class="tooltiptext hidden"></span>|.
-
-    rv_str = |<a{ lv_id }{ lv_class }{ lv_href }{ lv_click }{ lv_style }>{ iv_txt }{ lv_span }</a>|.
+    rv_str = |<a{ lv_id }{ lv_class }{ lv_href }{ lv_click }{ lv_style }>{ iv_txt }{ co_span_link_hint }</a>|.
 
   ENDMETHOD.
 
@@ -359,11 +357,8 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
 
   METHOD checkbox.
 
-    DATA: lv_span TYPE string.
-
-    lv_span = |<span class="tooltiptext hidden"></span>|.
     rv_html = |<input type="checkbox" id="{ iv_id }">|
-           && |{ lv_span }|.
+           && |{ co_span_link_hint }|.
 
   ENDMETHOD.
 

--- a/src/ui/core/zcl_abapgit_html.clas.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.abap
@@ -6,12 +6,13 @@ CLASS zcl_abapgit_html DEFINITION
     INTERFACES zif_abapgit_html.
 
     ALIASES:
-      add      FOR zif_abapgit_html~add,
-      render   FOR zif_abapgit_html~render,
-      is_empty FOR zif_abapgit_html~is_empty,
-      add_a    FOR zif_abapgit_html~add_a,
-      a        FOR zif_abapgit_html~a,
-      icon     FOR zif_abapgit_html~icon.
+      add          FOR zif_abapgit_html~add,
+      render       FOR zif_abapgit_html~render,
+      is_empty     FOR zif_abapgit_html~is_empty,
+      add_a        FOR zif_abapgit_html~add_a,
+      add_checkbox FOR zif_abapgit_html~add_checkbox,
+      a            FOR zif_abapgit_html~a,
+      icon         FOR zif_abapgit_html~icon.
 
     CONSTANTS c_indent_size TYPE i VALUE 2 ##NO_TEXT.
 
@@ -59,6 +60,11 @@ CLASS zcl_abapgit_html DEFINITION
         is_context       TYPE ty_indent_context
       RETURNING
         VALUE(rs_result) TYPE ty_study_result.
+    METHODS checkbox
+      IMPORTING
+        iv_id          TYPE string
+      RETURNING
+        VALUE(rv_html) TYPE string.
 
 ENDCLASS.
 
@@ -343,4 +349,16 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
     CONCATENATE LINES OF lt_temp INTO rv_html SEPARATED BY cl_abap_char_utilities=>newline.
 
   ENDMETHOD.
+
+  METHOD zif_abapgit_html~add_checkbox.
+
+    add( checkbox( iv_id ) ).
+
+  ENDMETHOD.
+
+
+  METHOD checkbox.
+    rv_html = |<input type="checkbox" id="{ iv_id }">|.
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/ui/core/zcl_abapgit_html.clas.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.abap
@@ -358,7 +358,13 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
 
 
   METHOD checkbox.
-    rv_html = |<input type="checkbox" id="{ iv_id }">|.
+
+    DATA: lv_span TYPE string.
+
+    lv_span = |<span class="tooltiptext hidden"></span>|.
+    rv_html = |<input type="checkbox" id="{ iv_id }">|
+           && |{ lv_span }|.
+
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/ui/core/zif_abapgit_html.intf.abap
+++ b/src/ui/core/zif_abapgit_html.intf.abap
@@ -35,6 +35,9 @@ INTERFACE zif_abapgit_html PUBLIC.
       !iv_class TYPE string OPTIONAL
       !iv_id    TYPE string OPTIONAL
       !iv_style TYPE string OPTIONAL.
+  METHODS add_checkbox
+    IMPORTING
+      iv_id type string.
   CLASS-METHODS a
     IMPORTING
       !iv_txt       TYPE string

--- a/src/ui/core/zif_abapgit_html.intf.abap
+++ b/src/ui/core/zif_abapgit_html.intf.abap
@@ -37,7 +37,7 @@ INTERFACE zif_abapgit_html PUBLIC.
       !iv_style TYPE string OPTIONAL.
   METHODS add_checkbox
     IMPORTING
-      iv_id type string.
+      iv_id TYPE string.
   CLASS-METHODS a
     IMPORTING
       !iv_txt       TYPE string

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -531,7 +531,7 @@ table.diff_tab td.num, th.num {
 }
 table.diff_tab td.patch, th.patch {
   width: 1%;
-  min-width: 6em;
+  min-width: 1.5em;
   padding-right: 8px;
   padding-left:  8px;
   text-align: right !important;
@@ -932,12 +932,6 @@ div.info-panel div.info-list td {
     border-style: solid;
     border-color: #555 transparent transparent transparent;
 }
-
-/* diff-patch */
-.patch-active {
-  color: lightgrey !important; 
-}
-
 
 /* HOTKEYS */
 ul.hotkeys {

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -839,7 +839,7 @@ LinkHints.prototype.tooltipActivate = function (oTooltip) {
 
   if (elInput) {
     // case 1) toggle the checkbox
-    elInput.checked = !elInput.checked;
+    elInput.click();
   } else {
     // case 2) click the link
     oTooltip.parentElement.click();

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -1114,12 +1114,12 @@ Patch.prototype.preparePatch = function(){
 
 Patch.prototype.registerClickHandlerForFiles = function(){
   // registers the link handlers for add and remove files
-  this.registerClickHandlerForPatchFile("input[id^='" + PatchFile.prototype.ID + "']");
+  this.registerClickHandlerForSelector("input[id^='" + PatchFile.prototype.ID + "']", this.onClickFileCheckbox);
 };
 
 Patch.prototype.registerClickHandlerForSections = function(){
   // registers the link handlers for add and remove sections
-  this.registerClickHandlerForPatchSection("input[id^='" + PatchSection.prototype.ID + "']");
+  this.registerClickHandlerForSelector("input[id^='" + PatchSection.prototype.ID + "']", this.onClickSectionCheckbox);
 };
 
 Patch.prototype.registerClickHandlerForSelector = function(sSelector, fnCallback){
@@ -1130,14 +1130,6 @@ Patch.prototype.registerClickHandlerForSelector = function(sSelector, fnCallback
     elem.addEventListener("click", fnCallback.bind(this));
   }.bind(this));
 
-};
-
-Patch.prototype.registerClickHandlerForPatchFile = function(sSelector){
-  this.registerClickHandlerForSelector(sSelector, this.onClickFileCheckbox);
-};
-
-Patch.prototype.registerClickHandlerForPatchSection = function(sSelector){
-  this.registerClickHandlerForSelector(sSelector, this.onClickSectionCheckbox);
 };
 
 Patch.prototype.getAllLineCheckboxesForId = function(sId, sIdPrefix){
@@ -1167,10 +1159,10 @@ Patch.prototype.getAllLineCheckboxesForSection = function(oSection){
 Patch.prototype.onClickFileCheckbox = function(oEvent) {
 
   var oFile = new PatchFile(oEvent.srcElement.id);
-  var elAllCheckboxLinksOfFile = this.getAllLineCheckboxesForFile(oFile);
+  var elAllLineCheckboxesOfFile = this.getAllLineCheckboxesForFile(oFile);
   var elAllSectionCheckboxesOfFile = this.getAllSectionCheckboxesForFile(oFile);
 
-  [].forEach.call(elAllCheckboxLinksOfFile,function(elem){
+  [].forEach.call(elAllLineCheckboxesOfFile,function(elem){
     elem.checked = oEvent.srcElement.checked;
   }.bind(this));
 
@@ -1212,14 +1204,14 @@ Patch.prototype.stagePatch = function() {
 
   // Collect add and remove info and submit to backend
 
-  var aAddPatch = this.collectElementsForId( PatchLine.prototype.ID, true );
-  var aRemovePatch = this.collectElementsForId( PatchLine.prototype.ID, false);
+  var aAddPatch = this.collectElementsForCheckboxId(PatchLine.prototype.ID, true);
+  var aRemovePatch = this.collectElementsForCheckboxId(PatchLine.prototype.ID, false);
 
   submitSapeventForm({"add": aAddPatch, "remove": aRemovePatch}, this.ACTION.PATCH_STAGE, "post");
 
 };
 
-Patch.prototype.collectElementsForId = function(sId, bChecked){
+Patch.prototype.collectElementsForCheckboxId = function(sId, bChecked){
 
   var sSelector = "input[id^='" + sId + "']";
 

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -1024,10 +1024,10 @@ Patch.prototype.escape = function(sFileName){
 };
 
 /*
-  We have three type of cascading links, each of them has two verbs, add and remove.
-  Which means that by clicking a file or section link all corresponding line links are clicked.
+  We have three type of cascading checkboxes.
+  Which means that by clicking a file or section checkbox all corresponding line checkboxes are checked.
 
-  The id of the link indicates its semantics and its membership.
+  The id of the checkbox indicates its semantics and its membership.
 
   */
 
@@ -1036,163 +1036,90 @@ Patch.prototype.escape = function(sFileName){
 
       example id of file link
 
-      patch_file_add_zcl_abapgit_user_exit.clas.abap
-      \________/  ^  \_____________________________/
-          |       |              |
-          |       |              |____ file name
-          |       |
-          |     verb [add|remove]
+      patch_file_zcl_abapgit_user_exit.clas.abap
+      \________/ \_____________________________/
+          |                   |
+          |                   |____ file name
+          |
+          |
           |
       constant prefix
 
   */
 
 function PatchFile(sId){
-  var oRegex = new RegExp("(" + this.ID.FILE + ")_(add|remove)_(.*$)");
+  var oRegex = new RegExp("(" + this.ID + ")_(.*$)");
   var oMatch = sId.match(oRegex);
   this.id        = sId;
   this.prefix    = oMatch[1];
-  this.verb      = oMatch[2];
-  this.file_name = oMatch[3];
+  this.file_name = oMatch[2];
 }
 
-PatchFile.prototype.ID = {
-  FILE:   "patch_file",
-  ADD:    "patch_file_add",
-  REMOVE: "patch_file_remove"
-};
+PatchFile.prototype.ID = "patch_file";
 
 /*
   2) section links within a file
 
       example id of section link
 
-      patch_section_add_zcl_abapgit_user_exit.clas.abap_1
-      \___________/  ^  \_____________________________/ ^
-            |        |              |                   |
-            |        |          file name               |
-            |        |                                  |
-            |      verb [add|remove]                    ------ section
+      patch_section_zcl_abapgit_user_exit.clas.abap_1
+      \___________/ \_____________________________/ ^
+            |                   |                   |
+            |               file name               |
+            |                                       |
+            |                                       ------ section
             |
       constant prefix
 
     */
 
 function PatchSection(sId){
-  var oRegex = new RegExp("(" + this.ID.SECTION + ")_(add|remove)_(.*)_(\\d+$)");
+  var oRegex = new RegExp("(" + this.ID + ")_(.*)_(\\d+$)");
   var oMatch = sId.match(oRegex);
   this.id        = sId;
   this.prefix    = oMatch[1];
-  this.verb      = oMatch[2];
-  this.file_name = oMatch[3];
-  this.section   = oMatch[4];
+  this.file_name = oMatch[2];
+  this.section   = oMatch[3];
 }
 
-PatchSection.prototype.ID = {
-  SECTION: "patch_section",
-  ADD:     "patch_section_add",
-  REMOVE:  "patch_section_remove"
-};
+PatchSection.prototype.ID = "patch_section";
 
 /*
   3) line links within a section
 
       example id of line link
 
-      patch_line_add_zcl_abapgit_user_exit.clas.abap_1_25
-      \________/  ^  \_____________________________/ ^  ^
-            ^     |                ^                 |  |
-            |     |                |                 |  ------- line number
-            |     |             file name            |
-            |     |                               section
-            |   verb [add|remove]
+      patch_line_zcl_abapgit_user_exit.clas.abap_1_25
+      \________/ \_____________________________/ ^  ^
+            ^                  ^                 |  |
+            |                  |                 |  ------- line number
+            |               file name            |
+            |                                 section
+            |
             |
       constant prefix
 
   */
-function PatchLine(sId){
-  var oRegex = new RegExp("(" + this.ID.LINE + ")_(add|remove)_(.*)_(\\d+)_(\\d+$)");
-  var oMatch = sId.match(oRegex);
-
-  this.id        = sId;
-  this.prefix    = oMatch[1];
-  this.verb      = oMatch[2];
-  this.file_name = oMatch[3];
-  this.section   = oMatch[4];
-  this.line      = oMatch[5];
-
-  this.corresponding_verb = this.CORRESPONDING_VERBS[this.verb];
-  this.elem               = document.querySelector("#" + Patch.prototype.escape(this.id));
-  this.correspondingLink  = this.getCorrespodingLink();
+function PatchLine(){
 }
 
-PatchLine.prototype.ID = {
-  LINE:   "patch_line",
-  ADD:    "patch_line_add",
-  REMOVE: "patch_line_remove"
-};
-
-PatchLine.prototype.CSS_CLASS = {
-  PATCH:        "patch",
-  PATCH_ACTIVE: "patch-active"
-};
-
-PatchLine.prototype.CORRESPONDING_VERBS = {
-  add:    "remove",
-  remove: "add"
-};
-
-PatchLine.prototype.getCorrespodingLinkId = function(){
-
-  // e.g.
-  //
-  //   patch_line_add_z_test_git_add_p.prog.abap_3_28 => patch_line_remove_z_test_git_add_p.prog.abap_3_28
-  //
-  // and vice versa
-
-  var oRegexPatchIdPrefix = new RegExp("^" + this.ID.LINE + "_" + this.verb );
-  return this.id.replace(oRegexPatchIdPrefix, this.ID.LINE + "_" + this.corresponding_verb);
-
-};
-
-PatchLine.prototype.toggle = function(){
-
-  if (!this.elem.classList.contains(this.CSS_CLASS.PATCH_ACTIVE)){
-    this.elem.classList.toggle(this.CSS_CLASS.PATCH_ACTIVE);
-    this.correspondingLink.classList.toggle(this.CSS_CLASS.PATCH_ACTIVE);
-  }
-
-};
-
-PatchLine.prototype.getCorrespodingLink = function(){
-  var sCorrespondingLinkId = this.getCorrespodingLinkId();
-  return document.querySelector('[ID="' + Patch.prototype.escape(sCorrespondingLinkId) + '"]');
-};
+PatchLine.prototype.ID = "patch_line";
 
 Patch.prototype.preparePatch = function(){
 
   this.registerClickHandlerForFiles();
   this.registerClickHandlerForSections();
-  this.registerClickHandlerForLines();
 
 };
 
 Patch.prototype.registerClickHandlerForFiles = function(){
   // registers the link handlers for add and remove files
-  this.registerClickHandlerForPatchFile("a[id^='" + PatchFile.prototype.ID.ADD + "']");
-  this.registerClickHandlerForPatchFile("a[id^='" + PatchFile.prototype.ID.REMOVE + "']");
+  this.registerClickHandlerForPatchFile("input[id^='" + PatchFile.prototype.ID + "']");
 };
 
 Patch.prototype.registerClickHandlerForSections = function(){
   // registers the link handlers for add and remove sections
-  this.registerClickHandlerForPatchSection("a[id^='" + PatchSection.prototype.ID.ADD + "']");
-  this.registerClickHandlerForPatchSection("a[id^='" + PatchSection.prototype.ID.REMOVE + "']");
-};
-
-Patch.prototype.registerClickHandlerForLines = function(){
-  // registers the link handlers for add and remove lines
-  this.registerClickHandlerForPatchLine("a[id^='" + PatchLine.prototype.ID.ADD + "']");
-  this.registerClickHandlerForPatchLine("a[id^='" + PatchLine.prototype.ID.REMOVE + "']");
+  this.registerClickHandlerForPatchSection("input[id^='" + PatchSection.prototype.ID + "']");
 };
 
 Patch.prototype.registerClickHandlerForSelector = function(sSelector, fnCallback){
@@ -1206,66 +1133,65 @@ Patch.prototype.registerClickHandlerForSelector = function(sSelector, fnCallback
 };
 
 Patch.prototype.registerClickHandlerForPatchFile = function(sSelector){
-  this.registerClickHandlerForSelector(sSelector, this.patchLinkClickFile);
+  this.registerClickHandlerForSelector(sSelector, this.onClickFileCheckbox);
 };
 
 Patch.prototype.registerClickHandlerForPatchSection = function(sSelector){
-  this.registerClickHandlerForSelector(sSelector, this.patchLinkClickSection);
+  this.registerClickHandlerForSelector(sSelector, this.onClickSectionCheckbox);
 };
 
-Patch.prototype.registerClickHandlerForPatchLine = function(sSelector) {
-  this.registerClickHandlerForSelector(sSelector, this.patchLinkClickLine);
-};
-
-Patch.prototype.patchLinkClickLine = function(oEvent){
-  this.togglePatchForElem(oEvent.srcElement);
-  oEvent.preventDefault();
-};
-
-Patch.prototype.togglePatchForElem = function(elLink) {
-  new PatchLine(elLink.id).toggle();
-};
-
-Patch.prototype.getAllLineLinksForId = function(sId, sIdPrefix){
+Patch.prototype.getAllLineCheckboxesForId = function(sId, sIdPrefix){
   var oRegex = new RegExp("^" + sIdPrefix);
-  sId = sId.replace(oRegex, PatchLine.prototype.ID.LINE);
-  return document.querySelectorAll("a[id^='"+ this.escape(sId) + "']");
+  sId = sId.replace(oRegex, PatchLine.prototype.ID);
+  return document.querySelectorAll("input[id^='"+ this.escape(sId) + "']");
 };
 
-Patch.prototype.getAllLineLinksForFile = function(oFile){
-  return this.getAllLineLinksForId(oFile.id, PatchFile.prototype.ID.FILE);
+Patch.prototype.getAllSectionCheckboxesForId = function(sId, sIdPrefix){
+  var oRegex = new RegExp("^" + sIdPrefix);
+  sId = sId.replace(oRegex, PatchSection.prototype.ID);
+  return document.querySelectorAll("input[id^='"+ this.escape(sId) + "']");
 };
 
-Patch.prototype.getAllLineLinksForSection = function(oSection){
-  return this.getAllLineLinksForId(oSection.id, PatchSection.prototype.ID.SECTION);
+Patch.prototype.getAllLineCheckboxesForFile = function(oFile){
+  return this.getAllLineCheckboxesForId(oFile.id, PatchFile.prototype.ID);
 };
 
-Patch.prototype.patchLinkClickFile = function(oEvent) {
+Patch.prototype.getAllSectionCheckboxesForFile = function(oFile){
+  return this.getAllSectionCheckboxesForId(oFile.id, PatchFile.prototype.ID);
+};
+
+Patch.prototype.getAllLineCheckboxesForSection = function(oSection){
+  return this.getAllLineCheckboxesForId(oSection.id, PatchSection.prototype.ID);
+};
+
+Patch.prototype.onClickFileCheckbox = function(oEvent) {
 
   var oFile = new PatchFile(oEvent.srcElement.id);
-  var elAllLineLinksOfFile = this.getAllLineLinksForFile(oFile);
+  var elAllCheckboxLinksOfFile = this.getAllLineCheckboxesForFile(oFile);
+  var elAllSectionCheckboxesOfFile = this.getAllSectionCheckboxesForFile(oFile);
 
-  [].forEach.call(elAllLineLinksOfFile,function(elem){
-    this.togglePatchForElem(elem);
+  [].forEach.call(elAllCheckboxLinksOfFile,function(elem){
+    elem.checked = oEvent.srcElement.checked;
   }.bind(this));
 
-  oEvent.preventDefault();
+  [].forEach.call(elAllSectionCheckboxesOfFile,function(elem){
+    elem.checked = oEvent.srcElement.checked;
+  }.bind(this));
+
 };
 
-Patch.prototype.patchLinkClickSection = function(oEvent){
+Patch.prototype.onClickSectionCheckbox = function(oEvent){
   var oSection = new PatchSection(oEvent.srcElement.id);
-  this.clickAllLineLinksInSection(oEvent, oSection.section);
-  oEvent.preventDefault();
+  this.clickAllLineCheckboxesInSection(oEvent, oSection.section);
 };
 
-Patch.prototype.clickAllLineLinksInSection = function(oEvent){
+Patch.prototype.clickAllLineCheckboxesInSection = function(oEvent){
 
   var oSection = new PatchSection(oEvent.srcElement.id);
-  var elAllLineLinksOfSection = this.getAllLineLinksForSection(oSection);
+  var elAllLineCheckboxesOfSection = this.getAllLineCheckboxesForSection(oSection);
 
-  [].forEach.call(elAllLineLinksOfSection,function(elem){
-    this.togglePatchForElem(elem);
-    oEvent.preventDefault();
+  [].forEach.call(elAllLineCheckboxesOfSection,function(elem){
+    elem.checked = oEvent.srcElement.checked;
   }.bind(this));
 
 };
@@ -1286,20 +1212,20 @@ Patch.prototype.stagePatch = function() {
 
   // Collect add and remove info and submit to backend
 
-  var aAddPatch = this.collectActiveElementsForId( PatchLine.prototype.ID.ADD );
-  var aRemovePatch = this.collectActiveElementsForId( PatchLine.prototype.ID.REMOVE );
+  var aAddPatch = this.collectElementsForId( PatchLine.prototype.ID, true );
+  var aRemovePatch = this.collectElementsForId( PatchLine.prototype.ID, false);
 
   submitSapeventForm({"add": aAddPatch, "remove": aRemovePatch}, this.ACTION.PATCH_STAGE, "post");
 
 };
 
-Patch.prototype.collectActiveElementsForId = function(sId){
+Patch.prototype.collectElementsForId = function(sId, bChecked){
 
-  var sSelector = "." + PatchLine.prototype.CSS_CLASS.PATCH + " a[id^='" + sId + "']";
+  var sSelector = "input[id^='" + sId + "']";
 
   return [].slice.call(document.querySelectorAll(sSelector))
     .filter(function(elem){
-      return elem.classList.contains(PatchLine.prototype.CSS_CLASS.PATCH_ACTIVE);
+      return (elem.checked === bChecked);
     }).map(function(elem){
       return elem.id;
     });

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -1146,18 +1146,6 @@ Patch.prototype.registerClickHandlerForSelector = function(sSelector, fnCallback
 
 };
 
-Patch.prototype.getAllLineCheckboxesForId = function(sId, sIdPrefix){
-  var oRegex = new RegExp("^" + sIdPrefix);
-  sId = sId.replace(oRegex, PatchLine.prototype.ID);
-  return document.querySelectorAll("input[id^='"+ this.escape(sId) + "']");
-};
-
-Patch.prototype.getAllSectionCheckboxesForId = function(sId, sIdPrefix){
-  var oRegex = new RegExp("^" + sIdPrefix);
-  sId = sId.replace(oRegex, PatchSection.prototype.ID);
-  return document.querySelectorAll("input[id^='"+ this.escape(sId) + "']");
-};
-
 Patch.prototype.getAllLineCheckboxesForFile = function(oFile){
   return this.getAllLineCheckboxesForId(oFile.id, PatchFile.prototype.ID);
 };
@@ -1168,6 +1156,20 @@ Patch.prototype.getAllSectionCheckboxesForFile = function(oFile){
 
 Patch.prototype.getAllLineCheckboxesForSection = function(oSection){
   return this.getAllLineCheckboxesForId(oSection.id, PatchSection.prototype.ID);
+};
+
+Patch.prototype.getAllLineCheckboxesForId = function(sId, sIdPrefix){
+  return this.getAllCheckboxesForId(sId, sIdPrefix,PatchLine.prototype.ID);
+};
+
+Patch.prototype.getAllSectionCheckboxesForId = function(sId, sIdPrefix){
+  return this.getAllCheckboxesForId(sId, sIdPrefix, PatchSection.prototype.ID);
+};
+
+Patch.prototype.getAllCheckboxesForId = function(sId, sIdPrefix, sNewIdPrefix){
+  var oRegex = new RegExp("^" + sIdPrefix);
+  sId = sId.replace(oRegex, sNewIdPrefix);
+  return document.querySelectorAll("input[id^='"+ this.escape(sId) + "']");
 };
 
 Patch.prototype.onClickFileCheckbox = function(oEvent) {

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -730,7 +730,7 @@ function LinkHints(sLinkHintKey, sColor){
   this.oTooltipMap = {};
   this.bTooltipsOn = false;
   this.sPending = "";
-  this.aTooltipElements = document.querySelectorAll("a span");
+  this.aTooltipElements = document.querySelectorAll("span.tooltiptext");
 }
 
 LinkHints.prototype.renderTooltip = function (oTooltip, iTooltipCounter) {
@@ -829,7 +829,21 @@ LinkHints.prototype.tooltipActivate = function (oTooltip) {
   // a tooltips was successfully specified, so we try to trigger the link
   // and remove all tooltips
   this.removeAllTooltips();
-  oTooltip.parentElement.click();
+
+  // we have technically 2 scenarios
+  // 1) hint to a checkbox: as input field cannot include tags
+  //    we place the span after input
+  // 2) hint to a link: the span in included in the anchor tag
+
+  var elInput = oTooltip.parentElement.querySelector("input");
+
+  if (elInput) {
+    // case 1) toggle the checkbox
+    elInput.checked = !elInput.checked;
+  } else {
+    // case 2) click the link
+    oTooltip.parentElement.click();
+  }
 
   // in case it is a dropdownmenu we have to expand and focus it
   this.activateDropDownMenu(oTooltip);

--- a/src/ui/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_diff.clas.abap
@@ -602,7 +602,7 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
     IF mv_patch_mode = abap_true.
 
       ro_html->add( |<th class="patch">| ).
-      ro_html->add( |<input type="checkbox" id="patch_section_{ is_diff-filename }_{ mv_section_count }">| ).
+      ro_html->add_checkbox( iv_id = |patch_section_{ is_diff-filename }_{ mv_section_count }| ).
       ro_html->add( '</th>' ).
 
     ELSE.
@@ -909,7 +909,7 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
       lv_id = |{ lv_object }_{ mv_section_count }_{ iv_index }|.
 
       io_html->add( |<td class="{ c_css_class-patch }">| ).
-      io_html->add( |<input type="checkbox" id="patch_line_{ lv_id }">| ).
+      io_html->add_checkbox( iv_id = |patch_line_{ lv_id }| ).
       io_html->add( |</td>| ).
 
     ELSE.
@@ -925,7 +925,7 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
   METHOD render_patch_head.
 
     io_html->add( |<th class="patch">| ).
-    io_html->add( |<input type="checkbox" id="patch_file_{ is_diff-filename }">| ).
+    io_html->add_checkbox( iv_id = |patch_file_{ is_diff-filename }| ).
     io_html->add( '</th>' ).
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_diff.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_gui_page_diff.clas.testclasses.abap
@@ -8,7 +8,6 @@ CLASS ltcl_patch DEFINITION FINAL FOR TESTING
     METHODS:
       get_patch_data_add FOR TESTING RAISING cx_static_check,
       get_patch_data_remove FOR TESTING RAISING cx_static_check,
-      invalid_action FOR TESTING RAISING cx_static_check,
       invalid_patch_missing_file FOR TESTING RAISING cx_static_check,
       invalid_patch_missing_index FOR TESTING RAISING cx_static_check.
 
@@ -25,8 +24,7 @@ CLASS ltcl_patch IMPLEMENTATION.
 
     zcl_abapgit_gui_page_diff=>get_patch_data(
       EXPORTING
-        iv_patch      = |patch_line_add_zcl_test_git_add_p.clas.abap_0_19|
-        iv_action     = |add|
+        iv_patch      = |patch_line_zcl_test_git_add_p.clas.abap_0_19|
       IMPORTING
         ev_filename   = lv_file_name
         ev_line_index = lv_line_index ).
@@ -48,8 +46,7 @@ CLASS ltcl_patch IMPLEMENTATION.
 
     zcl_abapgit_gui_page_diff=>get_patch_data(
       EXPORTING
-        iv_patch      = |patch_line_remove_ztest_patch.prog.abap_0_39|
-        iv_action     = |remove|
+        iv_patch      = |patch_line_ztest_patch.prog.abap_0_39|
       IMPORTING
         ev_filename   = lv_file_name
         ev_line_index = lv_line_index ).
@@ -64,24 +61,6 @@ CLASS ltcl_patch IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD invalid_action.
-
-    DATA: lx_error TYPE REF TO zcx_abapgit_exception.
-
-    TRY.
-        zcl_abapgit_gui_page_diff=>get_patch_data(
-          iv_patch  = |remove_patch_ztest_patch.prog.abap_39|
-          iv_action = |mix| ).
-
-        cl_abap_unit_assert=>fail( ).
-
-      CATCH zcx_abapgit_exception INTO lx_error.
-        cl_abap_unit_assert=>assert_equals(
-          exp = |Invalid action mix|
-          act = lx_error->get_text( ) ).
-    ENDTRY.
-
-  ENDMETHOD.
 
   METHOD invalid_patch_missing_file.
 
@@ -92,8 +71,7 @@ CLASS ltcl_patch IMPLEMENTATION.
     TRY.
         zcl_abapgit_gui_page_diff=>get_patch_data(
           EXPORTING
-            iv_patch      = |add_patch_39|
-            iv_action     = |add|
+            iv_patch      = |patch_39|
           IMPORTING
             ev_filename   = lv_file_name
             ev_line_index = lv_line_index ).
@@ -117,8 +95,7 @@ CLASS ltcl_patch IMPLEMENTATION.
     TRY.
         zcl_abapgit_gui_page_diff=>get_patch_data(
           EXPORTING
-            iv_patch      = |remove_patch_ztest_patch.prog.abap|
-            iv_action     = |remove|
+            iv_patch      = |patch_ztest_patch.prog.abap|
           IMPORTING
             ev_filename   = lv_file_name
             ev_line_index = lv_line_index ).


### PR DESCRIPTION
#2673
With this commit we replace the links on the patch page with checkboxes.
This has several advantages:
- better performance
- simplified and less cluttered UI
- less and easier to understand code

before:
![image](https://user-images.githubusercontent.com/17437789/57965790-fa922a00-7948-11e9-8c72-09ec101afc50.png)

after:
![image](https://user-images.githubusercontent.com/17437789/57965713-2eb91b00-7948-11e9-9690-4f286b7d4b38.png)
