### PR TITLE
Pass log to deserialization API and show log

### DIFF
--- a/src/background/zcl_abapgit_background_pull.clas.abap
+++ b/src/background/zcl_abapgit_background_pull.clas.abap
@@ -32,7 +32,8 @@ CLASS ZCL_ABAPGIT_BACKGROUND_PULL IMPLEMENTATION.
 
 
 * todo, set defaults in ls_checks
-    io_repo->deserialize( ls_checks ).
+    io_repo->deserialize( is_checks = ls_checks
+                          ii_log    = ii_log ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_tabl_compar.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl_compar.clas.abap
@@ -186,15 +186,23 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL_COMPAR IMPLEMENTATION.
         IF ls_current_table_field-rollname <> ls_previous_table_field-rollname.
           IF ls_current_table_field-rollname IS NOT INITIAL AND ls_previous_table_field-rollname IS NOT INITIAL.
             ii_log->add_info(
-              iv_msg  = |Field { ls_previous_table_field-fieldname }: Data element changed from { ls_previous_table_field-rollname } to { ls_current_table_field-rollname }|
+              iv_msg  = |Field { ls_previous_table_field-fieldname }: | &
+                        |Data element changed from { ls_previous_table_field-rollname } | &
+                        |to { ls_current_table_field-rollname }|
               is_item = ls_item ).
           ELSEIF ls_current_table_field-rollname IS NOT INITIAL.
             ii_log->add_info(
-              iv_msg  = |Field { ls_previous_table_field-fieldname }: Data type from internal type { ls_previous_table_field-inttype }(length { ls_previous_table_field-intlen }) to data element { ls_current_table_field-rollname }|
+              iv_msg  = |Field { ls_previous_table_field-fieldname }: | &
+                        |Data type changed from internal type | &
+                        |{ ls_previous_table_field-inttype }(length { ls_previous_table_field-intlen }) | &
+                        |to data element { ls_current_table_field-rollname }|
               is_item = ls_item ).
           ELSEIF ls_previous_table_field-rollname IS NOT INITIAL.
             ii_log->add_info(
-              iv_msg  = |Field { ls_previous_table_field-fieldname }: Data type from date element { ls_previous_table_field-rollname } to internal type { ls_current_table_field-inttype }(length { ls_current_table_field-intlen })|
+              iv_msg  = |Field { ls_previous_table_field-fieldname }: | &
+                        |Data type changed from date element { ls_previous_table_field-rollname } | &
+                        |to internal type | &
+                        |{ ls_current_table_field-inttype }(length { ls_current_table_field-intlen })|
               is_item = ls_item ).
           ENDIF.
           "TODO: perform several other checks, e.g. field length truncated, ...

--- a/src/objects/zcl_abapgit_object_tabl_compar.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl_compar.clas.abap
@@ -13,10 +13,10 @@ CLASS zcl_abapgit_object_tabl_compar DEFINITION
 
     TYPES:
       tty_founds  TYPE STANDARD TABLE OF rsfindlst
-                         WITH NON-UNIQUE DEFAULT KEY .
+                           WITH NON-UNIQUE DEFAULT KEY .
     TYPES:
       tty_seu_obj TYPE STANDARD TABLE OF seu_obj
-                         WITH NON-UNIQUE DEFAULT KEY .
+                           WITH NON-UNIQUE DEFAULT KEY .
 
     DATA mo_local TYPE REF TO zcl_abapgit_xml_input .
 
@@ -41,6 +41,7 @@ CLASS zcl_abapgit_object_tabl_compar DEFINITION
       IMPORTING
         !io_remote_version TYPE REF TO zcl_abapgit_xml_input
         !io_local_version  TYPE REF TO zcl_abapgit_xml_input
+        !ii_log            TYPE REF TO zif_abapgit_log
       RETURNING
         VALUE(rv_message)  TYPE string
       RAISING
@@ -148,7 +149,9 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL_COMPAR IMPLEMENTATION.
           ls_previous_table_field  LIKE LINE OF lt_previous_table_fields,
           lt_current_table_fields  TYPE TABLE OF dd03p,
           ls_current_table_field   LIKE LINE OF lt_current_table_fields,
-          ls_dd02v                 TYPE dd02v.
+          ls_dd02v                 TYPE dd02v,
+          ls_item                  TYPE zif_abapgit_definitions=>ty_item,
+          lv_inconsistent          TYPE abap_bool.
 
     io_remote_version->read(
       EXPORTING
@@ -173,17 +176,38 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL_COMPAR IMPLEMENTATION.
       CHANGING
         cg_data       = lt_current_table_fields ).
 
+    ls_item-obj_name = ls_dd02v-tabname.
+    ls_item-obj_type = 'TABL'.
+
     LOOP AT lt_previous_table_fields INTO ls_previous_table_field.
       READ TABLE lt_current_table_fields WITH KEY fieldname = ls_previous_table_field-fieldname
         INTO ls_current_table_field.
       IF sy-subrc = 0.
         IF ls_current_table_field-rollname <> ls_previous_table_field-rollname.
-          rv_message = 'Fields were changed. This may lead to inconsistencies.'.
+          IF ls_current_table_field-rollname IS NOT INITIAL AND ls_previous_table_field-rollname IS NOT INITIAL.
+            ii_log->add_info(
+              iv_msg  = |Field { ls_previous_table_field-fieldname }: Data element changed from { ls_previous_table_field-rollname } to { ls_current_table_field-rollname }|
+              is_item = ls_item ).
+          ELSEIF ls_current_table_field-rollname IS NOT INITIAL.
+            ii_log->add_info(
+              iv_msg  = |Field { ls_previous_table_field-fieldname }: Data type from internal type { ls_previous_table_field-inttype }(length { ls_previous_table_field-intlen }) to data element { ls_current_table_field-rollname }|
+              is_item = ls_item ).
+          ELSEIF ls_previous_table_field-rollname IS NOT INITIAL.
+            ii_log->add_info(
+              iv_msg  = |Field { ls_previous_table_field-fieldname }: Data type from date element { ls_previous_table_field-rollname } to internal type { ls_current_table_field-inttype }(length { ls_current_table_field-intlen })|
+              is_item = ls_item ).
+          ENDIF.
+          "TODO: perform several other checks, e.g. field length truncated, ...
+          lv_inconsistent = abap_true.
         ENDIF.
       ELSE.
-        rv_message = 'Fields were changed. This may lead to inconsistencies.'.
+        ii_log->add_info( iv_msg = |Field { ls_previous_table_field-fieldname } removed| is_item = ls_item ).
+        lv_inconsistent = abap_true.
       ENDIF.
     ENDLOOP.
+    IF lv_inconsistent = abap_true.
+      rv_message = |Database Table { ls_dd02v-tabname }: Fields were changed. This may lead to inconsistencies!|.
+    ENDIF.
 
     IF NOT rv_message IS INITIAL.
       rv_message = |Database Table { ls_dd02v-tabname }: { rv_message }|.
@@ -196,7 +220,8 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL_COMPAR IMPLEMENTATION.
 
     rs_result-text = validate(
       io_remote_version = io_remote
-      io_local_version  = mo_local ).
+      io_local_version  = mo_local
+      ii_log            = ii_log ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zif_abapgit_comparator.intf.abap
+++ b/src/objects/zif_abapgit_comparator.intf.abap
@@ -10,6 +10,7 @@ INTERFACE zif_abapgit_comparator
   METHODS compare
     IMPORTING
       !io_remote       TYPE REF TO zcl_abapgit_xml_input
+      !ii_log          TYPE REF TO zif_abapgit_log
     RETURNING
       VALUE(rs_result) TYPE ty_result
     RAISING

--- a/src/objects/zif_abapgit_object.intf.abap
+++ b/src/objects/zif_abapgit_object.intf.abap
@@ -29,6 +29,7 @@ INTERFACE zif_abapgit_object
       !iv_package TYPE devclass
       !io_xml     TYPE REF TO zcl_abapgit_xml_input
       !iv_step    TYPE ty_deserialization_step
+      !ii_log     TYPE REF TO zif_abapgit_log
     RAISING
       zcx_abapgit_exception .
   METHODS delete

--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -44,7 +44,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_main IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
 
 
   METHOD build_main_menu.
@@ -307,6 +307,63 @@ CLASS zcl_abapgit_gui_page_main IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_gui_event_handler~on_event.
+
+    DATA: lv_key           TYPE zif_abapgit_persistence=>ty_repo-key,
+          li_repo_overview TYPE REF TO zif_abapgit_gui_renderable.
+
+
+    IF NOT mo_repo_content IS INITIAL.
+      mo_repo_content->zif_abapgit_gui_event_handler~on_event(
+        EXPORTING
+          iv_action    = iv_action
+          iv_prev_page = iv_prev_page
+          iv_getdata   = iv_getdata
+          it_postdata  = it_postdata
+        IMPORTING
+          ei_page      = ei_page
+          ev_state     = ev_state ).
+
+      IF ev_state <> zcl_abapgit_gui=>c_event_state-not_handled.
+        RETURN.
+      ENDIF.
+    ENDIF.
+
+    lv_key = iv_getdata.
+
+    CASE iv_action.
+      WHEN c_actions-show.
+        zcl_abapgit_persistence_user=>get_instance( )->set_repo_show( lv_key ).
+        TRY.
+            zcl_abapgit_repo_srv=>get_instance( )->get( lv_key )->refresh( ).
+          CATCH zcx_abapgit_exception ##NO_HANDLER.
+        ENDTRY.
+        ev_state = zcl_abapgit_gui=>c_event_state-re_render.
+      WHEN c_actions-changed_by.
+        test_changed_by( ).
+        ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
+      WHEN c_actions-documentation.
+        zcl_abapgit_services_abapgit=>open_abapgit_wikipage( ).
+        ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
+      WHEN c_actions-overview.
+        CREATE OBJECT li_repo_overview TYPE zcl_abapgit_gui_page_repo_over.
+        ei_page = li_repo_overview.
+        ev_state = zcl_abapgit_gui=>c_event_state-new_page.
+      WHEN OTHERS.
+        super->zif_abapgit_gui_event_handler~on_event(
+          EXPORTING
+            iv_action    = iv_action
+            iv_prev_page = iv_prev_page
+            iv_getdata   = iv_getdata
+            it_postdata  = it_postdata
+          IMPORTING
+            ei_page      = ei_page
+            ev_state     = ev_state  ).
+    ENDCASE.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_gui_page_hotkey~get_hotkey_actions.
 
     DATA: ls_hotkey_action TYPE zif_abapgit_gui_page_hotkey=>ty_hotkey_with_name.
@@ -361,62 +418,10 @@ CLASS zcl_abapgit_gui_page_main IMPLEMENTATION.
     ls_hotkey_action-hotkey = |i|.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_gui_event_handler~on_event.
-
-    DATA: lv_key           TYPE zif_abapgit_persistence=>ty_repo-key,
-          li_repo_overview TYPE REF TO zif_abapgit_gui_renderable.
-
-
-    IF NOT mo_repo_content IS INITIAL.
-      mo_repo_content->zif_abapgit_gui_event_handler~on_event(
-        EXPORTING
-          iv_action    = iv_action
-          iv_prev_page = iv_prev_page
-          iv_getdata   = iv_getdata
-          it_postdata  = it_postdata
-        IMPORTING
-          ei_page      = ei_page
-          ev_state     = ev_state ).
-
-      IF ev_state <> zcl_abapgit_gui=>c_event_state-not_handled.
-        RETURN.
-      ENDIF.
-    ENDIF.
-
-    lv_key = iv_getdata.
-
-    CASE iv_action.
-      WHEN c_actions-show.
-        zcl_abapgit_persistence_user=>get_instance( )->set_repo_show( lv_key ).
-        TRY.
-            zcl_abapgit_repo_srv=>get_instance( )->get( lv_key )->refresh( ).
-          CATCH zcx_abapgit_exception ##NO_HANDLER.
-        ENDTRY.
-        ev_state = zcl_abapgit_gui=>c_event_state-re_render.
-      WHEN c_actions-changed_by.
-        test_changed_by( ).
-        ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
-      WHEN c_actions-documentation.
-        zcl_abapgit_services_abapgit=>open_abapgit_wikipage( ).
-        ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
-      WHEN c_actions-overview.
-        CREATE OBJECT li_repo_overview TYPE zcl_abapgit_gui_page_repo_over.
-        ei_page = li_repo_overview.
-        ev_state = zcl_abapgit_gui=>c_event_state-new_page.
-      WHEN OTHERS.
-        super->zif_abapgit_gui_event_handler~on_event(
-          EXPORTING
-            iv_action    = iv_action
-            iv_prev_page = iv_prev_page
-            iv_getdata   = iv_getdata
-            it_postdata  = it_postdata
-          IMPORTING
-            ei_page      = ei_page
-            ev_state     = ev_state  ).
-    ENDCASE.
+    ls_hotkey_action-name   = |Show log|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-repo_log.
+    ls_hotkey_action-hotkey = |l|.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -459,11 +459,9 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
 
   METHOD repository_services.
 
-    DATA: lv_url       TYPE string,
-          lv_key       TYPE zif_abapgit_persistence=>ty_repo-key,
-          li_log       TYPE REF TO zif_abapgit_log,
-          lv_log_title TYPE string.
-
+    DATA: lv_url TYPE string,
+          lv_key TYPE zif_abapgit_persistence=>ty_repo-key,
+          li_log TYPE REF TO zif_abapgit_log.
 
     lv_key = is_event_data-getdata. " TODO refactor
     lv_url = is_event_data-getdata. " TODO refactor
@@ -498,7 +496,7 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
       WHEN 'install'.    " 'install' is for explore page
         zcl_abapgit_services_repo=>new_online( lv_url ).
         ev_state = zcl_abapgit_gui=>c_event_state-re_render.
-      WHEN zif_abapgit_definitions=>c_action-repo_refresh_checksums.          " Rebuil local checksums
+      WHEN zif_abapgit_definitions=>c_action-repo_refresh_checksums.          " Rebuild local checksums
         zcl_abapgit_services_repo=>refresh_local_checksums( lv_key ).
         ev_state = zcl_abapgit_gui=>c_event_state-re_render.
       WHEN zif_abapgit_definitions=>c_action-repo_toggle_fav.                 " Toggle repo as favorite
@@ -513,11 +511,8 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
             io_repo = zcl_abapgit_repo_srv=>get_instance( )->get( lv_key ).
         ev_state = zcl_abapgit_gui=>c_event_state-new_page.
       WHEN zif_abapgit_definitions=>c_action-repo_log.
-        zcl_abapgit_repo_srv=>get_instance( )->get( lv_key )->get_log(
-          IMPORTING
-            ei_log   = li_log
-            ev_title = lv_log_title ).
-        zcl_abapgit_log_viewer=>show_log( ii_log = li_log iv_header_text = lv_log_title ).
+        li_log = zcl_abapgit_repo_srv=>get_instance( )->get( lv_key )->get_log( ).
+        zcl_abapgit_log_viewer=>show_log( ii_log = li_log iv_header_text = li_log->get_title( ) ).
         ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
     ENDCASE.
 

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -459,8 +459,10 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
 
   METHOD repository_services.
 
-    DATA: lv_url TYPE string,
-          lv_key TYPE zif_abapgit_persistence=>ty_repo-key.
+    DATA: lv_url       TYPE string,
+          lv_key       TYPE zif_abapgit_persistence=>ty_repo-key,
+          li_log       TYPE REF TO zif_abapgit_log,
+          lv_log_title TYPE string.
 
 
     lv_key = is_event_data-getdata. " TODO refactor
@@ -510,6 +512,13 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
           EXPORTING
             io_repo = zcl_abapgit_repo_srv=>get_instance( )->get( lv_key ).
         ev_state = zcl_abapgit_gui=>c_event_state-new_page.
+      WHEN zif_abapgit_definitions=>c_action-repo_log.
+        zcl_abapgit_repo_srv=>get_instance( )->get( lv_key )->get_log(
+          IMPORTING
+            ei_log   = li_log
+            ev_title = lv_log_title ).
+        zcl_abapgit_log_viewer=>show_log( ii_log = li_log iv_header_text = lv_log_title ).
+        ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
     ENDCASE.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_view_repo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_view_repo.clas.abap
@@ -263,7 +263,7 @@ CLASS ZCL_ABAPGIT_GUI_VIEW_REPO IMPLEMENTATION.
                          iv_act = |{ zif_abapgit_definitions=>c_action-go_diff }?key={ lv_key }|
                          iv_opt = zif_abapgit_html=>c_html_opt-strong ).
       ENDIF.
