### PR TITLE
Command palette (Ctrl+P): Go to repo ...

### DIFF
--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -846,3 +846,40 @@ table.commit tr .title {
   box-shadow: 2px 2px 6px 0px #ccc;
   cursor: pointer;
 }
+
+/* Command palette */
+
+.cmd-palette {
+  position: absolute;
+  z-index: 99;
+  top: 36px;
+  left: 50%;
+  width: 40em;
+  margin-left: -20em;
+  box-shadow: 1px 1px 3px 2px #dcdcdc;
+  background-color: white;
+  border: solid 2px;
+  padding: 0px 1px;
+}
+
+.cmd-palette input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.cmd-palette ul {
+  max-height: 10em;
+  overflow-y: scroll;
+  margin: 4px 0;
+  padding: 2px 4px;
+}
+
+.cmd-palette li {
+  list-style-type: none;
+  cursor: default;
+  padding: 4px 6px;
+}
+
+.cmd-palette li .icon {
+  margin-right: 10px;
+}

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -764,7 +764,7 @@ ul.hotkeys span.key-id {
   border: 1px solid;
   border-radius: 3px;
   padding: 1px 7px;
-  width: 0.5em;
+  width: 1em;
   display: inline-block;
   text-align: center;
   margin-top: 0.2em;

--- a/src/ui/zabapgit_css_theme_default.w3mi.data.css
+++ b/src/ui/zabapgit_css_theme_default.w3mi.data.css
@@ -359,3 +359,19 @@ div.corner-hint {
 .ci-result li.ci-error   { border-left-color: #cd5353; }
 .ci-result li.ci-warning { border-left-color: #ecd227; }
 .ci-result li.ci-info    { border-left-color: #acacac; }
+
+/* Command palette */
+
+.cmd-palette {
+  border-color: #ccc;
+}
+
+.cmd-palette li.selected {
+  background-color: hsla(214, 50%, 90%, 1);
+}
+
+.cmd-palette mark {
+  color: white;
+  background-color: #79a0d2;
+  /* todo merge with stage search */
+}

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -704,11 +704,11 @@ KeyNavigation.prototype.onkeydown = function(event) {
   } else if (/Down$/.test(event.key)) {
     isHandled = this.onArrowDown();
   } else if (/Up$/.test(event.key)) {
-    isHandled = this.onArrowUp()
+    isHandled = this.onArrowUp();
   } else if (event.key === "Backspace") {
-    isHandled = this.onBackspace()
+    isHandled = this.onBackspace();
   }
-  
+
   if (isHandled) event.preventDefault();
 };
 
@@ -732,13 +732,13 @@ KeyNavigation.prototype.focusListItem = function (li) {
   if (!anchor || anchor.nodeName !== "A") return false;
   anchor.focus();
   return true;
-}
+};
 
 KeyNavigation.prototype.closeDropdown = function (dropdownLi) {
   dropdownLi.classList.remove("force-nav-hover");
   if (dropdownLi.firstElementChild.nodeName === "A") dropdownLi.firstElementChild.focus();
   return true;
-}
+};
 
 KeyNavigation.prototype.onBackspace = function () {
   var activeElement = document.activeElement;
@@ -762,7 +762,7 @@ KeyNavigation.prototype.onBackspace = function () {
     && activeElement.parentElement.parentElement.parentElement.classList.contains("force-nav-hover")) {
     return this.closeDropdown(activeElement.parentElement.parentElement.parentElement);
   }
-}
+};
 
 KeyNavigation.prototype.onArrowDown = function () {
   var activeElement = document.activeElement;
@@ -804,7 +804,7 @@ KeyNavigation.prototype.onArrowUp = function () {
 
 KeyNavigation.prototype.getHandler = function () {
   return this.onkeydown.bind(this);
-}
+};
 
 // this functions enables the navigation with arrows through list items (li)
 // e.g. in dropdown menus
@@ -1081,7 +1081,7 @@ Hotkeys.addHotkeyToHelpSheet = function(key, description) {
   li.appendChild(spanDescr);
 
   hotkeysUl.appendChild(li);
-}
+};
 
 function setKeyBindings(oKeyMap){
 
@@ -1553,7 +1553,7 @@ CommandPalette.prototype.handleInputKey = function(event){
   //   this.highlight();
   // } else if (event.key === "Enter") {
   //   this.exec(this.selectedItem);
-  // } else 
+  // } else
   if (this.filter !== this.elements.input.value) {
     // this.selectIndex = 0;
     this.filter = this.elements.input.value;
@@ -1645,7 +1645,7 @@ CommandPalette.prototype.getCommandByElement = function(element) {
   for (var i = 0; i < this.commands.length; i++) {
     if (this.commands[i].element === element) return this.commands[i];
   }
-}
+};
 
 CommandPalette.prototype.handleUlClick = function(event) {
   var element = event.target || event.srcElement;

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -1550,6 +1550,8 @@ CommandPalette.prototype.handleInputKey = function(event){
     this.selectNext();
   } else if (event.key === "Enter") {
     this.exec(this.getSelected());
+  } else if (event.key === "Backspace" && !this.filter) {
+    this.toggleDisplay(false);
   } else if (this.filter !== this.elements.input.value) {
     this.filter = this.elements.input.value;
     this.applyFilter();
@@ -1584,7 +1586,7 @@ CommandPalette.prototype.applySelectIndex = function(newIndex){
     this.selectIndex = newIndex;
     this.adjustScrollPosition(newCmd.element);
   }
-}
+};
 
 CommandPalette.prototype.selectFirst = function(){
   for (var i = 0; i < this.commands.length; i++) {
@@ -1592,7 +1594,7 @@ CommandPalette.prototype.selectFirst = function(){
     this.applySelectIndex(i);
     break;
   }
-}
+};
 
 CommandPalette.prototype.selectNext = function(){
   for (var i = this.selectIndex + 1; i < this.commands.length; i++) {
@@ -1600,7 +1602,7 @@ CommandPalette.prototype.selectNext = function(){
     this.applySelectIndex(i);
     break;
   }
-}
+};
 
 CommandPalette.prototype.selectPrev = function(){
   for (var i = this.selectIndex - 1; i >= 0; i--) {
@@ -1608,11 +1610,11 @@ CommandPalette.prototype.selectPrev = function(){
     this.applySelectIndex(i);
     break;
   }
-}
+};
 
 CommandPalette.prototype.getSelected = function(){
   return this.commands[this.selectIndex];
-}
+};
 
 CommandPalette.prototype.adjustScrollPosition = function(itemElement){
   var bItem         = itemElement.getBoundingClientRect();

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -219,6 +219,13 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD get_events.
+
+    " Return actions you need on your page.
+
+  ENDMETHOD.
+
+
   METHOD get_global_hotkeys.
 
     " these are the global shortcuts active on all pages
@@ -356,18 +363,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD render_hotkey_overview.
-
-    ro_html = zcl_abapgit_gui_chunk_lib=>render_hotkey_overview( me ).
-
-  ENDMETHOD.
-
-  METHOD get_events.
-
-    " Return actions you need on your page.
-
-  ENDMETHOD.
-
   METHOD render_event_as_form.
 
     CREATE OBJECT ro_html.
@@ -376,12 +371,21 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
 
   ENDMETHOD.
 
+
+  METHOD render_hotkey_overview.
+
+    ro_html = zcl_abapgit_gui_chunk_lib=>render_hotkey_overview( me ).
+
+  ENDMETHOD.
+
+
   METHOD scripts.
 
     CREATE OBJECT ro_html.
 
     link_hints( ro_html ).
     insert_hotkeys_to_page( ro_html ).
+    ro_html->add( 'var gCommandPalette = new CommandPalette(enumerateTocAllRepos, "g", "Go to repo ...");' ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -385,8 +385,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
 
     link_hints( ro_html ).
     insert_hotkeys_to_page( ro_html ).
-    ro_html->add( 'var gCommandPalette = new CommandPalette(enumerateTocAllRepos, "g", "Go to repo ...");' ).
-
+    ro_html->add( 'var gCommandPalette = new CommandPalette(enumerateTocAllRepos, {' ).
+    ro_html->add( 'toggleKey: "F2",' ).
+    ro_html->add( 'hotkeyDescription: "Go to repo ..."' ).
+    ro_html->add( '});' ).
   ENDMETHOD.
 
 

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -385,9 +385,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
 
     link_hints( ro_html ).
     insert_hotkeys_to_page( ro_html ).
-    ro_html->add( 'var gCommandPalette = new CommandPalette(enumerateTocAllRepos, {' ).
-    ro_html->add( 'toggleKey: "F2",' ).
-    ro_html->add( 'hotkeyDescription: "Go to repo ..."' ).
+    ro_html->add( 'var gGoRepoPalette = new CommandPalette(enumerateTocAllRepos, {' ).
+    ro_html->add( '  toggleKey: "F2",' ).
+    ro_html->add( '  hotkeyDescription: "Go to repo ..."' ).
     ro_html->add( '});' ).
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -170,7 +170,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
 
     CREATE OBJECT ro_html.
     CREATE OBJECT lo_favbar.
-    CREATE OBJECT lo_allbar.
+    CREATE OBJECT lo_allbar EXPORTING iv_id = 'toc-all-repos'.
     CREATE OBJECT lo_pback.
 
     lt_favorites = zcl_abapgit_persistence_user=>get_instance( )->get_favorites( ).

--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -52,7 +52,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
     DATA: lo_advsub  TYPE REF TO zcl_abapgit_html_toolbar,
           lo_helpsub TYPE REF TO zcl_abapgit_html_toolbar.
 
-    CREATE OBJECT ro_menu.
+    CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-main'.
     CREATE OBJECT lo_advsub.
     CREATE OBJECT lo_helpsub.
 

--- a/src/ui/zcl_abapgit_gui_view_repo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_view_repo.clas.abap
@@ -148,7 +148,7 @@ CLASS ZCL_ABAPGIT_GUI_VIEW_REPO IMPLEMENTATION.
           lv_pull_opt    LIKE zif_abapgit_html=>c_html_opt-crossout,
           li_log         TYPE REF TO zif_abapgit_log.
 
-    CREATE OBJECT ro_toolbar.
+    CREATE OBJECT ro_toolbar EXPORTING iv_id = 'toolbar-repo'.
     CREATE OBJECT lo_tb_branch.
     CREATE OBJECT lo_tb_advanced.
     CREATE OBJECT lo_tb_tag.
@@ -805,5 +805,4 @@ CLASS ZCL_ABAPGIT_GUI_VIEW_REPO IMPLEMENTATION.
     ENDTRY.
 
   ENDMETHOD.
-
 ENDCLASS.


### PR DESCRIPTION
@FreHu @christianguenter2 
Speaking about Ctrl+P (#2895) ... - a good idea ! :)
Implemented for keyboard repo navigation ("Go to repo ...")
Key combination: F2 (with the prospect to use F1 for abapGit actions palette)
~~Draft but ready for beta-testing among highly-privileged beta members~~ 😜  ( = all interested) 

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/15635498/63943847-1f825700-ca79-11e9-812b-76ee20562d74.gif)

Features:
- `CommandPalette` class is quite abstract and can be reused, see below
- arrow navigation works, with auto scrolling
- auto patch hotkeys help sheet (and reusable util `Hotkeys.addHotkeyToHelpSheet`)
- accepts clicks and enter
- fuzzy search ("abc" would find "**abc**efg" and "**a**1**b**2**c**3") (fuzzy search function is also separated and reusable outside of the class). Search is case insensitive.
- optional icons
- Backspace in empty filter closes the palette
- `^` before the `toggleKey` means Ctrl (e.g. `^g` = Ctrl+g)

Currently a draft, known issues/todo:
- ~~search is case sensitive~~
- ~~g cannot be typed - closes the popup - probably needs a ctrl combination.~~
- How to stop sap from closing on Esc ?!
- ~~seems like some conflicts with `enableArrowListNavigation`~~

Reuse guide
- to activate run `var xxx = new CommandPalette(enumerateTocAllRepos, {toggleKey: "^g", hotkeyDescription: "Go to repo ..."});`
- where `g` (ctrl+g in this case) and `Go to repo` are the hotkey and it's description
- and `enumerateTocAllRepos` - a function returning array of commands in form of
- there can be several commandPalettes on a page
```js
{
  action, // sapevent action without "sapevent:" prefix
  iconClass, // OPTIONAL, "icon icon_x ..."
  title, // command text - "my command X"
}
```

Maybe in future: potentially possible to bind the popup to around of specific element, if required - e.g. the case with diff file jump. So that it is located more consistently.
