### PR TITLE
Cancel branch creation if branch already exists

### DIFF
--- a/src/git/zcl_abapgit_git_transport.clas.abap
+++ b/src/git/zcl_abapgit_git_transport.clas.abap
@@ -229,6 +229,8 @@ CLASS ZCL_ABAPGIT_GIT_TRANSPORT IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'missing necessary objects' ).
     ELSEIF lv_string CP '*refusing to delete the current branch*'.
       zcx_abapgit_exception=>raise( 'branch delete not allowed' ).
+    ELSEIF lv_string CP '*cannot lock ref*reference already exists*'.
+      zcx_abapgit_exception=>raise( 'branch already exists' ).
     ENDIF.
 
   ENDMETHOD.


### PR DESCRIPTION
For the other PR I tried to create branch `auth-jump` from master. I then saw that every file was changed. This was because I already had created that branch some time ago and forgot about it. abapGit simply switched to it after the create-action failed.