-      mo_repo->get_log( IMPORTING ei_log = li_log ).
+      li_log = mo_repo->get_log( ).
       IF li_log IS BOUND AND li_log->count( ) > 0.
         ro_toolbar->add( iv_txt = 'Log'
                          iv_act = |{ zif_abapgit_definitions=>c_action-repo_log }?{ lv_key }| ).

--- a/src/ui/zcl_abapgit_gui_view_repo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_view_repo.clas.abap
@@ -145,7 +145,8 @@ CLASS ZCL_ABAPGIT_GUI_VIEW_REPO IMPLEMENTATION.
           lv_key         TYPE zif_abapgit_persistence=>ty_value,
           lv_wp_opt      LIKE zif_abapgit_html=>c_html_opt-crossout,
           lv_crossout    LIKE zif_abapgit_html=>c_html_opt-crossout,
-          lv_pull_opt    LIKE zif_abapgit_html=>c_html_opt-crossout.
+          lv_pull_opt    LIKE zif_abapgit_html=>c_html_opt-crossout,
+          li_log         TYPE REF TO zif_abapgit_log.
 
     CREATE OBJECT ro_toolbar.
     CREATE OBJECT lo_tb_branch.
@@ -261,6 +262,11 @@ CLASS ZCL_ABAPGIT_GUI_VIEW_REPO IMPLEMENTATION.
         ro_toolbar->add( iv_txt = 'Show diff'
                          iv_act = |{ zif_abapgit_definitions=>c_action-go_diff }?key={ lv_key }|
                          iv_opt = zif_abapgit_html=>c_html_opt-strong ).
+      ENDIF.
+      mo_repo->get_log( IMPORTING ei_log = li_log ).
+      IF li_log IS BOUND AND li_log->count( ) > 0.
+        ro_toolbar->add( iv_txt = 'Log'
+                         iv_act = |{ zif_abapgit_definitions=>c_action-repo_log }?{ lv_key }| ).
       ENDIF.
       ro_toolbar->add( iv_txt = 'Branch'
                        io_sub = lo_tb_branch ) ##NO_TEXT.

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -120,7 +120,8 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
     ENDTRY.
 
 * and pass decisions to deserialize
-    io_repo->deserialize( ls_checks ).
+    io_repo->deserialize( is_checks = ls_checks
+                          ii_log    = io_repo->create_new_log( 'Pull Log' ) ).
 
   ENDMETHOD.
 
@@ -310,7 +311,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
         iv_text_button_2         = 'Cancel'
         iv_icon_button_2         = 'ICON_CANCEL'
         iv_default_button        = '2'
-        iv_display_cancel_button = abap_false ).               "#EC NOTEXT
+        iv_display_cancel_button = abap_false ).            "#EC NOTEXT
 
       IF lv_answer = '2'.
         RAISE EXCEPTION TYPE zcx_abapgit_cancel.
@@ -371,7 +372,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
       iv_text_button_2         = 'Cancel'
       iv_icon_button_2         = 'ICON_CANCEL'
       iv_default_button        = '2'
-      iv_display_cancel_button = abap_false ).                 "#EC NOTEXT
+      iv_display_cancel_button = abap_false ).              "#EC NOTEXT
 
     IF lv_answer = '2'.
       RAISE EXCEPTION TYPE zcx_abapgit_cancel.
@@ -387,7 +388,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
   METHOD remote_attach.
 
     DATA: ls_popup TYPE zif_abapgit_popups=>ty_popup,
-          ls_loc TYPE zif_abapgit_persistence=>ty_repo-local_settings,
+          ls_loc   TYPE zif_abapgit_persistence=>ty_repo-local_settings,
           lo_repo  TYPE REF TO zcl_abapgit_repo_online.
 
     ls_loc = zcl_abapgit_repo_srv=>get_instance( )->get( iv_key )->get_local_settings( ).
@@ -419,7 +420,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
   METHOD remote_change.
 
     DATA: ls_popup TYPE zif_abapgit_popups=>ty_popup,
-          ls_loc TYPE zif_abapgit_persistence=>ty_repo-local_settings,
+          ls_loc   TYPE zif_abapgit_persistence=>ty_repo-local_settings,
           lo_repo  TYPE REF TO zcl_abapgit_repo_online.
 
     lo_repo ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).
@@ -459,7 +460,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
       iv_text_button_2         = 'Cancel'
       iv_icon_button_2         = 'ICON_CANCEL'
       iv_default_button        = '2'
-      iv_display_cancel_button = abap_false ).                 "#EC NOTEXT
+      iv_display_cancel_button = abap_false ).              "#EC NOTEXT
 
     IF lv_answer = '2'.
       RAISE EXCEPTION TYPE zcx_abapgit_cancel.
