### PR TITLE
optimize skip logic #2864

### DIFF
--- a/src/zcl_abapgit_skip_objects.clas.abap
+++ b/src/zcl_abapgit_skip_objects.clas.abap
@@ -42,13 +42,17 @@ CLASS ZCL_ABAPGIT_SKIP_OBJECTS IMPLEMENTATION.
 
 
   METHOD skip_sadl_generated_objects.
+
     DATA: ls_tadir_class     LIKE LINE OF rt_tadir,
           ls_tadir           LIKE LINE OF rt_tadir,
+          lt_candidates      LIKE rt_tadir,
           lt_lines_to_delete TYPE zif_abapgit_definitions=>ty_tadir_tt.
 
-    rt_tadir = it_tadir.
+    lt_candidates = it_tadir.
+    DELETE lt_candidates WHERE object <> 'CLAS' OR genflag = abap_false.
+
     LOOP AT it_tadir INTO ls_tadir WHERE object = 'DDLS'.
-      LOOP AT rt_tadir INTO ls_tadir_class
+      LOOP AT lt_candidates INTO ls_tadir_class
           WHERE object = 'CLAS' AND obj_name CS ls_tadir-obj_name.
         IF has_sadl_superclass( ls_tadir_class ) = abap_true.
           APPEND ls_tadir_class TO lt_lines_to_delete.
@@ -56,6 +60,7 @@ CLASS ZCL_ABAPGIT_SKIP_OBJECTS IMPLEMENTATION.
       ENDLOOP.
     ENDLOOP.
 
+    rt_tadir = it_tadir.
     DELETE ADJACENT DUPLICATES FROM lt_lines_to_delete.
     LOOP AT lt_lines_to_delete INTO ls_tadir_class.
       DELETE TABLE rt_tadir FROM ls_tadir_class.

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -180,6 +180,7 @@ INTERFACE zif_abapgit_definitions
       devclass TYPE tadir-devclass,
       korrnum  TYPE tadir-korrnum,
       delflag  TYPE tadir-delflag,
+      genflag  TYPE tadir-genflag,
       path     TYPE string,
     END OF ty_tadir .
   TYPES:
@@ -331,16 +332,16 @@ INTERFACE zif_abapgit_definitions
     tt_repo_items TYPE STANDARD TABLE OF ty_repo_item WITH DEFAULT KEY .
   TYPES:
     BEGIN OF ty_s_user_settings,
-      max_lines                  TYPE i,
-      adt_jump_enabled           TYPE abap_bool,
-      show_default_repo          TYPE abap_bool,
-      link_hints_enabled         TYPE abap_bool,
-      link_hint_key              TYPE c LENGTH 1,
-      hotkeys                    TYPE tty_hotkey,
-      parallel_proc_disabled     TYPE abap_bool,
-      icon_scaling               TYPE c LENGTH 1,
-      ui_theme                   TYPE string,
-      hide_sapgui_hint           TYPE abap_bool,
+      max_lines              TYPE i,
+      adt_jump_enabled       TYPE abap_bool,
+      show_default_repo      TYPE abap_bool,
+      link_hints_enabled     TYPE abap_bool,
+      link_hint_key          TYPE c LENGTH 1,
+      hotkeys                TYPE tty_hotkey,
+      parallel_proc_disabled TYPE abap_bool,
+      icon_scaling           TYPE c LENGTH 1,
+      ui_theme               TYPE string,
+      hide_sapgui_hint       TYPE abap_bool,
     END OF ty_s_user_settings .
   TYPES:
     tty_dokil TYPE STANDARD TABLE OF dokil


### PR DESCRIPTION
this now filters the list of candidates before doing looping, new assumption is that TADIR-GENFLAG is set for the generated classes

it uses a bit more memory, and will also run a bit slower in case there are no DDLS objects

in my example, the top row of the performance trace is removed with this change, https://user-images.githubusercontent.com/5888506/62939058-a58f7400-bdd0-11e9-90c9-b7fa4dabb413.png

#2864