### PR TITLE
for low number of obj run single thread

### DIFF
--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -376,6 +376,7 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
     DATA: lt_tadir      TYPE zif_abapgit_definitions=>ty_tadir_tt,
           lo_serialize  TYPE REF TO zcl_abapgit_serialize,
           lt_found      LIKE rt_files,
+          lv_force      TYPE abap_bool,
           ls_apack_file TYPE zif_abapgit_definitions=>ty_file.
 
     FIELD-SYMBOLS: <ls_return> LIKE LINE OF rt_files.
@@ -408,10 +409,16 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
     CREATE OBJECT lo_serialize.
 
+* if there are less than 10 objects run in single thread
+* this helps a lot when debugging, plus performance gain
+* with low number of objects does not matter much
+    lv_force = boolc( lines( lt_tadir ) < 10 ).
+
     lt_found = lo_serialize->serialize(
-      it_tadir    = lt_tadir
-      iv_language = get_dot_abapgit( )->get_master_language( )
-      ii_log      = ii_log ).
+      it_tadir            = lt_tadir
+      iv_language         = get_dot_abapgit( )->get_master_language( )
+      ii_log              = ii_log
+      iv_force_sequential = lv_force ).
     APPEND LINES OF lt_found TO rt_files.
 
     mt_local                 = rt_files.


### PR DESCRIPTION
for low number of objects run single thread, this will make it easier to debug serialization