@@ -493,7 +494,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
       iv_text_button_2         = 'Cancel'
       iv_icon_button_2         = 'ICON_CANCEL'
       iv_default_button        = '2'
-      iv_display_cancel_button = abap_false ).                 "#EC NOTEXT
+      iv_display_cancel_button = abap_false ).              "#EC NOTEXT
 
     IF lv_answer = '2'.
       RAISE EXCEPTION TYPE zcx_abapgit_cancel.

--- a/src/utils/zcl_abapgit_log.clas.abap
+++ b/src/utils/zcl_abapgit_log.clas.abap
@@ -13,22 +13,22 @@ CLASS zcl_abapgit_log DEFINITION
         text TYPE string,
         type TYPE symsgty,
       END OF ty_msg .
-
     TYPES:
       BEGIN OF ty_log, "in order of occurrence
-        msg      TYPE ty_msg,
-        rc       TYPE balsort,
-        item     TYPE zif_abapgit_definitions=>ty_item,
+        msg  TYPE ty_msg,
+        rc   TYPE balsort,
+        item TYPE zif_abapgit_definitions=>ty_item,
       END OF ty_log .
 
     DATA:
       mt_log TYPE STANDARD TABLE OF ty_log WITH DEFAULT KEY .
+    DATA mv_title TYPE string .
 
     METHODS get_messages_status
       IMPORTING
-        it_msg   TYPE zif_abapgit_log=>tty_msg
+        !it_msg          TYPE zif_abapgit_log=>tty_msg
       RETURNING
-        VALUE(rv_status) TYPE symsgty.
+        VALUE(rv_status) TYPE symsgty .
   PRIVATE SECTION.
 ENDCLASS.
 
@@ -223,10 +223,23 @@ CLASS ZCL_ABAPGIT_LOG IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_log~get_title.
+    rv_title = mv_title.
+    IF rv_title IS INITIAL.
+      rv_title = 'Log'.
+    ENDIF.
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_log~has_rc.
 * todo, this method is only used in unit tests
 
     READ TABLE mt_log WITH KEY rc = iv_rc TRANSPORTING NO FIELDS.
     rv_yes = boolc( sy-subrc = 0 ).
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_log~set_title.
+    mv_title = iv_title.
   ENDMETHOD.
 ENDCLASS.

--- a/src/utils/zif_abapgit_log.intf.abap
+++ b/src/utils/zif_abapgit_log.intf.abap
@@ -1,6 +1,7 @@
 INTERFACE zif_abapgit_log
   PUBLIC .
 
+
   TYPES:
     BEGIN OF ty_log_out,
       type     TYPE symsgty,
@@ -11,7 +12,6 @@ INTERFACE zif_abapgit_log
   TYPES:
     tty_log_out TYPE STANDARD TABLE OF ty_log_out
                 WITH NON-UNIQUE DEFAULT KEY .
-
   TYPES:
     BEGIN OF ty_msg,
       text TYPE string,
@@ -20,16 +20,15 @@ INTERFACE zif_abapgit_log
   TYPES:
     tty_msg TYPE STANDARD TABLE OF ty_msg
                           WITH NON-UNIQUE DEFAULT KEY .
-
   TYPES:
     BEGIN OF ty_item_status_out,
-      item     TYPE zif_abapgit_definitions=>ty_item ,
+      item     TYPE zif_abapgit_definitions=>ty_item,
       status   TYPE symsgty,
       messages TYPE tty_msg,
     END OF ty_item_status_out .
   TYPES:
     tty_item_status_out TYPE SORTED TABLE OF ty_item_status_out
-                        WITH UNIQUE KEY item-obj_type item-obj_name.
+                        WITH UNIQUE KEY item-obj_type item-obj_name .
 
   METHODS add
     IMPORTING
@@ -66,7 +65,19 @@ INTERFACE zif_abapgit_log
       !iv_rc        TYPE balsort
     RETURNING
       VALUE(rv_yes) TYPE abap_bool .
-  METHODS get_messages RETURNING VALUE(rt_msg) TYPE tty_log_out.
-  METHODS get_item_status EXPORTING et_item_status TYPE tty_item_status_out.
-  METHODS get_status RETURNING VALUE(rv_status) TYPE symsgty.
+  METHODS get_messages
+    RETURNING
+      VALUE(rt_msg) TYPE tty_log_out .
+  METHODS get_item_status
+    EXPORTING
+      !et_item_status TYPE tty_item_status_out .
+  METHODS get_status
+    RETURNING
+      VALUE(rv_status) TYPE symsgty .
+  METHODS get_title
+    RETURNING
+      VALUE(rv_title) TYPE string .
+  METHODS set_title
+    IMPORTING
+      !iv_title TYPE string .
 ENDINTERFACE.

--- a/src/zcl_abapgit_objects.clas.abap
+++ b/src/zcl_abapgit_objects.clas.abap
@@ -20,7 +20,6 @@ CLASS zcl_abapgit_objects DEFINITION
         files TYPE zif_abapgit_definitions=>ty_files_tt,
         item  TYPE zif_abapgit_definitions=>ty_item,
       END OF ty_serialization .
-
     TYPES:
       BEGIN OF ty_step_data,
         step_id      TYPE zif_abapgit_object=>ty_deserialization_step,
@@ -29,10 +28,10 @@ CLASS zcl_abapgit_objects DEFINITION
         is_ddic      TYPE abap_bool,
         syntax_check TYPE abap_bool,
         objects      TYPE ty_deserialization_tt,
-      END OF ty_step_data.
+      END OF ty_step_data .
     TYPES:
       ty_step_data_tt TYPE STANDARD TABLE OF ty_step_data
-                                WITH DEFAULT KEY.
+                                  WITH DEFAULT KEY .
 
     CLASS-METHODS serialize
       IMPORTING
@@ -46,6 +45,7 @@ CLASS zcl_abapgit_objects DEFINITION
       IMPORTING
         !io_repo                 TYPE REF TO zcl_abapgit_repo
         !is_checks               TYPE zif_abapgit_definitions=>ty_deserialize_checks
+        !ii_log                  TYPE REF TO zif_abapgit_log
       RETURNING
         VALUE(rt_accessed_files) TYPE zif_abapgit_definitions=>ty_file_signatures_tt
       RAISING
@@ -100,17 +100,22 @@ CLASS zcl_abapgit_objects DEFINITION
   PROTECTED SECTION.
 
   PRIVATE SECTION.
-    TYPES: BEGIN OF ty_obj_serializer_map,
-             item     TYPE zif_abapgit_definitions=>ty_item,
-             metadata TYPE zif_abapgit_definitions=>ty_metadata,
-           END OF ty_obj_serializer_map,
-           tty_obj_serializer_map
-        TYPE SORTED TABLE OF ty_obj_serializer_map WITH UNIQUE KEY item.
-    CLASS-DATA gt_obj_serializer_map TYPE tty_obj_serializer_map.
+
+    TYPES:
+      BEGIN OF ty_obj_serializer_map,
+        item     TYPE zif_abapgit_definitions=>ty_item,
+        metadata TYPE zif_abapgit_definitions=>ty_metadata,
+      END OF ty_obj_serializer_map .
+    TYPES:
+      tty_obj_serializer_map
+          TYPE SORTED TABLE OF ty_obj_serializer_map WITH UNIQUE KEY item .
+
+    CLASS-DATA gt_obj_serializer_map TYPE tty_obj_serializer_map .
 
     CLASS-METHODS files_to_deserialize
       IMPORTING
         !io_repo          TYPE REF TO zcl_abapgit_repo
+        !ii_log           TYPE REF TO zif_abapgit_log OPTIONAL
       RETURNING
         VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
       RAISING
@@ -120,7 +125,6 @@ CLASS zcl_abapgit_objects DEFINITION
         !it_files TYPE zif_abapgit_definitions=>ty_files_tt
       RAISING
         zcx_abapgit_exception .
-
     CLASS-METHODS prioritize_deser
       IMPORTING
         !it_results       TYPE zif_abapgit_definitions=>ty_results_tt
@@ -182,55 +186,57 @@ CLASS zcl_abapgit_objects DEFINITION
         !ii_object TYPE REF TO zif_abapgit_object
         !it_remote TYPE zif_abapgit_definitions=>ty_files_tt
         !is_result TYPE zif_abapgit_definitions=>ty_result
+        !ii_log    TYPE REF TO zif_abapgit_log
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS deserialize_objects
       IMPORTING
-        is_step  TYPE ty_step_data
+        !is_step  TYPE ty_step_data
+        !ii_log   TYPE REF TO zif_abapgit_log
       CHANGING
-        ct_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt
+        !ct_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS check_objects_locked
       IMPORTING
-        iv_language TYPE spras
-        it_items    TYPE zif_abapgit_definitions=>ty_items_tt
+        !iv_language TYPE spras
+        !it_items    TYPE zif_abapgit_definitions=>ty_items_tt
       RAISING
-        zcx_abapgit_exception.
+        zcx_abapgit_exception .
     CLASS-METHODS create_object
       IMPORTING
-        is_item        TYPE zif_abapgit_definitions=>ty_item
-        iv_language    TYPE spras
-        is_metadata    TYPE zif_abapgit_definitions=>ty_metadata OPTIONAL
-        iv_native_only TYPE abap_bool DEFAULT abap_false
+        !is_item        TYPE zif_abapgit_definitions=>ty_item
+        !iv_language    TYPE spras
+        !is_metadata    TYPE zif_abapgit_definitions=>ty_metadata OPTIONAL
+        !iv_native_only TYPE abap_bool DEFAULT abap_false
       RETURNING
-        VALUE(ri_obj)  TYPE REF TO zif_abapgit_object
+        VALUE(ri_obj)   TYPE REF TO zif_abapgit_object
       RAISING
         zcx_abapgit_exception .
     CLASS-METHODS map_tadir_to_items
       IMPORTING
-        it_tadir        TYPE zif_abapgit_definitions=>ty_tadir_tt
+        !it_tadir       TYPE zif_abapgit_definitions=>ty_tadir_tt
       RETURNING
-        VALUE(rt_items) TYPE zif_abapgit_definitions=>ty_items_tt.
+        VALUE(rt_items) TYPE zif_abapgit_definitions=>ty_items_tt .
     CLASS-METHODS map_results_to_items
       IMPORTING
-        it_results      TYPE zif_abapgit_definitions=>ty_results_tt
+        !it_results     TYPE zif_abapgit_definitions=>ty_results_tt
       RETURNING
