### PR TITLE
Improve error information - follow up Part 2

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -22,7 +22,6 @@
 /* exported onDirectionChange */
 /* exported onOrderByChange  */
 /* exported onTagTypeChange */
-/* exported errorMessagePanelRegisterClick */
 /* exported getIndocStyleSheet */
 
 /**********************************************************
@@ -1351,23 +1350,4 @@ function GitGraphScroller() { // eslint-disable-line no-unused-vars
   var gitGraphWrapperEl = document.querySelector(".gitGraph-Wrapper");
   var gitGraphscrollWrapperEl = document.querySelector(".gitGraph-scrollWrapper");
   gitGraphWrapperEl.scrollLeft = gitGraphscrollWrapperEl.scrollLeft;
-}
-
-// Click on error message panel toggles longtext
-function errorMessagePanelRegisterClick(){
-  var elMessage = document.getElementById("message");
-  if (elMessage){
-    elMessage.addEventListener("click", function(oEvent){
-      toggleMessageDetail(oEvent);
-    });
-  }
-}
-
-function toggleMessageDetail(oEvent){
-  if (oEvent &&  ( oEvent.target.id === "a_goto_source"
-                || oEvent.target.id === "a_callstack"
-                || oEvent.target.id === "a_goto_message") ) {
-    return;
-  }
-  toggleDisplay("message-detail");
 }

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -95,10 +95,6 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT CREATE PUBLIC.
       RAISING
         zcx_abapgit_exception.
 
-    METHODS reg_error_message_panel_click
-      IMPORTING
-        io_html TYPE REF TO zcl_abapgit_html.
-
 ENDCLASS.
 
 
@@ -315,11 +311,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD reg_error_message_panel_click.
-    io_html->add( |errorMessagePanelRegisterClick();| ).
-  ENDMETHOD.
-
-
   METHOD render_error_message_box.
 
     " You should remember that the we have to instantiate ro_html even
@@ -362,7 +353,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
 
     link_hints( ro_html ).
     insert_hotkeys_to_page( ro_html ).
-    reg_error_message_panel_click( ro_html ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
- Cleanup JS
- Delete superflous functions and methods

#2811 