### PR TITLE
oo: fix dump during deserialization

### DIFF
--- a/src/objects/zcl_abapgit_oo_class.clas.abap
+++ b/src/objects/zcl_abapgit_oo_class.clas.abap
@@ -262,7 +262,7 @@ CLASS ZCL_ABAPGIT_OO_CLASS IMPLEMENTATION.
           EXPORTING
             clskey                        = ls_clskey
             exposure                      = iv_exposure
-            state                         = 'A'
+            state                         = 'I'
             source                        = it_source
             suppress_constrctr_generation = seox_true
           EXCEPTIONS
@@ -304,8 +304,10 @@ CLASS ZCL_ABAPGIT_OO_CLASS IMPLEMENTATION.
       zcx_abapgit_exception=>raise( |CLAS, error while scanning source. Subrc = { sy-subrc }| ).
     ENDIF.
 
+    CALL FUNCTION 'SEO_CLIF_INACTIVE_CHECK'.
+
 * this will update the SEO* database tables
-    lo_update->revert_scan_result( ).
+    lo_update->revert_scan_result( suppress_access_permission = abap_true  ).
 
     IF iv_exposure = seoc_exposure_public.
       generate_classpool( iv_name ).


### PR DESCRIPTION
A class with redefintions was causing dumps.

I have learned that SAPLSEOR:INSERT_REDEFINITIONS tries to insert all redefinitions
without checking if they already exist.

To enable the check, we have to make sure wbinactive is X.

So, we have to add CALL FUNCTION 'SEO_CLIF_INACTIVE_CHECK' which sets
wbinactive to X.

But we have to also set suppress_access_permission because otherwise
the function seo_clif_access_permission set wbinactive  to ' '.

Finally we have to pass state %3D 'I' otherewise wbinactive is again set to ' '.

I haven't changed the state in the old release branch because I cannot
test this change.