-        VALUE(rt_items) TYPE zif_abapgit_definitions=>ty_items_tt.
+        VALUE(rt_items) TYPE zif_abapgit_definitions=>ty_items_tt .
     CLASS-METHODS filter_files_to_deserialize
       IMPORTING
-        it_results        TYPE zif_abapgit_definitions=>ty_results_tt
+        !it_results       TYPE zif_abapgit_definitions=>ty_results_tt
+        !ii_log           TYPE REF TO zif_abapgit_log OPTIONAL
       RETURNING
-        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt.
+        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt .
     CLASS-METHODS adjust_namespaces
       IMPORTING
-        it_results        TYPE zif_abapgit_definitions=>ty_results_tt
+        !it_results       TYPE zif_abapgit_definitions=>ty_results_tt
       RETURNING
-        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt.
+        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt .
     CLASS-METHODS get_deserialize_steps
       RETURNING
-        VALUE(rt_steps) TYPE ty_step_data_tt.
-
+        VALUE(rt_steps) TYPE ty_step_data_tt .
 ENDCLASS.
 
 
@@ -335,13 +341,14 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 * before pull, this is useful eg. when overwriting a TABL object.
 * only the main XML file is used for comparison
 
-    DATA: ls_remote_file    TYPE zif_abapgit_definitions=>ty_file,
-          lo_remote_version TYPE REF TO zcl_abapgit_xml_input,
-          lv_count          TYPE i,
-          ls_result         TYPE zif_abapgit_comparator=>ty_result,
-          lv_answer         TYPE string,
-          li_comparator     TYPE REF TO zif_abapgit_comparator.
-
+    DATA: ls_remote_file      TYPE zif_abapgit_definitions=>ty_file,
+          lo_remote_version   TYPE REF TO zcl_abapgit_xml_input,
+          lv_count            TYPE i,
+          ls_result           TYPE zif_abapgit_comparator=>ty_result,
+          lv_answer           TYPE string,
+          li_comparator       TYPE REF TO zif_abapgit_comparator,
+          lv_gui_is_available TYPE abap_bool,
+          ls_item             TYPE zif_abapgit_definitions=>ty_item.
 
     FIND ALL OCCURRENCES OF '.' IN is_result-filename MATCH COUNT lv_count.
 
@@ -365,28 +372,39 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
           iv_xml      = zcl_abapgit_convert=>xstring_to_string_utf8( ls_remote_file-data )
           iv_filename = ls_remote_file-filename.
 
-      ls_result = li_comparator->compare( lo_remote_version ).
+      ls_result = li_comparator->compare( io_remote = lo_remote_version ii_log = ii_log ).
       IF ls_result-text IS INITIAL.
         RETURN.
       ENDIF.
 
-      CALL FUNCTION 'POPUP_TO_CONFIRM'
-        EXPORTING
-          titlebar              = 'Warning'
-          text_question         = ls_result-text
-          text_button_1         = 'Abort'
-          icon_button_1         = 'ICON_CANCEL'
-          text_button_2         = 'Pull anyway'
-          icon_button_2         = 'ICON_OKAY'
-          default_button        = '2'
-          display_cancel_button = abap_false
-        IMPORTING
-          answer                = lv_answer
-        EXCEPTIONS
-          text_not_found        = 1
-          OTHERS                = 2.                        "#EC NOTEXT
-      IF sy-subrc <> 0 OR lv_answer = 1.
-        zcx_abapgit_exception=>raise( 'Deserialization aborted by user' ).
+      "log comparison result
+      ls_item-obj_type = is_result-obj_type.
+      ls_item-obj_name = is_result-obj_name.
+      ii_log->add_warning( iv_msg = ls_result-text is_item = ls_item ).
+
+      "continue or abort?
+      lv_gui_is_available = zcl_abapgit_ui_factory=>get_gui_functions( )->gui_is_available( ).
+      IF lv_gui_is_available = abap_true.
+        CALL FUNCTION 'POPUP_TO_CONFIRM'
+          EXPORTING
+            titlebar              = 'Warning'
+            text_question         = ls_result-text
+            text_button_1         = 'Abort'
+            icon_button_1         = 'ICON_CANCEL'
+            text_button_2         = 'Pull anyway'
+            icon_button_2         = 'ICON_OKAY'
+            default_button        = '2'
+            display_cancel_button = abap_false
+          IMPORTING
+            answer                = lv_answer
+          EXCEPTIONS
+            text_not_found        = 1
+            OTHERS                = 2.                        "#EC NOTEXT
+        IF sy-subrc <> 0 OR lv_answer = 1.
+          zcx_abapgit_exception=>raise( |Deserialization for object { is_result-obj_name } (type { is_result-obj_type }) aborted by user| ).
+        ENDIF.
+      ELSE.
+        zcx_abapgit_exception=>raise( |Deserialization for object { is_result-obj_name } (type { is_result-obj_type }) aborted, user descision required| ).
       ENDIF.
     ENDIF.
 
@@ -532,7 +550,8 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
           lv_path     TYPE string,
           lt_items    TYPE zif_abapgit_definitions=>ty_items_tt,
           lt_steps_id TYPE zif_abapgit_object=>ty_deserialization_step_tt,
-          lt_steps    TYPE ty_step_data_tt.
+          lt_steps    TYPE ty_step_data_tt,
+          lx_exc      TYPE REF TO zcx_abapgit_exception.
     DATA: lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
 
     FIELD-SYMBOLS: <ls_result>  TYPE zif_abapgit_definitions=>ty_result,
@@ -552,7 +571,7 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
     lt_remote = io_repo->get_files_remote( ).
 
-    lt_results = files_to_deserialize( io_repo ).
+    lt_results = files_to_deserialize( io_repo = io_repo ii_log = ii_log ).
 
     checks_adjust(
       EXPORTING
@@ -577,60 +596,74 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
       ls_item-obj_type = <ls_result>-obj_type.
       ls_item-obj_name = <ls_result>-obj_name.
 
-      lv_package = lo_folder_logic->path_to_package(
-        iv_top  = io_repo->get_package( )
-        io_dot  = io_repo->get_dot_abapgit( )
-        iv_path = <ls_result>-path ).
+      "error handling & logging added
+      TRY.
 
-      IF ls_item-obj_type = 'DEVC'.
-        " Packages have the same filename across different folders. The path needs to be supplied
-        " to find the correct file.
-        lv_path = <ls_result>-path.
-      ENDIF.
+          lv_package = lo_folder_logic->path_to_package(
+            iv_top  = io_repo->get_package( )
+            io_dot  = io_repo->get_dot_abapgit( )
+            iv_path = <ls_result>-path ).
 
-      CREATE OBJECT lo_files
-        EXPORTING
-          is_item = ls_item
-          iv_path = lv_path.
-      lo_files->set_files( lt_remote ).
+          IF ls_item-obj_type = 'DEVC'.
+            " Packages have the same filename across different folders. The path needs to be supplied
+            " to find the correct file.
+            lv_path = <ls_result>-path.
+          ENDIF.
 
-* Analyze XML in order to instantiate the proper serializer
-      lo_xml = lo_files->read_xml( ).
+          CREATE OBJECT lo_files
+            EXPORTING
+              is_item = ls_item
+              iv_path = lv_path.
+          lo_files->set_files( lt_remote ).
 
-      li_obj = create_object( is_item     = ls_item
-                              iv_language = io_repo->get_dot_abapgit( )->get_master_language( )
-                              is_metadata = lo_xml->get_metadata( ) ).
+          "analyze XML in order to instantiate the proper serializer
+          lo_xml = lo_files->read_xml( ).
 
-      compare_remote_to_local(
-        ii_object = li_obj
-        it_remote = lt_remote
-        is_result = <ls_result> ).
+          li_obj = create_object( is_item     = ls_item
+                                  iv_language = io_repo->get_dot_abapgit( )->get_master_language( )
+                                  is_metadata = lo_xml->get_metadata( ) ).
 
-      li_obj->mo_files = lo_files.
+          compare_remote_to_local(
+            ii_object = li_obj
+            it_remote = lt_remote
+            is_result = <ls_result>
+            ii_log    = ii_log ).
 
-* Get required steps for deserialize the object
-      lt_steps_id = li_obj->get_deserialize_steps( ).
+          li_obj->mo_files = lo_files.
 
-      LOOP AT lt_steps_id ASSIGNING <lv_step_id>.
-        READ TABLE lt_steps WITH KEY step_id = <lv_step_id> ASSIGNING <ls_step>.
-        ASSERT sy-subrc = 0.
-        IF <ls_step>-is_ddic = abap_true AND li_obj->get_metadata( )-ddic = abap_false.
-          " DDIC only for DDIC objects
-          zcx_abapgit_exception=>raise( |Step { <lv_step_id> } is only for DDIC objects| ).
-        ENDIF.
-        APPEND INITIAL LINE TO <ls_step>-objects ASSIGNING <ls_deser>.
-        <ls_deser>-item    = ls_item.
-        <ls_deser>-obj     = li_obj.
-        <ls_deser>-xml     = lo_xml.
-        <ls_deser>-package = lv_package.
-      ENDLOOP.
+          "get required steps for deserialize the object
+          lt_steps_id = li_obj->get_deserialize_steps( ).
+
+          LOOP AT lt_steps_id ASSIGNING <lv_step_id>.
+            READ TABLE lt_steps WITH KEY step_id = <lv_step_id> ASSIGNING <ls_step>.
+            ASSERT sy-subrc = 0.
+            IF <ls_step>-is_ddic = abap_true AND li_obj->get_metadata( )-ddic = abap_false.
+              " DDIC only for DDIC objects
+              zcx_abapgit_exception=>raise( |Step { <lv_step_id> } is only for DDIC objects| ).
+            ENDIF.
+            APPEND INITIAL LINE TO <ls_step>-objects ASSIGNING <ls_deser>.
+            <ls_deser>-item    = ls_item.
+            <ls_deser>-obj     = li_obj.
+            <ls_deser>-xml     = lo_xml.
+            <ls_deser>-package = lv_package.
+          ENDLOOP.
+
+          CLEAR: lv_path, lv_package.
+
+        CATCH zcx_abapgit_exception INTO lx_exc.
+          ii_log->add_exception( ix_exc = lx_exc is_item = ls_item ).
+          ii_log->add_error( iv_msg = |Import of object { ls_item-obj_name } failed| is_item = ls_item ).
+          "object should not be part of any deserialization step
+          CONTINUE.
+      ENDTRY.
 
     ENDLOOP.
 
-* run deserialize for all step and it's objets
+    "run deserialize for all steps and it's objects
     SORT lt_steps BY order.
     LOOP AT lt_steps ASSIGNING <ls_step>.
       deserialize_objects( EXPORTING is_step = <ls_step>
+                                     ii_log  = ii_log
                            CHANGING ct_files = rt_accessed_files ).
     ENDLOOP.
 
@@ -671,7 +704,8 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
   METHOD deserialize_objects.
 
-    DATA: li_progress TYPE REF TO zif_abapgit_progress.
+    DATA: li_progress TYPE REF TO zif_abapgit_progress,
+          lx_exc      TYPE REF TO zcx_abapgit_exception.
 
     FIELD-SYMBOLS: <ls_obj> LIKE LINE OF is_step-objects.
 
@@ -685,10 +719,20 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
         iv_current = sy-tabix
         iv_text    = |Deserialize { is_step-descr } - { <ls_obj>-item-obj_name }| ) ##NO_TEXT.
 
