### PR TITLE
me filter at stage page

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -263,6 +263,7 @@ RepoOverViewHelper.prototype.onPageLoad = function() {
 function StageHelper(params) {
   this.pageSeed        = params.seed;
   this.formAction      = params.formAction;
+  this.user            = params.user;
   this.choiseCount     = 0;
   this.lastFilterValue = "";
 
@@ -296,7 +297,24 @@ function StageHelper(params) {
   };
 
   this.setHooks();
+  if (this.user) this.injectFilterMe();
 }
+
+StageHelper.prototype.injectFilterMe = function() {
+  var changedByHead = this.dom.stageTab.tHead.rows[0].cells[this.colIndex.user];
+  changedByHead.innerText = changedByHead.innerText + " (";
+  var a = document.createElement("A");
+  a.appendChild(document.createTextNode("me"));
+  a.onclick = this.onFilterMe.bind(this);
+  a.href = "#";
+  changedByHead.appendChild(a);
+  changedByHead.appendChild(document.createTextNode(")"));
+};
+
+StageHelper.prototype.onFilterMe = function() {
+  this.dom.objectSearch.value = this.user;
+  this.onFilter({ type: "keypress", which: 13, target: this.dom.objectSearch });
+};
 
 // Hook global click listener on table, load/unload actions
 StageHelper.prototype.setHooks = function() {
@@ -383,7 +401,7 @@ StageHelper.prototype.onTableClick = function (event) {
 StageHelper.prototype.onFilter = function (e) {
   if ( // Enter hit or clear, IE SUCKS !
     e.type === "input" && !e.target.value && this.lastFilterValue
-    || e.type === "keypress" && e.which === 13 ) {
+    || e.type === "keypress" && (e.which === 13 || e.key === "Enter") ) {
 
     this.applyFilterValue(e.target.value);
     submitSapeventForm({ filterValue: e.target.value }, "stage_filter", "post");

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -151,6 +151,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
   ENDMETHOD.
 
+
   METHOD find_transports.
     DATA: li_cts_api TYPE REF TO zif_abapgit_cts_api,
           ls_new     LIKE LINE OF rt_transports.
@@ -188,6 +189,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
     ENDTRY.
 
   ENDMETHOD.
+
 
   METHOD get_events.
 
@@ -480,12 +482,30 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD render_master_language_warning.
+
+    DATA: ls_dot_abapgit TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit.
+
+    CREATE OBJECT ro_html.
+
+    ls_dot_abapgit = mo_repo->get_dot_abapgit( )->get_data( ).
+
+    IF ls_dot_abapgit-master_language <> sy-langu.
+      ro_html->add( zcl_abapgit_gui_chunk_lib=>render_warning_banner(
+                        |Caution: Master language of the repo is '{ ls_dot_abapgit-master_language }', |
+                     && |but you're logged on in '{ sy-langu }'| ) ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD scripts.
 
     ro_html = super->scripts( ).
 
     ro_html->add( 'var gStageParams = {' ).
     ro_html->add( |  seed:            "{ mv_seed }",| ). " Unique page id
+    ro_html->add( |  user:            "{ to_lower( sy-uname ) }",| ).
     ro_html->add( '  formAction:      "stage_commit",' ).
 
     ro_html->add( '  ids: {' ).
@@ -586,22 +606,4 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
     INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
 
   ENDMETHOD.
-
-
-  METHOD render_master_language_warning.
-
-    DATA: ls_dot_abapgit TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit.
-
-    CREATE OBJECT ro_html.
-
-    ls_dot_abapgit = mo_repo->get_dot_abapgit( )->get_data( ).
-
-    IF ls_dot_abapgit-master_language <> sy-langu.
-      ro_html->add( zcl_abapgit_gui_chunk_lib=>render_warning_banner(
-                        |Caution: Master language of the repo is '{ ls_dot_abapgit-master_language }', |
-                     && |but you're logged on in '{ sy-langu }'| ) ).
-    ENDIF.
-
-  ENDMETHOD.
-
 ENDCLASS.


### PR DESCRIPTION
Added a dynamic "me" link to filter repo changes done by current user. Useful when several people work on the code

![image](https://user-images.githubusercontent.com/15635498/67224366-b34d1f80-f439-11e9-874f-73aac184327f.png)

to be done: some improvements on Commit button when filter applied (separate PR later)

P.S. render_master_language_warning unchanged - se80 reordering