### PR TITLE
Fix for issue #2772

### DIFF
--- a/src/zcl_abapgit_transport_objects.clas.abap
+++ b/src/zcl_abapgit_transport_objects.clas.abap
@@ -64,6 +64,7 @@ CLASS ZCL_ABAPGIT_TRANSPORT_OBJECTS IMPLEMENTATION.
                 iv_data     = ls_local_file-file-data ).
             ENDIF.
           WHEN zif_abapgit_definitions=>c_state-deleted.
+* SUSC, see https://github.com/larshp/abapGit/issues/2772
             IF ls_transport_object-delflag = abap_false AND ls_transport_object-object <> 'SUSC'.
               zcx_abapgit_exception=>raise( |Object { ls_transport_object-obj_name
               } should be removed, but has NO deletion flag in transport| ).

--- a/src/zcl_abapgit_transport_objects.clas.abap
+++ b/src/zcl_abapgit_transport_objects.clas.abap
@@ -64,7 +64,7 @@ CLASS ZCL_ABAPGIT_TRANSPORT_OBJECTS IMPLEMENTATION.
                 iv_data     = ls_local_file-file-data ).
             ENDIF.
           WHEN zif_abapgit_definitions=>c_state-deleted.
-            IF ls_transport_object-delflag = abap_false AND ls_transport_object-object NE 'SUSC'.
+            IF ls_transport_object-delflag = abap_false AND ls_transport_object-object <> 'SUSC'.
               zcx_abapgit_exception=>raise( |Object { ls_transport_object-obj_name
               } should be removed, but has NO deletion flag in transport| ).
             ENDIF.

--- a/src/zcl_abapgit_transport_objects.clas.abap
+++ b/src/zcl_abapgit_transport_objects.clas.abap
@@ -64,11 +64,9 @@ CLASS ZCL_ABAPGIT_TRANSPORT_OBJECTS IMPLEMENTATION.
                 iv_data     = ls_local_file-file-data ).
             ENDIF.
           WHEN zif_abapgit_definitions=>c_state-deleted.
-            IF ls_transport_object-delflag = abap_false.
-              IF ls_transport_object-object NE 'SUSC'.
-                zcx_abapgit_exception=>raise( |Object { ls_transport_object-obj_name
-                } should be removed, but has NO deletion flag in transport| ).
-              ENDIF.
+            IF ls_transport_object-delflag = abap_false AND ls_transport_object-object NE 'SUSC'.
+              zcx_abapgit_exception=>raise( |Object { ls_transport_object-obj_name
+              } should be removed, but has NO deletion flag in transport| ).
             ENDIF.
             io_stage->rm(
               iv_path     = ls_object_status-path

--- a/src/zcl_abapgit_transport_objects.clas.abap
+++ b/src/zcl_abapgit_transport_objects.clas.abap
@@ -65,8 +65,10 @@ CLASS ZCL_ABAPGIT_TRANSPORT_OBJECTS IMPLEMENTATION.
             ENDIF.
           WHEN zif_abapgit_definitions=>c_state-deleted.
             IF ls_transport_object-delflag = abap_false.
-              zcx_abapgit_exception=>raise( |Object { ls_transport_object-obj_name
+              IF ls_transport_object-object NE 'SUSC'.
+                zcx_abapgit_exception=>raise( |Object { ls_transport_object-obj_name
                 } should be removed, but has NO deletion flag in transport| ).
+              ENDIF.
             ENDIF.
             io_stage->rm(
               iv_path     = ls_object_status-path

--- a/src/zcl_abapgit_transport_objects.clas.testclasses.abap
+++ b/src/zcl_abapgit_transport_objects.clas.testclasses.abap
@@ -10,6 +10,7 @@ CLASS ltcl_transport_objects DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HA
       cant_be_added_with_del_flag    FOR TESTING RAISING cx_static_check,
       cant_be_modified_with_del_flag FOR TESTING RAISING cx_static_check,
       deleted_to_removed_files       FOR TESTING RAISING cx_static_check,
+      should_remove_no_delflag FOR TESTING RAISING cx_static_check,
       shouldnt_remove_no_delflag FOR TESTING RAISING cx_static_check,
       should_add_all_local_files FOR TESTING RAISING cx_static_check,
       should_delete_all_related  FOR TESTING RAISING cx_static_check,
@@ -264,6 +265,22 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
       iv_path     = '/a_path' ).
   ENDMETHOD.
 
+  METHOD should_remove_no_delflag.
+    given_the_transport_object(
+       iv_obj_name   = 'ZFOO'
+       iv_obj_type   = 'SUSC'
+       iv_delflag    = abap_false ).
+
+    given_the_object_status(
+      iv_obj_name   = 'ZFOO'
+      iv_obj_type   = 'SUSC'
+      iv_filename   = 'zfoo.susc.xml'
+      iv_path       = '/a_path'
+      iv_lstate     = zif_abapgit_definitions=>c_state-deleted ).
+
+    then_it_should_not_raise_excpt( ).
+  ENDMETHOD.
+  
   METHOD shouldnt_remove_no_delflag.
     given_the_transport_object(
        iv_obj_name   = 'CL_FOO'

--- a/src/zcl_abapgit_transport_objects.clas.testclasses.abap
+++ b/src/zcl_abapgit_transport_objects.clas.testclasses.abap
@@ -280,7 +280,7 @@ CLASS ltcl_transport_objects IMPLEMENTATION.
 
     then_it_should_not_raise_excpt( ).
   ENDMETHOD.
-  
+
   METHOD shouldnt_remove_no_delflag.
     given_the_transport_object(
        iv_obj_name   = 'CL_FOO'


### PR DESCRIPTION
When deleting an authorization object class via transaction SU21, TADIR-DELFLAG is not set. Added logic to skip the error for SUSC objects.

See #2772  for details.