-      <ls_obj>-obj->deserialize( iv_package = <ls_obj>-package
-                                 io_xml     = <ls_obj>-xml
-                                 iv_step    = is_step-step_id ).
-      APPEND LINES OF <ls_obj>-obj->mo_files->get_accessed_files( ) TO ct_files.
+      TRY.
+          <ls_obj>-obj->deserialize( iv_package = <ls_obj>-package
+                                     io_xml     = <ls_obj>-xml
+                                     iv_step    = is_step-step_id
+                                     ii_log     = ii_log ).
+          APPEND LINES OF <ls_obj>-obj->mo_files->get_accessed_files( ) TO ct_files.
+
+          ii_log->add_success( iv_msg = |Object { <ls_obj>-item-obj_name } imported| is_item = <ls_obj>-item ).
+
+        CATCH zcx_abapgit_exception INTO lx_exc.
+          ii_log->add_exception( ix_exc = lx_exc is_item = <ls_obj>-item ).
+          ii_log->add_error( iv_msg = |Import of object { <ls_obj>-item-obj_name } failed| is_item = <ls_obj>-item ).
+      ENDTRY.
+
     ENDLOOP.
 
     zcl_abapgit_objects_activation=>activate( is_step-is_ddic ).
@@ -718,18 +762,91 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
     rt_results = adjust_namespaces(
                    prioritize_deser(
                      filter_files_to_deserialize(
-                       zcl_abapgit_file_status=>status( io_repo ) ) ) ).
+                       it_results = zcl_abapgit_file_status=>status( io_repo )
+                       ii_log     = ii_log ) ) ).
 
   ENDMETHOD.
 
 
   METHOD filter_files_to_deserialize.
 
+    DATA lt_objects LIKE rt_results.
+    DATA lr_object  TYPE REF TO zif_abapgit_definitions=>ty_result.
+    DATA ls_item    TYPE zif_abapgit_definitions=>ty_item.
+    DATA lv_tabix   TYPE sy-tabix.
+
     rt_results = it_results.
 
+    "preparation for object logging, sort all file entries by objects
+    IF ii_log IS BOUND.
+      lt_objects = rt_results.
+      SORT lt_objects
+        BY obj_type
+           obj_name.
+      DELETE ADJACENT DUPLICATES FROM lt_objects COMPARING obj_type obj_name.
+      DELETE lt_objects WHERE obj_type IS INITIAL AND obj_name IS INITIAL.
+    ENDIF.
+
+    "ignore objects w/o changes
     DELETE rt_results WHERE match = abap_true.     " Full match
+    "log objects w/o changes
+    IF sy-subrc = 0 AND ii_log IS BOUND.
+      SORT rt_results BY obj_type obj_name.
+      LOOP AT lt_objects REFERENCE INTO lr_object.
+        lv_tabix = sy-tabix.
+        READ TABLE rt_results WITH KEY obj_type = lr_object->obj_type
+                                       obj_name = lr_object->obj_name
+                              BINARY SEARCH TRANSPORTING NO FIELDS.
+        IF sy-subrc <> 0.
+          "all parts of the objects have not changed
+          ls_item-devclass = lr_object->package.
+          ls_item-obj_type = lr_object->obj_type.
+          ls_item-obj_name = lr_object->obj_name.
+          ii_log->add_success( iv_msg  = |Object { ls_item-obj_name } (type { ls_item-obj_type }) not changed; no import required|
+                               is_item = ls_item ).
+          "ignore object for further messages
+          DELETE lt_objects INDEX lv_tabix.
+        ENDIF.
+      ENDLOOP.
+    ENDIF.
+
+    "ignore objects w/o object type
     DELETE rt_results WHERE obj_type IS INITIAL.
+    "log objects w/o object type
+    IF sy-subrc = 0 AND ii_log IS BOUND.
+      LOOP AT lt_objects REFERENCE INTO lr_object WHERE obj_type IS INITIAL.
+        CHECK lr_object->obj_name IS NOT INITIAL.
+        ls_item-devclass = lr_object->package.
+        ls_item-obj_type = lr_object->obj_type.
+        ls_item-obj_name = lr_object->obj_name.
+        ii_log->add_warning( iv_msg  = |Object type for { ls_item-obj_name } not defined - will be ignored by abapGit|
+                             is_item = ls_item ).
+      ENDLOOP.
+      DELETE lt_objects WHERE obj_type IS INITIAL.
+    ENDIF.
+
+    "ignore objects that exists only local
     DELETE rt_results WHERE lstate = zif_abapgit_definitions=>c_state-added AND rstate IS INITIAL.
+    "log objects that exists only local
+    IF sy-subrc = 0 AND ii_log IS BOUND.
+      SORT rt_results BY obj_type obj_name.
+      LOOP AT lt_objects REFERENCE INTO lr_object.
+        lv_tabix = sy-tabix.
+        READ TABLE rt_results WITH KEY obj_type = lr_object->obj_type
+                                       obj_name = lr_object->obj_name
+                              BINARY SEARCH TRANSPORTING NO FIELDS.
+        IF sy-subrc <> 0.
+          "all parts exists only local
+          ls_item-devclass = lr_object->package.
+          ls_item-obj_type = lr_object->obj_type.
+          ls_item-obj_name = lr_object->obj_name.
+          ii_log->add_success( iv_msg  = |Object { ls_item-obj_name } (type { ls_item-obj_type }) only exists local; no import required|
+                               is_item = ls_item ).
+          "ignore object for further messages
+          DELETE lt_objects INDEX lv_tabix.
+        ENDIF.
+      ENDLOOP.
+    ENDIF.
 
     SORT rt_results
       BY obj_type ASCENDING

--- a/src/zcl_abapgit_objects.clas.abap
+++ b/src/zcl_abapgit_objects.clas.abap
@@ -401,10 +401,12 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
             text_not_found        = 1
             OTHERS                = 2.                        "#EC NOTEXT
         IF sy-subrc <> 0 OR lv_answer = 1.
-          zcx_abapgit_exception=>raise( |Deserialization for object { is_result-obj_name } (type { is_result-obj_type }) aborted by user| ).
+          zcx_abapgit_exception=>raise( |Deserialization for object { is_result-obj_name } | &
+                                        |(type { is_result-obj_type }) aborted by user| ).
         ENDIF.
       ELSE.
-        zcx_abapgit_exception=>raise( |Deserialization for object { is_result-obj_name } (type { is_result-obj_type }) aborted, user descision required| ).
+        zcx_abapgit_exception=>raise( |Deserialization for object { is_result-obj_name } | &
+                                      |(type { is_result-obj_type }) aborted, user descision required| ).
       ENDIF.
     ENDIF.
 
@@ -802,8 +804,9 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
           ls_item-devclass = lr_object->package.
           ls_item-obj_type = lr_object->obj_type.
           ls_item-obj_name = lr_object->obj_name.
-          ii_log->add_success( iv_msg  = |Object { ls_item-obj_name } (type { ls_item-obj_type }) not changed; no import required|
-                               is_item = ls_item ).
+          ii_log->add_success(
+            iv_msg  = |Object { ls_item-obj_name } (type { ls_item-obj_type }) not changed; no import required|
+            is_item = ls_item ).
           "ignore object for further messages
           DELETE lt_objects INDEX lv_tabix.
         ENDIF.
@@ -819,8 +822,9 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
         ls_item-devclass = lr_object->package.
         ls_item-obj_type = lr_object->obj_type.
         ls_item-obj_name = lr_object->obj_name.
-        ii_log->add_warning( iv_msg  = |Object type for { ls_item-obj_name } not defined - will be ignored by abapGit|
-                             is_item = ls_item ).
+        ii_log->add_warning(
+          iv_msg  = |Object type for { ls_item-obj_name } not defined - will be ignored by abapGit|
+          is_item = ls_item ).
       ENDLOOP.
       DELETE lt_objects WHERE obj_type IS INITIAL.
     ENDIF.
@@ -840,8 +844,9 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
           ls_item-devclass = lr_object->package.
           ls_item-obj_type = lr_object->obj_type.
           ls_item-obj_name = lr_object->obj_name.
-          ii_log->add_success( iv_msg  = |Object { ls_item-obj_name } (type { ls_item-obj_type }) only exists local; no import required|
-                               is_item = ls_item ).
+          ii_log->add_success(
+            iv_msg  = |Object { ls_item-obj_name } (type { ls_item-obj_type }) only exists local; no import required|
+            is_item = ls_item ).
           "ignore object for further messages
           DELETE lt_objects INDEX lv_tabix.
         ENDIF.

--- a/src/zcl_abapgit_objects.clas.testclasses.abap
+++ b/src/zcl_abapgit_objects.clas.testclasses.abap
@@ -60,7 +60,8 @@ CLASS ltcl_dangerous IMPLEMENTATION.
       iv_branch_name = 'refs/heads/master'
       iv_package     = c_package ).
     lo_repo->status( ).
-    lo_repo->deserialize( ls_checks ).
+    lo_repo->deserialize( is_checks = ls_checks
+                          ii_log    = new zcl_abapgit_log( ) ).
 
     lt_tadir = zcl_abapgit_factory=>get_tadir( )->read( c_package ).
     LOOP AT lt_types ASSIGNING <lv_type>.

--- a/src/zcl_abapgit_objects.clas.testclasses.abap
+++ b/src/zcl_abapgit_objects.clas.testclasses.abap
@@ -44,12 +44,14 @@ CLASS ltcl_dangerous IMPLEMENTATION.
           lv_msg     TYPE string,
           lt_results TYPE zif_abapgit_definitions=>ty_results_tt,
           ls_checks  TYPE zif_abapgit_definitions=>ty_deserialize_checks,
-          lt_types   TYPE zcl_abapgit_objects=>ty_types_tt.
+          lt_types   TYPE zcl_abapgit_objects=>ty_types_tt,
+          lo_log     TYPE REF TO zif_abapgit_log.
 
     FIELD-SYMBOLS: <ls_result> LIKE LINE OF lt_results,
                    <ls_tadir>  LIKE LINE OF lt_tadir,
                    <lv_type>   LIKE LINE OF lt_types.
 
