### PR TITLE
Patch: make cell around checkbox clickable

### DIFF
--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -540,6 +540,7 @@ table.diff_tab td.patch, th.patch {
   border-right: 1px solid #eee;
   -ms-user-select: none;
   user-select: none;
+  cursor: pointer;
 }
 table.diff_tab td.num::before {
   content: attr(line-num);


### PR DESCRIPTION
follow up
#2684
#2673

Makes it a bit easier to click checkboxes.

![abapGit_patch](https://user-images.githubusercontent.com/17437789/58041176-b749de00-7b37-11e9-84a4-191a83b323e6.gif)
