### PR TITLE
#2724 added message after commit

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_commit.clas.abap
@@ -329,8 +329,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_event_handler~on_event.
 
-    DATA: ls_commit TYPE zcl_abapgit_services_git=>ty_commit_fields,
-          li_popups TYPE REF TO zif_abapgit_popups.
+    DATA: ls_commit TYPE zcl_abapgit_services_git=>ty_commit_fields.
 
     CASE iv_action.
       WHEN c_action-commit_post.

--- a/src/ui/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_commit.clas.abap
@@ -329,10 +329,12 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_event_handler~on_event.
 
-    DATA: ls_commit TYPE zcl_abapgit_services_git=>ty_commit_fields.
+    DATA: ls_commit TYPE zcl_abapgit_services_git=>ty_commit_fields,
+          li_popups TYPE REF TO zif_abapgit_popups.
 
     CASE iv_action.
       WHEN c_action-commit_post.
+
 
         parse_commit_request(
           EXPORTING it_postdata = it_postdata
@@ -344,6 +346,14 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
           is_commit = ls_commit
           io_repo   = mo_repo
           io_stage  = mo_stage ).
+
+
+          li_popups = zcl_abapgit_ui_factory=>get_popups( ).
+          li_popups->popup_to_inform(
+            iv_titlebar = 'Commit was successful'
+            iv_text_message = 'The commit was successful.'
+
+           ).
 
         ev_state = zcl_abapgit_gui=>c_event_state-go_back_to_bookmark.
 

--- a/src/ui/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_commit.clas.abap
@@ -347,7 +347,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
           io_repo   = mo_repo
           io_stage  = mo_stage ).
 
-        MESSAGE 'Commit was successful' TYPE 'S'.
+        MESSAGE 'Commit was successful' TYPE 'S' ##NO_TEXT.
 
         ev_state = zcl_abapgit_gui=>c_event_state-go_back_to_bookmark.
 

--- a/src/ui/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_commit.clas.abap
@@ -58,7 +58,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_commit IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -348,12 +348,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
           io_stage  = mo_stage ).
 
 
-          li_popups = zcl_abapgit_ui_factory=>get_popups( ).
-          li_popups->popup_to_inform(
-            iv_titlebar = 'Commit was successful'
-            iv_text_message = 'The commit was successful.'
-
-           ).
+        li_popups = zcl_abapgit_ui_factory=>get_popups( ).
+        li_popups->popup_to_inform(
+          iv_titlebar     = 'Commit was successful'
+          iv_text_message = 'The commit was successful.' ).
 
         ev_state = zcl_abapgit_gui=>c_event_state-go_back_to_bookmark.
 

--- a/src/ui/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_commit.clas.abap
@@ -58,7 +58,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_page_commit IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -347,11 +347,7 @@ CLASS zcl_abapgit_gui_page_commit IMPLEMENTATION.
           io_repo   = mo_repo
           io_stage  = mo_stage ).
 
-
-        li_popups = zcl_abapgit_ui_factory=>get_popups( ).
-        li_popups->popup_to_inform(
-          iv_titlebar     = 'Commit was successful'
-          iv_text_message = 'The commit was successful.' ).
+        MESSAGE 'Commit was successful' TYPE 'S'.
 
         ev_state = zcl_abapgit_gui=>c_event_state-go_back_to_bookmark.
 


### PR DESCRIPTION
* A popup_to_inform is used to show to user that the commit is successful.

<img width="399" alt="ABAPGIT_commit_successful" src="https://user-images.githubusercontent.com/32391037/66722721-9c8f4300-ee11-11e9-8ef3-b3cbec5737e5.PNG">