+    CREATE OBJECT lo_log TYPE zcl_abapgit_log.
 
     zcl_abapgit_factory=>get_sap_package( c_package )->create_local( ).
 
@@ -61,7 +63,7 @@ CLASS ltcl_dangerous IMPLEMENTATION.
       iv_package     = c_package ).
     lo_repo->status( ).
     lo_repo->deserialize( is_checks = ls_checks
-                          ii_log    = new zcl_abapgit_log( ) ).
+                          ii_log    = lo_log ).
 
     lt_tadir = zcl_abapgit_factory=>get_tadir( )->read( c_package ).
     LOOP AT lt_types ASSIGNING <lv_type>.

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -118,9 +118,8 @@ CLASS zcl_abapgit_repo DEFINITION
       RETURNING
         VALUE(ri_log) TYPE REF TO zif_abapgit_log .
     METHODS get_log
-      EXPORTING
-        !ei_log   TYPE REF TO zif_abapgit_log
-        !ev_title TYPE string .
+      RETURNING
+        VALUE(ri_log) TYPE REF TO zif_abapgit_log .
     METHODS reset_log .
   PROTECTED SECTION.
 
@@ -131,7 +130,6 @@ CLASS zcl_abapgit_repo DEFINITION
     DATA mv_request_remote_refresh TYPE abap_bool .
     DATA mt_status TYPE zif_abapgit_definitions=>ty_results_tt .
     DATA mi_log TYPE REF TO zif_abapgit_log .
-    DATA mv_log_title TYPE string .
 
     METHODS set
       IMPORTING
@@ -261,7 +259,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
   METHOD create_new_log.
 
     CREATE OBJECT mi_log TYPE zcl_abapgit_log.
-    mv_log_title = iv_title.
+    mi_log->set_title( iv_title ).
 
     ri_log = mi_log.
 
@@ -456,8 +454,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
 
   METHOD get_log.
-    ei_log   = mi_log.
-    ev_title = mv_log_title.
+    ri_log = mi_log.
   ENDMETHOD.
 
 
@@ -547,7 +544,6 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
   METHOD reset_log.
     CLEAR mi_log.
-    CLEAR mv_log_title.
   ENDMETHOD.
 
 

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -1,140 +1,153 @@
-CLASS zcl_abapgit_repo DEFINITION
-  PUBLIC
-  ABSTRACT
-  CREATE PUBLIC .
+class ZCL_ABAPGIT_REPO definition
+  public
+  abstract
+  create public .
 
-  PUBLIC SECTION.
+public section.
 
-    METHODS bind_listener
-      IMPORTING
-        !ii_listener TYPE REF TO zif_abapgit_repo_listener .
-    METHODS deserialize_checks
-      RETURNING
-        VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_deserialize_checks
-      RAISING
-        zcx_abapgit_exception .
-    METHODS delete_checks
-      RETURNING
-        VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_delete_checks
-      RAISING
-        zcx_abapgit_exception .
-    METHODS constructor
-      IMPORTING
-        !is_data TYPE zif_abapgit_persistence=>ty_repo .
-    METHODS get_key
-      RETURNING
-        VALUE(rv_key) TYPE zif_abapgit_persistence=>ty_value .
-    METHODS get_name
-      RETURNING
-        VALUE(rv_name) TYPE string
-      RAISING
-        zcx_abapgit_exception .
-    METHODS get_files_local
-      IMPORTING
-        !ii_log         TYPE REF TO zif_abapgit_log OPTIONAL
-        !it_filter      TYPE zif_abapgit_definitions=>ty_tadir_tt OPTIONAL
-      RETURNING
-        VALUE(rt_files) TYPE zif_abapgit_definitions=>ty_files_item_tt
-      RAISING
-        zcx_abapgit_exception .
-    METHODS get_local_checksums_per_file
-      RETURNING
-        VALUE(rt_checksums) TYPE zif_abapgit_definitions=>ty_file_signatures_tt .
-    METHODS get_files_remote
-      RETURNING
-        VALUE(rt_files) TYPE zif_abapgit_definitions=>ty_files_tt
-      RAISING
-        zcx_abapgit_exception .
-    METHODS get_package
-      RETURNING
-        VALUE(rv_package) TYPE zif_abapgit_persistence=>ty_repo-package .
-    METHODS get_dot_abapgit
-      RETURNING
-        VALUE(ro_dot_abapgit) TYPE REF TO zcl_abapgit_dot_abapgit .
-    METHODS set_dot_abapgit
-      IMPORTING
-        !io_dot_abapgit TYPE REF TO zcl_abapgit_dot_abapgit
-      RAISING
-        zcx_abapgit_exception .
-    METHODS deserialize
-      IMPORTING
-        !is_checks TYPE zif_abapgit_definitions=>ty_deserialize_checks
-      RAISING
-        zcx_abapgit_exception .
-    METHODS refresh
-      IMPORTING
-        !iv_drop_cache TYPE abap_bool DEFAULT abap_false
-      RAISING
-        zcx_abapgit_exception .
-    METHODS update_local_checksums
-      IMPORTING
-        !it_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt
-      RAISING
-        zcx_abapgit_exception .
-    METHODS rebuild_local_checksums
-      RAISING
-        zcx_abapgit_exception .
-    METHODS find_remote_dot_abapgit
-      RETURNING
-        VALUE(ro_dot) TYPE REF TO zcl_abapgit_dot_abapgit
-      RAISING
-        zcx_abapgit_exception .
-    METHODS is_offline
-      RETURNING
-        VALUE(rv_offline) TYPE abap_bool
-      RAISING
-        zcx_abapgit_exception .
-    METHODS set_files_remote
-      IMPORTING
-        !it_files TYPE zif_abapgit_definitions=>ty_files_tt .
-    METHODS get_local_settings
-      RETURNING
-        VALUE(rs_settings) TYPE zif_abapgit_persistence=>ty_repo-local_settings .
-    METHODS set_local_settings
-      IMPORTING
-        !is_settings TYPE zif_abapgit_persistence=>ty_repo-local_settings
-      RAISING
-        zcx_abapgit_exception .
-    METHODS has_remote_source
-          ABSTRACT
-      RETURNING
-        VALUE(rv_yes) TYPE abap_bool .
-    METHODS status
-      IMPORTING
-        !ii_log           TYPE REF TO zif_abapgit_log OPTIONAL
-      RETURNING
-        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
-      RAISING
-        zcx_abapgit_exception .
-    METHODS switch_repo_type
-      IMPORTING
-        iv_offline TYPE abap_bool
-      RAISING
-        zcx_abapgit_exception .
-  PROTECTED SECTION.
+  methods BIND_LISTENER
+    importing
+      !II_LISTENER type ref to ZIF_ABAPGIT_REPO_LISTENER .
+  methods DESERIALIZE_CHECKS
+    returning
+      value(RS_CHECKS) type ZIF_ABAPGIT_DEFINITIONS=>TY_DESERIALIZE_CHECKS
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods DELETE_CHECKS
+    returning
+      value(RS_CHECKS) type ZIF_ABAPGIT_DEFINITIONS=>TY_DELETE_CHECKS
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods CONSTRUCTOR
+    importing
+      !IS_DATA type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO .
+  methods GET_KEY
+    returning
+      value(RV_KEY) type ZIF_ABAPGIT_PERSISTENCE=>TY_VALUE .
+  methods GET_NAME
+    returning
+      value(RV_NAME) type STRING
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods GET_FILES_LOCAL
+    importing
+      !II_LOG type ref to ZIF_ABAPGIT_LOG optional
+      !IT_FILTER type ZIF_ABAPGIT_DEFINITIONS=>TY_TADIR_TT optional
+    returning
+      value(RT_FILES) type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_ITEM_TT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods GET_LOCAL_CHECKSUMS_PER_FILE
+    returning
+      value(RT_CHECKSUMS) type ZIF_ABAPGIT_DEFINITIONS=>TY_FILE_SIGNATURES_TT .
+  methods GET_FILES_REMOTE
+    returning
+      value(RT_FILES) type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_TT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods GET_PACKAGE
+    returning
+      value(RV_PACKAGE) type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-PACKAGE .
+  methods GET_DOT_ABAPGIT
+    returning
+      value(RO_DOT_ABAPGIT) type ref to ZCL_ABAPGIT_DOT_ABAPGIT .
+  methods SET_DOT_ABAPGIT
+    importing
+      !IO_DOT_ABAPGIT type ref to ZCL_ABAPGIT_DOT_ABAPGIT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods DESERIALIZE
+    importing
+      !IS_CHECKS type ZIF_ABAPGIT_DEFINITIONS=>TY_DESERIALIZE_CHECKS
+      !II_LOG type ref to ZIF_ABAPGIT_LOG
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods REFRESH
+    importing
+      !IV_DROP_CACHE type ABAP_BOOL default ABAP_FALSE
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods UPDATE_LOCAL_CHECKSUMS
+    importing
+      !IT_FILES type ZIF_ABAPGIT_DEFINITIONS=>TY_FILE_SIGNATURES_TT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods REBUILD_LOCAL_CHECKSUMS
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods FIND_REMOTE_DOT_ABAPGIT
+    returning
+      value(RO_DOT) type ref to ZCL_ABAPGIT_DOT_ABAPGIT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods IS_OFFLINE
+    returning
+      value(RV_OFFLINE) type ABAP_BOOL
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods SET_FILES_REMOTE
+    importing
+      !IT_FILES type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_TT .
+  methods GET_LOCAL_SETTINGS
+    returning
+      value(RS_SETTINGS) type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-LOCAL_SETTINGS .
+  methods SET_LOCAL_SETTINGS
+    importing
+      !IS_SETTINGS type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-LOCAL_SETTINGS
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods HAS_REMOTE_SOURCE
+  abstract
+    returning
+      value(RV_YES) type ABAP_BOOL .
+  methods STATUS
+    importing
+      !II_LOG type ref to ZIF_ABAPGIT_LOG optional
+    returning
+      value(RT_RESULTS) type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods SWITCH_REPO_TYPE
+    importing
+      !IV_OFFLINE type ABAP_BOOL
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods CREATE_NEW_LOG
+    importing
+      !IV_TITLE type STRING optional
+    returning
+      value(RI_LOG) type ref to ZIF_ABAPGIT_LOG .
+  methods GET_LOG
+    exporting
+      !EI_LOG type ref to ZIF_ABAPGIT_LOG
+      !EV_TITLE type STRING .
+  methods RESET_LOG .
+protected section.
 
