### PR TITLE
ui: add a workaround for JavaGUI dyn form bug

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -93,11 +93,17 @@ function debugOutput(text, dstID) {
   stdout.innerHTML = stdout.innerHTML + wrapped;
 }
 
-// Create hidden form and submit with sapevent
+// Use a pre-created form or create a hidden form
+// and submit with sapevent
 function submitSapeventForm(params, action, method) {
-  var form = document.createElement("form");
-  form.setAttribute("method", method || "post");
-  form.setAttribute("action", "sapevent:" + action);
+  var stub_form_id = "form_" + action;
+  var form = document.getElementById(stub_form_id);
+
+  if (form === null) {
+    form = document.createElement("form");
+    form.setAttribute("method", method || "post");
+    form.setAttribute("action", "sapevent:" + action);
+  }
 
   for(var key in params) {
     var hiddenField = document.createElement("input");
@@ -107,7 +113,10 @@ function submitSapeventForm(params, action, method) {
     form.appendChild(hiddenField);
   }
 
-  document.body.appendChild(form);
+  if (form.id !== stub_form_id) {
+    document.body.appendChild(form);
+  }
+
   form.submit();
 }
 

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -23,6 +23,7 @@ CLASS zcl_abapgit_gui_page_stage DEFINITION
   PROTECTED SECTION.
     METHODS:
       render_content REDEFINITION,
+      get_events     REDEFINITION,
       scripts        REDEFINITION.
 
   PRIVATE SECTION.
@@ -147,7 +148,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
   ENDMETHOD.
 
-
   METHOD find_transports.
     DATA: li_cts_api TYPE REF TO zif_abapgit_cts_api,
           ls_new     LIKE LINE OF rt_transports.
@@ -183,6 +183,17 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
       CATCH zcx_abapgit_exception.
         ASSERT 1 = 2.
     ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD get_events.
+
+    FIELD-SYMBOLS: <ls_event> TYPE zcl_abapgit_gui_page=>ty_event.
+
+    APPEND INITIAL LINE TO rt_events ASSIGNING <ls_event>.
+    <ls_event>-method = 'post'.
+    <ls_event>-name = 'stage_commit'.
+
   ENDMETHOD.
 
 


### PR DESCRIPTION
Per request: https://github.com/larshp/abapGit/issues/2769#issuecomment-521765859

---

JavaGUI does not pass values of options from forms generated via
JavaScript.

This commit adds enhances the base page class to render stub forms
(empty form elements), so the page's JavaScript does not need to create
the form element on its own.

It is an optional behavior and can be enabled by redefining the method
get_events which should return table of required events and the base
page object will add the empty form elements for them. Every table line
will be converted to a form with id = "form_" + the event's name.

On the action submit SAP event in the common JavaScript, the method
checks if there is the stub form and if so, the method uses it instead
of creating the dynamic one. Otherwise, it follows the old approach that
creates the form at run-time.

--- v2

Use 'null' instead of 'undefined' to check the form was not found in
the JavaScript code.

---

Issues: #1866, #2769