### PR TITLE
Stage improvements: commit selected button

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -264,17 +264,21 @@ function StageHelper(params) {
   this.pageSeed        = params.seed;
   this.formAction      = params.formAction;
   this.user            = params.user;
-  this.choiseCount     = 0;
+  this.selectedCount   = 0;
+  this.filteredCount   = 0;
   this.lastFilterValue = "";
 
   // DOM nodes
   this.dom = {
-    stageTab:     document.getElementById(params.ids.stageTab),
-    commitBtn:    document.getElementById(params.ids.commitBtn),
-    commitAllBtn: document.getElementById(params.ids.commitAllBtn),
-    objectSearch: document.getElementById(params.ids.objectSearch),
-    fileCounter:  document.getElementById(params.ids.fileCounter)
+    stageTab:          document.getElementById(params.ids.stageTab),
+    commitAllBtn:      document.getElementById(params.ids.commitAllBtn),
+    commitSelectedBtn: document.getElementById(params.ids.commitSelectedBtn),
+    commitFilteredBtn: document.getElementById(params.ids.commitFilteredBtn),
+    objectSearch:      document.getElementById(params.ids.objectSearch),
+    selectedCounter:   null,
+    filteredCounter:   null,
   };
+  this.findCounters();
 
   // Table columns (autodetection)
   this.colIndex      = this.detectColumns();
@@ -300,6 +304,11 @@ function StageHelper(params) {
   if (this.user) this.injectFilterMe();
 }
 
+StageHelper.prototype.findCounters = function() {
+  this.dom.selectedCounter = this.dom.commitSelectedBtn.querySelector("span.counter");
+  this.dom.filteredCounter = this.dom.commitFilteredBtn.querySelector("span.counter");
+};
+
 StageHelper.prototype.injectFilterMe = function() {
   var changedByHead = this.dom.stageTab.tHead.rows[0].cells[this.colIndex.user];
   changedByHead.innerText = changedByHead.innerText + " (";
@@ -318,12 +327,13 @@ StageHelper.prototype.onFilterMe = function() {
 
 // Hook global click listener on table, load/unload actions
 StageHelper.prototype.setHooks = function() {
-  this.dom.stageTab.onclick        = this.onTableClick.bind(this);
-  this.dom.commitBtn.onclick       = this.submit.bind(this);
-  this.dom.objectSearch.oninput    = this.onFilter.bind(this);
-  this.dom.objectSearch.onkeypress = this.onFilter.bind(this);
-  window.onbeforeunload            = this.onPageUnload.bind(this);
-  window.onload                    = this.onPageLoad.bind(this);
+  this.dom.stageTab.onclick          = this.onTableClick.bind(this);
+  this.dom.commitSelectedBtn.onclick = this.submit.bind(this);
+  this.dom.commitFilteredBtn.onclick = this.submitVisible.bind(this);
+  this.dom.objectSearch.oninput      = this.onFilter.bind(this);
+  this.dom.objectSearch.onkeypress   = this.onFilter.bind(this);
+  window.onbeforeunload              = this.onPageUnload.bind(this);
+  window.onload                      = this.onPageLoad.bind(this);
 };
 
 // Detect column index
@@ -411,7 +421,8 @@ StageHelper.prototype.onFilter = function (e) {
 StageHelper.prototype.applyFilterValue = function(sFilterValue) {
 
   this.lastFilterValue = sFilterValue;
-  this.iterateStageTab(true, this.applyFilterToRow, sFilterValue);
+  this.filteredCount = this.iterateStageTab(true, this.applyFilterToRow, sFilterValue);
+  this.updateMenu();
 
 };
 
@@ -445,6 +456,7 @@ StageHelper.prototype.applyFilterToRow = function (row, filter) {
   for (var j = targets.length - 1; j >= 0; j--) {
     if (targets[j].isChanged) targets[j].elem.innerHTML = targets[j].newHtml;
   }
+  return isVisible ? 1 : 0;
 };
 
 // Get how status should affect object counter
@@ -469,7 +481,7 @@ StageHelper.prototype.updateRow = function (row, newStatus) {
     this.updateRowCommand(row, newStatus); // For initial run
   }
 
-  this.choiseCount += this.getStatusImpact(newStatus) - this.getStatusImpact(oldStatus);
+  this.selectedCount += this.getStatusImpact(newStatus) - this.getStatusImpact(oldStatus);
 };
 
 // Update Status cell (render set of commands)
@@ -496,13 +508,29 @@ StageHelper.prototype.updateRowCommand = function (row, status) {
 
 // Update menu items visibility
 StageHelper.prototype.updateMenu = function () {
-  this.dom.commitBtn.style.display    = (this.choiseCount > 0) ? ""     : "none";
-  this.dom.commitAllBtn.style.display = (this.choiseCount > 0) ? "none" : "";
-  this.dom.fileCounter.innerHTML      = this.choiseCount.toString();
+  var display;
+  if (this.selectedCount > 0) {
+    display = "selected";
+    this.dom.selectedCounter.innerText = this.selectedCount.toString();
+  } else if (this.lastFilterValue) {
+    display = "filtered";
+    this.dom.filteredCounter.innerText = this.filteredCount.toString();
+  } else {
+    display = "default";
+  }
+
+  this.dom.commitAllBtn.style.display      = display === "default" ? "" : "none";
+  this.dom.commitSelectedBtn.style.display = display === "selected" ? "" : "none";
+  this.dom.commitFilteredBtn.style.display = display === "filtered" ? "" : "none";
 };
 
 // Submit stage state to the server
 StageHelper.prototype.submit = function () {
+  submitSapeventForm(this.collectData(), this.formAction);
+};
+
+StageHelper.prototype.submitVisible = function () {
+  this.markVisiblesAsAdded();
   submitSapeventForm(this.collectData(), this.formAction);
 };
 
@@ -515,10 +543,24 @@ StageHelper.prototype.collectData = function () {
   return data;
 };
 
+StageHelper.prototype.markVisiblesAsAdded = function () {
+  this.iterateStageTab(false, function (row) {
+    var name = row.cells[this.colIndex["name"]].innerText;
+    var cellStatus = row.cells[this.colIndex["status"]];
+    // TODO refacotr, unify updateRow logic
+    if (row.style.display === "" && row.className === "local") { // visible
+      this.updateRow(row, this.STATUS.add);
+    } else {
+      this.updateRow(row, this.STATUS.reset);
+    }
+  });
+};
+
 // Table iteration helper
 StageHelper.prototype.iterateStageTab = function (changeMode, cb /*, ...*/) {
   var restArgs = Array.prototype.slice.call(arguments, 2);
   var table    = this.dom.stageTab;
+  var retTotal = 0;
 
   if (changeMode) {
     var scrollOffset = window.pageYOffset;
@@ -529,7 +571,8 @@ StageHelper.prototype.iterateStageTab = function (changeMode, cb /*, ...*/) {
     var tbody = table.tBodies[b];
     for (var r = 0, rN = tbody.rows.length; r < rN; r++) {
       var args = [tbody.rows[r]].concat(restArgs);
-      cb.apply(this, args); // callback
+      var retVal = cb.apply(this, args); // callback
+      if (typeof retVal === "number") retTotal += retVal;
     }
   }
 
@@ -537,6 +580,8 @@ StageHelper.prototype.iterateStageTab = function (changeMode, cb /*, ...*/) {
     this.dom.stageTab.style.display = "";
     window.scrollTo(0, scrollOffset);
   }
+
+  return retTotal;
 };
 
 /**********************************************************

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -301,10 +301,15 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
     ro_html->add( '<td class="indent5em">' ).
     ro_html->add_a( iv_act   = 'errorStub(event)' " Will be reinit by JS
                     iv_typ   = zif_abapgit_html=>c_action_type-onclick
-                    iv_id    = 'commitButton'
+                    iv_id    = 'commitSelectedButton'
                     iv_style = 'display: none'
-                    iv_txt   = 'Commit (<span id="fileCounter"></span>)'
+                    iv_txt   = 'Commit selected (<span class="counter"></span>)'
                     iv_opt   = zif_abapgit_html=>c_html_opt-strong ) ##NO_TEXT.
+    ro_html->add_a( iv_act   = 'errorStub(event)' " Will be reinit by JS
+                    iv_typ   = zif_abapgit_html=>c_action_type-onclick
+                    iv_id    = 'commitFilteredButton'
+                    iv_style = 'display: none'
+                    iv_txt   = 'Add <b>filtered</b> and commit (<span class="counter"></span>)' ) ##NO_TEXT.
     ro_html->add_a( iv_act = |{ c_action-stage_all }|
                     iv_id  = 'commitAllButton'
                     iv_txt = lv_add_all_txt ) ##NO_TEXT.
@@ -509,11 +514,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
     ro_html->add( '  formAction:      "stage_commit",' ).
 
     ro_html->add( '  ids: {' ).
-    ro_html->add( '    stageTab:      "stageTab",' ).
-    ro_html->add( '    commitBtn:     "commitButton",' ).
-    ro_html->add( '    commitAllBtn:  "commitAllButton",' ).
-    ro_html->add( '    objectSearch:  "objectSearch",' ).
-    ro_html->add( '    fileCounter:   "fileCounter"' ).
+    ro_html->add( '    stageTab:          "stageTab",' ).
+    ro_html->add( '    commitAllBtn:      "commitAllButton",' ).
+    ro_html->add( '    commitSelectedBtn: "commitSelectedButton",' ).
+    ro_html->add( '    commitFilteredBtn: "commitFilteredButton",' ).
+    ro_html->add( '    objectSearch:      "objectSearch",' ).
     ro_html->add( '  }' ).
 
     ro_html->add( '}' ).


### PR DESCRIPTION
Follows #2988 
Main purpose: press "me" filter - then immediately press commit, without explicit adding

Long explanation: before there were 2 commit options "Commit all" and "Commit those which are manually marked to add". Now I added the 3rd - "Commit all those which are filtered by current filter" - which appears when filter is active AND there is nothing manually selected. So from UX perspective it is a shortcut for quick filter + commit (2 clicks vs 3 clicks). Plus it is very "intuitive" to filter and then click commit which before was commiting **everything** (which is "unexpected") and I stumbled into this a couple of times.

Sorry cannot attach a picture - some github issue, will try later. But it is better to click it live. Stage -> filter something -> see how button changes -> click commit -> check commit list at the bottom

To do in future: diff statuses in stage and commit page, and probably auto adding files, deleted locally (there was an issue somewhere about it)