-    DATA mt_local TYPE zif_abapgit_definitions=>ty_files_item_tt .
-    DATA mt_remote TYPE zif_abapgit_definitions=>ty_files_tt .
-    DATA mv_request_local_refresh TYPE abap_bool .
-    DATA ms_data TYPE zif_abapgit_persistence=>ty_repo .
-    DATA mv_request_remote_refresh TYPE abap_bool .
-    DATA mt_status TYPE zif_abapgit_definitions=>ty_results_tt .
+  data MT_LOCAL type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_ITEM_TT .
+  data MT_REMOTE type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_TT .
+  data MV_REQUEST_LOCAL_REFRESH type ABAP_BOOL .
+  data MS_DATA type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO .
+  data MV_REQUEST_REMOTE_REFRESH type ABAP_BOOL .
+  data MT_STATUS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT .
+  data MI_LOG type ref to ZIF_ABAPGIT_LOG .
+  data MV_LOG_TITLE type STRING .
 
-    METHODS set
-      IMPORTING
-        !it_checksums       TYPE zif_abapgit_persistence=>ty_local_checksum_tt OPTIONAL
-        !iv_url             TYPE zif_abapgit_persistence=>ty_repo-url OPTIONAL
-        !iv_branch_name     TYPE zif_abapgit_persistence=>ty_repo-branch_name OPTIONAL
-        !iv_head_branch     TYPE zif_abapgit_persistence=>ty_repo-head_branch OPTIONAL
-        !iv_offline         TYPE zif_abapgit_persistence=>ty_repo-offline OPTIONAL
-        !is_dot_abapgit     TYPE zif_abapgit_persistence=>ty_repo-dot_abapgit OPTIONAL
-        !is_local_settings  TYPE zif_abapgit_persistence=>ty_repo-local_settings OPTIONAL
-        !iv_deserialized_at TYPE zif_abapgit_persistence=>ty_repo-deserialized_at OPTIONAL
-        !iv_deserialized_by TYPE zif_abapgit_persistence=>ty_repo-deserialized_by OPTIONAL
-      RAISING
-        zcx_abapgit_exception .
-    METHODS reset_status .
-    METHODS reset_remote .
+  methods SET
+    importing
+      !IT_CHECKSUMS type ZIF_ABAPGIT_PERSISTENCE=>TY_LOCAL_CHECKSUM_TT optional
+      !IV_URL type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-URL optional
+      !IV_BRANCH_NAME type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-BRANCH_NAME optional
+      !IV_HEAD_BRANCH type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-HEAD_BRANCH optional
+      !IV_OFFLINE type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-OFFLINE optional
+      !IS_DOT_ABAPGIT type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-DOT_ABAPGIT optional
+      !IS_LOCAL_SETTINGS type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-LOCAL_SETTINGS optional
+      !IV_DESERIALIZED_AT type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-DESERIALIZED_AT optional
+      !IV_DESERIALIZED_BY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-DESERIALIZED_BY optional
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  methods RESET_STATUS .
+  methods RESET_REMOTE .
   PRIVATE SECTION.
 
     DATA mi_listener TYPE REF TO zif_abapgit_repo_listener .
@@ -245,6 +258,16 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD CREATE_NEW_LOG.
+
+    CREATE OBJECT mi_log TYPE zcl_abapgit_log.
+    mv_log_title = iv_title.
+
+    ri_log = mi_log.
+
+  ENDMETHOD.
+
+
   METHOD delete_checks.
 
     DATA: li_package TYPE REF TO zif_abapgit_sap_package.
@@ -274,7 +297,8 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
     TRY.
         lt_updated_files = zcl_abapgit_objects=>deserialize(
             io_repo   = me
-            is_checks = is_checks ).
+            is_checks = is_checks
+            ii_log    = ii_log ).
       CATCH zcx_abapgit_exception INTO lx_error.
 * ensure to reset default transport request task
         zcl_abapgit_default_transport=>get_instance( )->reset( ).
@@ -431,6 +455,12 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD get_log.
+    ei_log   = mi_log.
+    ev_title = mv_log_title.
+  ENDMETHOD.
+
+
   METHOD get_name.
 
     rv_name = ms_data-local_settings-display_name.
@@ -506,10 +536,18 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
     mv_request_local_refresh = abap_true.
     reset_remote( ).
 
+    CLEAR mi_log.
+
     IF iv_drop_cache = abap_true.
       CLEAR: mt_local.
     ENDIF.
 
+  ENDMETHOD.
+
+
+  METHOD reset_log.
+    CLEAR mi_log.
+    CLEAR mv_log_title.
   ENDMETHOD.
 
 

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -1,153 +1,153 @@
-class ZCL_ABAPGIT_REPO definition
-  public
-  abstract
-  create public .
+CLASS zcl_abapgit_repo DEFINITION
+  PUBLIC
+  ABSTRACT
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods BIND_LISTENER
-    importing
-      !II_LISTENER type ref to ZIF_ABAPGIT_REPO_LISTENER .
-  methods DESERIALIZE_CHECKS
-    returning
-      value(RS_CHECKS) type ZIF_ABAPGIT_DEFINITIONS=>TY_DESERIALIZE_CHECKS
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods DELETE_CHECKS
-    returning
-      value(RS_CHECKS) type ZIF_ABAPGIT_DEFINITIONS=>TY_DELETE_CHECKS
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods CONSTRUCTOR
-    importing
-      !IS_DATA type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO .
-  methods GET_KEY
-    returning
-      value(RV_KEY) type ZIF_ABAPGIT_PERSISTENCE=>TY_VALUE .
-  methods GET_NAME
-    returning
-      value(RV_NAME) type STRING
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods GET_FILES_LOCAL
-    importing
-      !II_LOG type ref to ZIF_ABAPGIT_LOG optional
-      !IT_FILTER type ZIF_ABAPGIT_DEFINITIONS=>TY_TADIR_TT optional
-    returning
-      value(RT_FILES) type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_ITEM_TT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods GET_LOCAL_CHECKSUMS_PER_FILE
-    returning
-      value(RT_CHECKSUMS) type ZIF_ABAPGIT_DEFINITIONS=>TY_FILE_SIGNATURES_TT .
-  methods GET_FILES_REMOTE
-    returning
-      value(RT_FILES) type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_TT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods GET_PACKAGE
-    returning
-      value(RV_PACKAGE) type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-PACKAGE .
-  methods GET_DOT_ABAPGIT
-    returning
-      value(RO_DOT_ABAPGIT) type ref to ZCL_ABAPGIT_DOT_ABAPGIT .
-  methods SET_DOT_ABAPGIT
-    importing
-      !IO_DOT_ABAPGIT type ref to ZCL_ABAPGIT_DOT_ABAPGIT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods DESERIALIZE
-    importing
-      !IS_CHECKS type ZIF_ABAPGIT_DEFINITIONS=>TY_DESERIALIZE_CHECKS
-      !II_LOG type ref to ZIF_ABAPGIT_LOG
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods REFRESH
-    importing
-      !IV_DROP_CACHE type ABAP_BOOL default ABAP_FALSE
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods UPDATE_LOCAL_CHECKSUMS
-    importing
-      !IT_FILES type ZIF_ABAPGIT_DEFINITIONS=>TY_FILE_SIGNATURES_TT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods REBUILD_LOCAL_CHECKSUMS
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods FIND_REMOTE_DOT_ABAPGIT
-    returning
-      value(RO_DOT) type ref to ZCL_ABAPGIT_DOT_ABAPGIT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods IS_OFFLINE
-    returning
-      value(RV_OFFLINE) type ABAP_BOOL
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods SET_FILES_REMOTE
-    importing
-      !IT_FILES type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_TT .
-  methods GET_LOCAL_SETTINGS
-    returning
-      value(RS_SETTINGS) type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-LOCAL_SETTINGS .
-  methods SET_LOCAL_SETTINGS
-    importing
-      !IS_SETTINGS type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-LOCAL_SETTINGS
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods HAS_REMOTE_SOURCE
-  abstract
-    returning
-      value(RV_YES) type ABAP_BOOL .
-  methods STATUS
-    importing
-      !II_LOG type ref to ZIF_ABAPGIT_LOG optional
-    returning
-      value(RT_RESULTS) type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods SWITCH_REPO_TYPE
-    importing
-      !IV_OFFLINE type ABAP_BOOL
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods CREATE_NEW_LOG
-    importing
-      !IV_TITLE type STRING optional
-    returning
-      value(RI_LOG) type ref to ZIF_ABAPGIT_LOG .
-  methods GET_LOG
-    exporting
-      !EI_LOG type ref to ZIF_ABAPGIT_LOG
-      !EV_TITLE type STRING .
-  methods RESET_LOG .
-protected section.
+    METHODS bind_listener
+      IMPORTING
+        !ii_listener TYPE REF TO zif_abapgit_repo_listener .
+    METHODS deserialize_checks
+      RETURNING
+        VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_deserialize_checks
+      RAISING
+        zcx_abapgit_exception .
+    METHODS delete_checks
+      RETURNING
+        VALUE(rs_checks) TYPE zif_abapgit_definitions=>ty_delete_checks
+      RAISING
+        zcx_abapgit_exception .
+    METHODS constructor
+      IMPORTING
+        !is_data TYPE zif_abapgit_persistence=>ty_repo .
+    METHODS get_key
+      RETURNING
+        VALUE(rv_key) TYPE zif_abapgit_persistence=>ty_value .
+    METHODS get_name
+      RETURNING
+        VALUE(rv_name) TYPE string
+      RAISING
+        zcx_abapgit_exception .
+    METHODS get_files_local
+      IMPORTING
+        !ii_log         TYPE REF TO zif_abapgit_log OPTIONAL
+        !it_filter      TYPE zif_abapgit_definitions=>ty_tadir_tt OPTIONAL
+      RETURNING
+        VALUE(rt_files) TYPE zif_abapgit_definitions=>ty_files_item_tt
+      RAISING
+        zcx_abapgit_exception .
+    METHODS get_local_checksums_per_file
+      RETURNING
+        VALUE(rt_checksums) TYPE zif_abapgit_definitions=>ty_file_signatures_tt .
+    METHODS get_files_remote
+      RETURNING
+        VALUE(rt_files) TYPE zif_abapgit_definitions=>ty_files_tt
+      RAISING
+        zcx_abapgit_exception .
+    METHODS get_package
+      RETURNING
+        VALUE(rv_package) TYPE zif_abapgit_persistence=>ty_repo-package .
+    METHODS get_dot_abapgit
+      RETURNING
+        VALUE(ro_dot_abapgit) TYPE REF TO zcl_abapgit_dot_abapgit .
+    METHODS set_dot_abapgit
+      IMPORTING
+        !io_dot_abapgit TYPE REF TO zcl_abapgit_dot_abapgit
+      RAISING
+        zcx_abapgit_exception .
+    METHODS deserialize
+      IMPORTING
+        !is_checks TYPE zif_abapgit_definitions=>ty_deserialize_checks
+        !ii_log    TYPE REF TO zif_abapgit_log
+      RAISING
+        zcx_abapgit_exception .
+    METHODS refresh
+      IMPORTING
+        !iv_drop_cache TYPE abap_bool DEFAULT abap_false
+      RAISING
+        zcx_abapgit_exception .
+    METHODS update_local_checksums
+      IMPORTING
+        !it_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt
+      RAISING
+        zcx_abapgit_exception .
+    METHODS rebuild_local_checksums
+      RAISING
+        zcx_abapgit_exception .
+    METHODS find_remote_dot_abapgit
+      RETURNING
+        VALUE(ro_dot) TYPE REF TO zcl_abapgit_dot_abapgit
+      RAISING
+        zcx_abapgit_exception .
+    METHODS is_offline
+      RETURNING
+        VALUE(rv_offline) TYPE abap_bool
+      RAISING
+        zcx_abapgit_exception .
+    METHODS set_files_remote
+      IMPORTING
+        !it_files TYPE zif_abapgit_definitions=>ty_files_tt .
+    METHODS get_local_settings
+      RETURNING
+        VALUE(rs_settings) TYPE zif_abapgit_persistence=>ty_repo-local_settings .
+    METHODS set_local_settings
+      IMPORTING
+        !is_settings TYPE zif_abapgit_persistence=>ty_repo-local_settings
+      RAISING
+        zcx_abapgit_exception .
+    METHODS has_remote_source
+          ABSTRACT
+      RETURNING
+        VALUE(rv_yes) TYPE abap_bool .
+    METHODS status
+      IMPORTING
+        !ii_log           TYPE REF TO zif_abapgit_log OPTIONAL
+      RETURNING
+        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
+      RAISING
+        zcx_abapgit_exception .
+    METHODS switch_repo_type
+      IMPORTING
+        !iv_offline TYPE abap_bool
+      RAISING
+        zcx_abapgit_exception .
+    METHODS create_new_log
+      IMPORTING
+        !iv_title     TYPE string OPTIONAL
+      RETURNING
+        VALUE(ri_log) TYPE REF TO zif_abapgit_log .
+    METHODS get_log
+      EXPORTING
+        !ei_log   TYPE REF TO zif_abapgit_log
+        !ev_title TYPE string .
+    METHODS reset_log .
+  PROTECTED SECTION.
 
