### PR TITLE
Completely dynamic JS hints

### DIFF
--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -53,6 +53,7 @@ input:focus, textarea:focus {
 .pad-right    { padding-right: 6px; }
 .inline       { display: inline; }
 .hidden       { visibility: hidden; }
+.nodisplay    { display: none }
 
 /* PANELS */
 div.panel {
@@ -523,7 +524,7 @@ div.tutorial h2 { font-size: 14pt;}
 }
 .nav-container.float-right ul ul { left: auto; right: 0; }
 .nav-container ul li.current-menu-item { font-weight: 700; }
-.nav-container ul li.block ul { display: block; }
+.nav-container ul li.force-nav-hover ul { display: block; }
 .nav-container ul li:hover > ul { display: block; }
 
 /* special selection style for 1st level items (see also .corner below) */
@@ -719,26 +720,23 @@ div.message-panel:hover .message-panel-commands {
 }
 
 /* Tooltip text */
-.tooltiptext {
-    line-height: 15px;
-    width: 60px;
+.link-hint {
+    line-height: 1em;
     text-align: center;
-    padding: 5px 0;
-    border-radius: 6px;
+    padding: 5px 15px;
+    border-radius: 4px;
 
     /* Position the tooltip text */
     position: absolute;
     z-index: 1;
     margin-left: -60px;
     margin-top: -30px;
-
-    /* Fade in tooltip */
-    opacity: 1;
-    transition: opacity 0.3s;
 }
 
+.link-hint .pending { color: hsla(0, 0%, 0%, 0.2); }
+
 /* Tooltip arrow */
-.tooltiptext::after {
+.link-hint::after {
     content: "";
     position: absolute;
     top: 100%;
@@ -746,6 +744,7 @@ div.message-panel:hover .message-panel-commands {
     margin-left: -5px;
     border-width: 5px;
     border-style: solid;
+    border-color: transparent;
 }
 
 /* HOTKEYS */

--- a/src/ui/zabapgit_css_theme_default.w3mi.data.css
+++ b/src/ui/zabapgit_css_theme_default.w3mi.data.css
@@ -334,9 +334,7 @@ div.info-panel .update {
 }
 
 /* Tooltips text */
-.tooltiptext { color: #000; }
-/* Tooltip arrow */
-.tooltiptext::after { border-color: #555 transparent transparent transparent; }
+.link-hint { color: var(--theme-primary-font-color); }
 
 /* HOTKEYS */
 ul.hotkeys span.key-id {

--- a/src/ui/zabapgit_css_theme_default.w3mi.data.css
+++ b/src/ui/zabapgit_css_theme_default.w3mi.data.css
@@ -16,6 +16,7 @@
   --theme-greyscale-medium: #b3b3b3;
   --theme-greyscale-light: #ccc;
   --theme-greyscale-lighter: lightgrey;
+  --theme-linkhint-background: lightgreen;
 }
 
 /* GLOBALS */
@@ -335,6 +336,8 @@ div.info-panel .update {
 
 /* Tooltips text */
 .link-hint { color: var(--theme-primary-font-color); }
+.link-hint { background-color: var(--theme-linkhint-background) }
+.link-hint::after { border-top-color: var(--theme-linkhint-background) }
 
 /* HOTKEYS */
 ul.hotkeys span.key-id {

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -799,10 +799,10 @@ LinkHints.prototype.deployHintContainers = function() {
 };
 
 LinkHints.prototype.getHandler = function() {
-  return this.handleKeydown.bind(this);
+  return this.handleKey.bind(this);
 };
 
-LinkHints.prototype.handleKeydown = function(event){
+LinkHints.prototype.handleKey = function(event){
 
   if (event.defaultPrevented) {
     return;
@@ -814,29 +814,13 @@ LinkHints.prototype.handleKeydown = function(event){
   // Maybe we must add other types here in the future
   if (event.key === this.linkHintHotKey && activeElementType !== "INPUT" && activeElementType !== "TEXTAREA") {
 
-    this.displayHints(!this.areHintsDisplayed);
     this.pendingPath    = "";
+    this.displayHints(!this.areHintsDisplayed);
 
   } else if (this.areHintsDisplayed) {
 
-    if (event.keyCode === 27 || event.keyCode === 8 && this.pendingPath === "") {
-      // Escape or backspace with initial entry - abort search
-      this.displayHints(false);
-      return;
-    }
-
     // the user tries to reach a hint
-    if (event.keyCode === 8) { // Backspace
-      this.pendingPath = this.pendingPath.substring(0, this.pendingPath.length - 1);
-    } else {
-      this.pendingPath += event.key;
-    }
-
-    if (this.pendingPath === "") { // Empty after backspace ? Just reset all
-      this.displayHints(true);
-      return;
-    }
-
+    this.pendingPath += event.key;
     var hint = this.hintsMap[this.pendingPath];
 
     if (hint) { // we are there, we have a fully specified tooltip. Let's activate it
@@ -899,7 +883,7 @@ LinkHints.prototype.filterHints = function () {
 function activateLinkHints(linkHintHotKey) {
   if (!linkHintHotKey) return;
   var oLinkHint = new LinkHints(linkHintHotKey);
-  document.addEventListener("keydown", oLinkHint.getHandler());
+  document.addEventListener("keypress", oLinkHint.getHandler());
 }
 
 /* HOTKEYS */

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -14,7 +14,7 @@
 /* exported perfLog */
 /* exported perfClear */
 /* exported enableArrowListNavigation */
-/* exported setLinkHints */
+/* exported activateLinkHints */
 /* exported setKeyBindings */
 /* exported preparePatch */
 /* exported registerStagePatch */
@@ -74,12 +74,12 @@ if (!String.prototype.includes) {
 
 // String startsWith polyfill, taken from https://developer.mozilla.org
 if (!String.prototype.startsWith) {
-    Object.defineProperty(String.prototype, 'startsWith', {
-        value: function(search, pos) {
-            pos = !pos || pos < 0 ? 0 : +pos;
-            return this.substring(pos, pos + search.length) === search;
-        }
-    });
+  Object.defineProperty(String.prototype, "startsWith", {
+    value: function(search, pos) {
+      pos = !pos || pos < 0 ? 0 : +pos;
+      return this.substring(pos, pos + search.length) === search;
+    }
+  });
 }
 
 /**********************************************************
@@ -799,18 +799,18 @@ LinkHints.prototype.deployHintContainers = function() {
 
   hintsMap.last = codeCounter - 1;
   return hintsMap;
-}
+};
 
 LinkHints.prototype.patchAndHookStyleSheets = function() {
   var sheet = getIndocStyleSheet();
   // Seems like 0 is a must for IE
   sheet.insertRule(".link-hint::after { border-top-color: " + this.hintBgColor + " }", 0);
   sheet.insertRule(".link-hint { background-color: " + this.hintBgColor + " }", 0);
-}
+};
 
 LinkHints.prototype.getHandler = function() {
   return this.handleKeydown.bind(this);
-}
+};
 
 LinkHints.prototype.handleKeydown = function(event){
 
@@ -878,10 +878,10 @@ LinkHints.prototype.displayHints = function(isActivate) {
 };
 
 LinkHints.prototype.hintActivate = function (hint) {
-  if (hint.parent.nodeName === 'A'
+  if (hint.parent.nodeName === "A"
     && hint.parent.href === document.location.href  // href is #
     && !hint.parent.onclick                         // no handler
-    && hint.parent.parentElement && hint.parent.parentElement.nodeName === 'LI') {
+    && hint.parent.parentElement && hint.parent.parentElement.nodeName === "LI") {
     // probably it is a dropdown ...
     hint.parent.parentElement.classList.toggle("force-nav-hover");
     hint.parent.focus();

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -23,6 +23,7 @@
 /* exported onOrderByChange  */
 /* exported onTagTypeChange */
 /* exported errorMessagePanelRegisterClick */
+/* exported getIndocStyleSheet */
 
 /**********************************************************
  * Polyfills
@@ -754,7 +755,7 @@ function LinkHints(linkHintHotKey){
   this.linkHintHotKey    = linkHintHotKey;
   this.areHintsDisplayed = false;
   this.pendingPath       = ""; // already typed code prefix
-  this.hintsMap          = this.deployHintContainers(); 
+  this.hintsMap          = this.deployHintContainers();
   this.activatedDropdown = null;
 }
 
@@ -840,7 +841,7 @@ LinkHints.prototype.handleKey = function(event){
       if (!visibleHints) {
         this.displayHints(false);
         if (this.activatedDropdown) this.closeActivatedDropdown();
-      } 
+      }
     }
   }
 };

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -755,6 +755,7 @@ function LinkHints(linkHintHotKey){
   this.areHintsDisplayed = false;
   this.pendingPath       = "";
   this.hintsMap          = this.deployHintContainers();
+  this.activatedDropdown = null;
 }
 
 LinkHints.prototype.getHintStartValue = function(targetsCount){
@@ -814,7 +815,9 @@ LinkHints.prototype.handleKey = function(event){
   // Maybe we must add other types here in the future
   if (event.key === this.linkHintHotKey && activeElementType !== "INPUT" && activeElementType !== "TEXTAREA") {
 
-    this.pendingPath    = "";
+    if (this.areHintsDisplayed && this.activatedDropdown) this.closeActivatedDropdown();
+
+    this.pendingPath       = "";
     this.displayHints(!this.areHintsDisplayed);
 
   } else if (this.areHintsDisplayed) {
@@ -831,11 +834,18 @@ LinkHints.prototype.handleKey = function(event){
       // the partially matched are shown
       var visibleHints = this.filterHints();
       if (!visibleHints) this.displayHints(false);
+      if (!visibleHints && this.activatedDropdown) this.closeActivatedDropdown();
     }
 
   }
 
 };
+
+LinkHints.prototype.closeActivatedDropdown = function() {
+  if (!this.activatedDropdown) return;
+  this.activatedDropdown.classList.remove("force-nav-hover");
+  this.activatedDropdown = null;
+}
 
 LinkHints.prototype.displayHints = function(isActivate) {
   this.areHintsDisplayed = isActivate;
@@ -857,7 +867,8 @@ LinkHints.prototype.hintActivate = function (hint) {
     && !hint.parent.onclick                         // no handler
     && hint.parent.parentElement && hint.parent.parentElement.nodeName === "LI") {
     // probably it is a dropdown ...
-    hint.parent.parentElement.classList.toggle("force-nav-hover");
+    this.activatedDropdown = hint.parent.parentElement;
+    this.activatedDropdown.classList.toggle("force-nav-hover");
     hint.parent.focus();
   } else {
     hint.parent.click();

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -868,7 +868,9 @@ LinkHints.prototype.displayHints = function(isActivate) {
 
 LinkHints.prototype.hintActivate = function (hint) {
   if (hint.parent.nodeName === "A"
-    && hint.parent.href === document.location.href  // href is #
+    // hint.parent.href doesn't have a # at the end while accessing dropdowns the first time.
+    // Seems like a idiosyncrasy of SAPGUI's IE. So let's ignore the last character.
+    && ( hint.parent.href.substr(0, hint.parent.href.length - 1) === document.location.href ) // href is #
     && !hint.parent.onclick                         // no handler
     && hint.parent.parentElement && hint.parent.parentElement.nodeName === "LI") {
     // probably it is a dropdown ...
@@ -877,6 +879,7 @@ LinkHints.prototype.hintActivate = function (hint) {
     hint.parent.focus();
   } else {
     hint.parent.click();
+    if (this.activatedDropdown) this.closeActivatedDropdown();
   }
 };
 

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -750,14 +750,11 @@ function enableArrowListNavigation() {
 
 /* LINK HINTS - Vimium like link hints */
 
-function LinkHints(linkHintHotKey, hintBgColor){
+function LinkHints(linkHintHotKey){
   this.linkHintHotKey    = linkHintHotKey;
-  this.hintBgColor       = hintBgColor;
   this.areHintsDisplayed = false;
   this.pendingPath       = "";
-
-  this.patchAndHookStyleSheets();
-  this.hintsMap = this.deployHintContainers();
+  this.hintsMap          = this.deployHintContainers();
 }
 
 LinkHints.prototype.getHintStartValue = function(targetsCount){
@@ -799,13 +796,6 @@ LinkHints.prototype.deployHintContainers = function() {
 
   hintsMap.last = codeCounter - 1;
   return hintsMap;
-};
-
-LinkHints.prototype.patchAndHookStyleSheets = function() {
-  var sheet = getIndocStyleSheet();
-  // Seems like 0 is a must for IE
-  sheet.insertRule(".link-hint::after { border-top-color: " + this.hintBgColor + " }", 0);
-  sheet.insertRule(".link-hint { background-color: " + this.hintBgColor + " }", 0);
 };
 
 LinkHints.prototype.getHandler = function() {
@@ -906,9 +896,9 @@ LinkHints.prototype.filterHints = function () {
   return visibleHints;
 };
 
-function activateLinkHints(linkHintHotKey, hintBgColor) {
-  if (!linkHintHotKey || !hintBgColor) return;
-  var oLinkHint = new LinkHints(linkHintHotKey, hintBgColor);
+function activateLinkHints(linkHintHotKey) {
+  if (!linkHintHotKey) return;
+  var oLinkHint = new LinkHints(linkHintHotKey);
   document.addEventListener("keydown", oLinkHint.getHandler());
 }
 

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -103,7 +103,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
 
 
   METHOD call_browser.
@@ -293,7 +293,7 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
     IF mo_settings->get_link_hints_enabled( ) = abap_true
     AND lv_link_hint_key IS NOT INITIAL.
 
-      io_html->add( |setLinkHints("{ lv_link_hint_key }","{ lv_background_color }");| ).
+      io_html->add( |activateLinkHints("{ lv_link_hint_key }","{ lv_background_color }");| ).
       io_html->add( |setInitialFocusWithQuerySelector('a span', true);| ).
       io_html->add( |enableArrowListNavigation();| ).
 
@@ -314,6 +314,11 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
     ro_html->add( '</head>' ).                              "#EC NOTEXT
     ro_html->add( '</html>' ).                              "#EC NOTEXT
 
+  ENDMETHOD.
+
+
+  METHOD reg_error_message_panel_click.
+    io_html->add( |errorMessagePanelRegisterClick();| ).
   ENDMETHOD.
 
 
@@ -393,6 +398,14 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_gui_error_handler~handle_error.
+
+    mx_error = ix_error.
+    rv_handled = abap_true.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_gui_event_handler~on_event.
 
     CASE iv_action.
@@ -427,14 +440,6 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
         ev_state = zcl_abapgit_gui=>c_event_state-not_handled.
 
     ENDCASE.
-
-  ENDMETHOD.
-
-
-  METHOD zif_abapgit_gui_error_handler~handle_error.
-
-    mx_error = ix_error.
-    rv_handled = abap_true.
 
   ENDMETHOD.
 
@@ -477,9 +482,4 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
     ro_html->add( '</html>' ).                              "#EC NOTEXT
 
   ENDMETHOD.
-
-  METHOD reg_error_message_panel_click.
-    io_html->add( |errorMessagePanelRegisterClick();| ).
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -288,12 +288,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
           lv_background_color TYPE string.
 
     lv_link_hint_key = mo_settings->get_link_hint_key( ).
-    lv_background_color = mo_settings->get_link_hint_background_color( ).
 
-    IF mo_settings->get_link_hints_enabled( ) = abap_true
-    AND lv_link_hint_key IS NOT INITIAL.
+    IF mo_settings->get_link_hints_enabled( ) = abap_true AND lv_link_hint_key IS NOT INITIAL.
 
-      io_html->add( |activateLinkHints("{ lv_link_hint_key }","{ lv_background_color }");| ).
+      io_html->add( |activateLinkHints("{ lv_link_hint_key }");| ).
       io_html->add( |setInitialFocusWithQuerySelector('a span', true);| ).
       io_html->add( |enableArrowListNavigation();| ).
 

--- a/src/ui/zcl_abapgit_gui_page_settings.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_settings.clas.abap
@@ -230,11 +230,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETTINGS IMPLEMENTATION.
       mo_settings->set_link_hint_key( |{ <ls_post_field>-value }| ).
     ENDIF.
 
-    READ TABLE mt_post_fields ASSIGNING <ls_post_field> WITH KEY name = 'link_hint_background_color'.
-    IF sy-subrc = 0.
-      mo_settings->set_link_hint_background_color( |{ <ls_post_field>-value }| ).
-    ENDIF.
-
     IF is_post_field_checked( 'parallel_proc_disabled' ) = abap_true.
       mo_settings->set_parallel_proc_disabled( abap_true ).
     ELSE.
@@ -609,7 +604,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETTINGS IMPLEMENTATION.
     ENDIF.
 
     lv_link_hint_key = mo_settings->get_link_hint_key( ).
-    lv_link_background_color = mo_settings->get_link_hint_background_color( ).
 
     CREATE OBJECT ro_html.
     ro_html->add( |<h2>Vimium like link hints</h2>| ).
@@ -619,11 +613,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETTINGS IMPLEMENTATION.
     ro_html->add( |<br>| ).
     ro_html->add( |<input type="text" name="link_hint_key" size="1" maxlength="1" value="{ lv_link_hint_key }" |
                && |> Single key to activate links| ).
-    ro_html->add( |<br>| ).
-    ro_html->add( |<br>| ).
-    ro_html->add( |<input type="text" name="link_hint_background_color" size="20" maxlength="20"|
-               && | value="{ lv_link_background_color }"|
-               && |> Background Color (HTML colors e.g. lightgreen or #42f47a)| ).
 
     ro_html->add( |<br>| ).
     ro_html->add( |<br>| ).

--- a/src/zcl_abapgit_settings.clas.abap
+++ b/src/zcl_abapgit_settings.clas.abap
@@ -110,12 +110,6 @@ CLASS zcl_abapgit_settings DEFINITION PUBLIC CREATE PUBLIC.
       get_link_hint_key
         RETURNING
           VALUE(rv_link_hint_key) TYPE string,
-      get_link_hint_background_color
-        RETURNING
-          VALUE(rv_background_color) TYPE string,
-      set_link_hint_background_color
-        IMPORTING
-          iv_background_color TYPE string,
       set_hotkeys
         IMPORTING
           it_hotkeys TYPE zif_abapgit_definitions=>tty_hotkey,
@@ -158,8 +152,7 @@ CLASS zcl_abapgit_settings DEFINITION PUBLIC CREATE PUBLIC.
           ms_user_settings TYPE zif_abapgit_definitions=>ty_s_user_settings.
 
     METHODS:
-      set_default_link_hint_key,
-      set_default_link_hint_bg_color.
+      set_default_link_hint_key.
 
 ENDCLASS.
 
@@ -200,11 +193,6 @@ CLASS ZCL_ABAPGIT_SETTINGS IMPLEMENTATION.
 
   METHOD get_link_hints_enabled.
     rv_link_hints_enabled = ms_user_settings-link_hints_enabled.
-  ENDMETHOD.
-
-
-  METHOD get_link_hint_background_color.
-    rv_background_color = ms_user_settings-link_hint_background_color.
   ENDMETHOD.
 
 
@@ -301,14 +289,8 @@ CLASS ZCL_ABAPGIT_SETTINGS IMPLEMENTATION.
     set_commitmsg_comment_length( c_commitmsg_comment_length_dft ).
     set_commitmsg_body_size( c_commitmsg_body_size_dft ).
     set_default_link_hint_key( ).
-    set_default_link_hint_bg_color( ).
     set_icon_scaling( '' ).
 
-  ENDMETHOD.
-
-
-  METHOD set_default_link_hint_bg_color.
-    set_link_hint_background_color( |lightgreen| ).
   ENDMETHOD.
 
 
@@ -337,11 +319,6 @@ CLASS ZCL_ABAPGIT_SETTINGS IMPLEMENTATION.
 
   METHOD set_link_hints_enabled.
     ms_user_settings-link_hints_enabled = iv_link_hints_enabled.
-  ENDMETHOD.
-
-
-  METHOD set_link_hint_background_color.
-    ms_user_settings-link_hint_background_color = iv_background_color.
   ENDMETHOD.
 
 
@@ -402,9 +379,6 @@ CLASS ZCL_ABAPGIT_SETTINGS IMPLEMENTATION.
       set_default_link_hint_key( ).
     ENDIF.
 
-    IF ms_user_settings-link_hint_background_color IS INITIAL.
-      set_default_link_hint_bg_color( ).
-    ENDIF.
   ENDMETHOD.
 
 

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -336,7 +336,6 @@ INTERFACE zif_abapgit_definitions
       show_default_repo          TYPE abap_bool,
       link_hints_enabled         TYPE abap_bool,
       link_hint_key              TYPE c LENGTH 1,
-      link_hint_background_color TYPE string,
       hotkeys                    TYPE tty_hotkey,
       parallel_proc_disabled     TYPE abap_bool,
       icon_scaling               TYPE c LENGTH 1,


### PR DESCRIPTION
to #2811

@christianguenter2 

draft for the moment, might be some polishing needed but works and ready for review

- hints are completely generated in JS, so no auxilliary `<span class="tooltiptext hidden">`
- some terminology fixes (tooltip vs hint) and some css
- I changed the JS code quite heavily ... sorry ... appeared to be an interesting subject, carried away :) ... hopefully for good.
- `ZCL_ABAPGIT_HTML ` - just removed the tooltip span, others are se80 reorderings
- same for ZCL_ABAPGIT_GUI_PAGE - just a rename in JS function
- known issue: a dropdown displayed with hint cannot be hidden ... actually no change from existing logic ... not sure if possible to fix cleanly ... maybe with timeout
- known issue: I added backspace for reverting hint steps back ... but works only on the first page - after IE perceives it as back button :( not sure how to fix

Doubt: why setting color in settings ? Imho it should depend on theme directly. Didn't change but imho not quite consistent.
