### PR TITLE
always add byte order mark

### DIFF
--- a/src/utils/zcl_abapgit_convert.clas.abap
+++ b/src/utils/zcl_abapgit_convert.clas.abap
@@ -21,7 +21,7 @@ CLASS zcl_abapgit_convert DEFINITION
         VALUE(rv_xstring) TYPE xstring .
     CLASS-METHODS xstring_to_string_utf8
       IMPORTING
-        !iv_data         TYPE xstring
+        !iv_data         TYPE xsequence
       RETURNING
         VALUE(rv_string) TYPE string .
     CLASS-METHODS xstring_to_int
@@ -43,41 +43,36 @@ CLASS zcl_abapgit_convert DEFINITION
         VALUE(rt_lines) TYPE string_table .
     CLASS-METHODS conversion_exit_isola_output
       IMPORTING
-        iv_spras        TYPE spras
+        !iv_spras       TYPE spras
       RETURNING
-        VALUE(rv_spras) TYPE laiso.
+        VALUE(rv_spras) TYPE laiso .
     CLASS-METHODS alpha_output
       IMPORTING
-        iv_val        TYPE clike
+        !iv_val       TYPE clike
       RETURNING
-        VALUE(rv_str) TYPE string.
-
+        VALUE(rv_str) TYPE string .
     CLASS-METHODS string_to_xstring
       IMPORTING
-        iv_str         TYPE string
+        !iv_str        TYPE string
       RETURNING
-        VALUE(rv_xstr) TYPE xstring.
-
+        VALUE(rv_xstr) TYPE xstring .
     CLASS-METHODS base64_to_xstring
       IMPORTING
-        iv_base64      TYPE string
+        !iv_base64     TYPE string
       RETURNING
-        VALUE(rv_xstr) TYPE xstring.
-
+        VALUE(rv_xstr) TYPE xstring .
     CLASS-METHODS bintab_to_xstring
       IMPORTING
-        it_bintab      TYPE lvc_t_mime
-        iv_size        TYPE i
+        !it_bintab     TYPE lvc_t_mime
+        !iv_size       TYPE i
       RETURNING
-        VALUE(rv_xstr) TYPE xstring.
-
+        VALUE(rv_xstr) TYPE xstring .
     CLASS-METHODS xstring_to_bintab
       IMPORTING
-        iv_xstr   TYPE xstring
+        !iv_xstr   TYPE xstring
       EXPORTING
-        ev_size   TYPE i
-        et_bintab TYPE lvc_t_mime.
-
+        !ev_size   TYPE i
+        !et_bintab TYPE lvc_t_mime .
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.

--- a/src/xml/zcl_abapgit_xml.clas.abap
+++ b/src/xml/zcl_abapgit_xml.clas.abap
@@ -37,7 +37,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_xml IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_XML IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -172,6 +172,7 @@ CLASS zcl_abapgit_xml IMPLEMENTATION.
 
     DATA: li_ostream       TYPE REF TO if_ixml_ostream,
           li_renderer      TYPE REF TO if_ixml_renderer,
+          lv_mark          TYPE string,
           li_streamfactory TYPE REF TO if_ixml_stream_factory.
 
 
@@ -184,6 +185,13 @@ CLASS zcl_abapgit_xml IMPLEMENTATION.
     li_renderer->set_normalizing( iv_normalize ).
 
     li_renderer->render( ).
+
+* unicode systems always add the byte order mark to the xml, while non-unicode does not
+* this code will always add the byte order mark if it is not in the xml
+    lv_mark = zcl_abapgit_convert=>xstring_to_string_utf8( cl_abap_char_utilities=>byte_order_mark_utf8 ).
+    IF rv_xml(1) <> lv_mark.
+      CONCATENATE lv_mark rv_xml INTO rv_xml.
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
this will always add the byte order mark to xml files, this is relevant for non-unicode systems.
assuming most systems are on unicode this is the least invasive fix.

closes #1044
closes #799