-  data MT_LOCAL type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_ITEM_TT .
-  data MT_REMOTE type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_TT .
-  data MV_REQUEST_LOCAL_REFRESH type ABAP_BOOL .
-  data MS_DATA type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO .
-  data MV_REQUEST_REMOTE_REFRESH type ABAP_BOOL .
-  data MT_STATUS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT .
-  data MI_LOG type ref to ZIF_ABAPGIT_LOG .
-  data MV_LOG_TITLE type STRING .
+    DATA mt_local TYPE zif_abapgit_definitions=>ty_files_item_tt .
+    DATA mt_remote TYPE zif_abapgit_definitions=>ty_files_tt .
+    DATA mv_request_local_refresh TYPE abap_bool .
+    DATA ms_data TYPE zif_abapgit_persistence=>ty_repo .
+    DATA mv_request_remote_refresh TYPE abap_bool .
+    DATA mt_status TYPE zif_abapgit_definitions=>ty_results_tt .
+    DATA mi_log TYPE REF TO zif_abapgit_log .
+    DATA mv_log_title TYPE string .
 
-  methods SET
-    importing
-      !IT_CHECKSUMS type ZIF_ABAPGIT_PERSISTENCE=>TY_LOCAL_CHECKSUM_TT optional
-      !IV_URL type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-URL optional
-      !IV_BRANCH_NAME type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-BRANCH_NAME optional
-      !IV_HEAD_BRANCH type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-HEAD_BRANCH optional
-      !IV_OFFLINE type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-OFFLINE optional
-      !IS_DOT_ABAPGIT type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-DOT_ABAPGIT optional
-      !IS_LOCAL_SETTINGS type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-LOCAL_SETTINGS optional
-      !IV_DESERIALIZED_AT type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-DESERIALIZED_AT optional
-      !IV_DESERIALIZED_BY type ZIF_ABAPGIT_PERSISTENCE=>TY_REPO-DESERIALIZED_BY optional
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  methods RESET_STATUS .
-  methods RESET_REMOTE .
+    METHODS set
+      IMPORTING
+        !it_checksums       TYPE zif_abapgit_persistence=>ty_local_checksum_tt OPTIONAL
+        !iv_url             TYPE zif_abapgit_persistence=>ty_repo-url OPTIONAL
+        !iv_branch_name     TYPE zif_abapgit_persistence=>ty_repo-branch_name OPTIONAL
+        !iv_head_branch     TYPE zif_abapgit_persistence=>ty_repo-head_branch OPTIONAL
+        !iv_offline         TYPE zif_abapgit_persistence=>ty_repo-offline OPTIONAL
+        !is_dot_abapgit     TYPE zif_abapgit_persistence=>ty_repo-dot_abapgit OPTIONAL
+        !is_local_settings  TYPE zif_abapgit_persistence=>ty_repo-local_settings OPTIONAL
+        !iv_deserialized_at TYPE zif_abapgit_persistence=>ty_repo-deserialized_at OPTIONAL
+        !iv_deserialized_by TYPE zif_abapgit_persistence=>ty_repo-deserialized_by OPTIONAL
+      RAISING
+        zcx_abapgit_exception .
+    METHODS reset_status .
+    METHODS reset_remote .
   PRIVATE SECTION.
 
     DATA mi_listener TYPE REF TO zif_abapgit_repo_listener .
@@ -258,7 +258,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD CREATE_NEW_LOG.
+  METHOD create_new_log.
 
     CREATE OBJECT mi_log TYPE zcl_abapgit_log.
     mv_log_title = iv_title.

--- a/src/zcl_abapgit_repo.clas.xml
+++ b/src/zcl_abapgit_repo.clas.xml
@@ -11,6 +11,14 @@
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
    </VSEOCLASS>
+   <DESCRIPTIONS>
+    <SEOCOMPOTX>
+     <CLSNAME>ZCL_ABAPGIT_REPO</CLSNAME>
+     <CMPNAME>MI_LOG</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Log</DESCRIPT>
+    </SEOCOMPOTX>
+   </DESCRIPTIONS>
   </asx:values>
  </asx:abap>
 </abapGit>

--- a/src/zcl_abapgit_repo.clas.xml
+++ b/src/zcl_abapgit_repo.clas.xml
@@ -11,14 +11,6 @@
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
    </VSEOCLASS>
-   <DESCRIPTIONS>
-    <SEOCOMPOTX>
-     <CLSNAME>ZCL_ABAPGIT_REPO</CLSNAME>
-     <CMPNAME>MI_LOG</CMPNAME>
-     <LANGU>E</LANGU>
-     <DESCRIPT>Log</DESCRIPT>
-    </SEOCOMPOTX>
-   </DESCRIPTIONS>
   </asx:values>
  </asx:abap>
 </abapGit>

--- a/src/zcl_abapgit_repo_content_list.clas.abap
+++ b/src/zcl_abapgit_repo_content_list.clas.abap
@@ -203,7 +203,27 @@ CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
 
 
   METHOD get_log.
+    DATA li_repo_log TYPE REF TO zif_abapgit_log.
+    DATA lt_repo_msg TYPE        zif_abapgit_log=>tty_log_out.
+    DATA lr_repo_msg TYPE REF TO zif_abapgit_log=>ty_log_out.
+
     ri_log = mi_log.
+
+    "add warning and error messages from repo log
+    li_repo_log = mo_repo->get_log( ).
+    IF li_repo_log IS BOUND.
+      lt_repo_msg = li_repo_log->get_messages( ).
+      LOOP AT lt_repo_msg REFERENCE INTO lr_repo_msg WHERE type CA 'EW'.
+        CASE lr_repo_msg->type.
+          WHEN 'E'.
+            ri_log->add_error( iv_msg = lr_repo_msg->text ).
+          WHEN 'W'.
+            ri_log->add_warning( iv_msg = lr_repo_msg->text ).
+          WHEN others.
+            CONTINUE.
+        ENDCASE.
+      ENDLOOP.
+    ENDIF.
   ENDMETHOD.
 
 

--- a/src/zcl_abapgit_repo_content_list.clas.abap
+++ b/src/zcl_abapgit_repo_content_list.clas.abap
@@ -219,7 +219,7 @@ CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
             ri_log->add_error( iv_msg = lr_repo_msg->text ).
           WHEN 'W'.
             ri_log->add_warning( iv_msg = lr_repo_msg->text ).
-          WHEN others.
+          WHEN OTHERS.
             CONTINUE.
         ENDCASE.
       ENDLOOP.

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -407,6 +407,7 @@ INTERFACE zif_abapgit_definitions
       repo_syntax_check        TYPE string VALUE 'repo_syntax_check',
       repo_code_inspector      TYPE string VALUE 'repo_code_inspector',
       repo_open_in_master_lang TYPE string VALUE 'repo_open_in_master_lang',
+      repo_log                 TYPE string VALUE 'repo_log',
       abapgit_home             TYPE string VALUE 'abapgit_home',
       abapgit_install          TYPE string VALUE 'abapgit_install',
       zip_import               TYPE string VALUE 'zip_import',


### PR DESCRIPTION
Interface ZIF_ABAPGIT_LOG is now passed for deserialization API.

This includes:
- Log messages for FUGR: Imported function modules and includes
- Improved error messages for TABL compare
- Log objects w/o changes
- Log is shown in the UI if available ("Log" entry appears if a log exists, no persistence!)
This PR enhances #2534 and #2694

Another important change: In case an object fails (or a single function module in a group fails), the import continues with the next object. Currently no error message is shown - I guess the log should be highlighted in case of an error!

Screenshot after "Pull" was triggered (red frame only in screenshot!):
![image](https://user-images.githubusercontent.com/43238681/59048032-5cc5b700-8885-11e9-95a8-dc207d66ce6b.png)

When pressing the "Log" button, a simple message list appears (re-use of existing log UI):
![image](https://user-images.githubusercontent.com/43238681/59048071-6d762d00-8885-11e9-9703-a608387ab4c3.png)