### PR TITLE
stage UX improvements: ctrl-enter, autoadd deleted, remote state bugfix

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -302,6 +302,7 @@ function StageHelper(params) {
 
   this.setHooks();
   if (this.user) this.injectFilterMe();
+  this.dom.objectSearch.focus();
 }
 
 StageHelper.prototype.findCounters = function() {
@@ -327,6 +328,7 @@ StageHelper.prototype.onFilterMe = function() {
 
 // Hook global click listener on table, load/unload actions
 StageHelper.prototype.setHooks = function() {
+  window.onkeypress                  = this.onCtrlEnter.bind(this);
   this.dom.stageTab.onclick          = this.onTableClick.bind(this);
   this.dom.commitSelectedBtn.onclick = this.submit.bind(this);
   this.dom.commitFilteredBtn.onclick = this.submitVisible.bind(this);
@@ -407,11 +409,22 @@ StageHelper.prototype.onTableClick = function (event) {
   this.updateMenu();
 };
 
+StageHelper.prototype.onCtrlEnter = function (e) {
+  if (e.ctrlKey && (e.which === 10 || e.key === "Enter")){
+    var clickMap = {
+      "default":  this.dom.commitAllBtn,
+      "selected": this.dom.commitSelectedBtn,
+      "filtered": this.dom.commitFilteredBtn
+    };
+    clickMap[this.calculateActiveCommitCommand()].click();
+  }
+};
+
 // Search object
 StageHelper.prototype.onFilter = function (e) {
   if ( // Enter hit or clear, IE SUCKS !
     e.type === "input" && !e.target.value && this.lastFilterValue
-    || e.type === "keypress" && (e.which === 13 || e.key === "Enter") ) {
+    || e.type === "keypress" && (e.which === 13 || e.key === "Enter") && !e.ctrlKey ) {
 
     this.applyFilterValue(e.target.value);
     submitSapeventForm({ filterValue: e.target.value }, "stage_filter", "post");
@@ -506,19 +519,24 @@ StageHelper.prototype.updateRowCommand = function (row, status) {
   }
 };
 
+StageHelper.prototype.calculateActiveCommitCommand = function () {
+  var active;
+  if (this.selectedCount > 0) {
+    active = "selected";
+  } else if (this.lastFilterValue) {
+    active = "filtered";
+  } else {
+    active = "default";
+  }
+  return active;
+};
+
 // Update menu items visibility
 StageHelper.prototype.updateMenu = function () {
-  var display;
-  if (this.selectedCount > 0) {
-    display = "selected";
-    this.dom.selectedCounter.innerText = this.selectedCount.toString();
-  } else if (this.lastFilterValue) {
-    display = "filtered";
-    this.dom.filteredCounter.innerText = this.filteredCount.toString();
-  } else {
-    display = "default";
-  }
-
+  var display = this.calculateActiveCommitCommand();
+  if (display === "selected") this.dom.selectedCounter.innerText = this.selectedCount.toString();
+  if (display === "filtered") this.dom.filteredCounter.innerText = this.filteredCount.toString();
+  
   this.dom.commitAllBtn.style.display      = display === "default" ? "" : "none";
   this.dom.commitSelectedBtn.style.display = display === "selected" ? "" : "none";
   this.dom.commitFilteredBtn.style.display = display === "filtered" ? "" : "none";

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -302,6 +302,7 @@ function StageHelper(params) {
 
   this.setHooks();
   if (this.user) this.injectFilterMe();
+  Hotkeys.addHotkeyToHelpSheet("^↵", "Commit");
   this.dom.objectSearch.focus();
 }
 

--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -536,7 +536,7 @@ StageHelper.prototype.updateMenu = function () {
   var display = this.calculateActiveCommitCommand();
   if (display === "selected") this.dom.selectedCounter.innerText = this.selectedCount.toString();
   if (display === "filtered") this.dom.filteredCounter.innerText = this.filteredCount.toString();
-  
+
   this.dom.commitAllBtn.style.display      = display === "default" ? "" : "none";
   this.dom.commitSelectedBtn.style.display = display === "selected" ? "" : "none";
   this.dom.commitFilteredBtn.style.display = display === "filtered" ? "" : "none";
@@ -563,8 +563,6 @@ StageHelper.prototype.collectData = function () {
 
 StageHelper.prototype.markVisiblesAsAdded = function () {
   this.iterateStageTab(false, function (row) {
-    var name = row.cells[this.colIndex["name"]].innerText;
-    var cellStatus = row.cells[this.colIndex["status"]];
     // TODO refacotr, unify updateRow logic
     if (row.style.display === "" && row.className === "local") { // visible
       this.updateRow(row, this.STATUS.add);

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -531,7 +531,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
       ASSERT sy-subrc = 0.
 
       IF <ls_status>-lstate = zif_abapgit_definitions=>c_state-deleted
-        and <ls_status>-rstate = zif_abapgit_definitions=>c_state-unchanged.
+        AND <ls_status>-rstate = zif_abapgit_definitions=>c_state-unchanged.
 
         ro_stage->rm(
           iv_path     = <ls_remote>-path

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -73,10 +73,16 @@ CLASS zcl_abapgit_gui_page_stage DEFINITION
     METHODS render_actions
       RETURNING
         VALUE(ro_html) TYPE REF TO zcl_abapgit_html .
-    METHODS process_stage_list
+    METHODS stage_selected
       IMPORTING
         !it_postdata TYPE cnht_post_data_tab
-        !io_stage    TYPE REF TO zcl_abapgit_stage
+      RETURNING
+        VALUE(ro_stage)    TYPE REF TO zcl_abapgit_stage
+      RAISING
+        zcx_abapgit_exception .
+    METHODS stage_all
+      RETURNING
+        VALUE(ro_stage)    TYPE REF TO zcl_abapgit_stage
       RAISING
         zcx_abapgit_exception .
     METHODS build_menu
@@ -224,69 +230,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
         io_stage      = lo_stage.
 
     ri_page = lo_page.
-
-  ENDMETHOD.
-
-
-  METHOD process_stage_list.
-
-    DATA: lv_string TYPE string,
-          lt_fields TYPE tihttpnvp,
-          ls_file   TYPE zif_abapgit_definitions=>ty_file.
-
-    FIELD-SYMBOLS: <ls_file> LIKE LINE OF ms_files-local,
-                   <ls_status> LIKE LINE OF ms_files-status,
-                   <ls_item> LIKE LINE OF lt_fields.
-
-    CONCATENATE LINES OF it_postdata INTO lv_string.
-    lt_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_string ).
-
-    IF lines( lt_fields ) = 0.
-      zcx_abapgit_exception=>raise( 'process_stage_list: empty list' ).
-    ENDIF.
-
-    LOOP AT lt_fields ASSIGNING <ls_item>.
-
-      zcl_abapgit_path=>split_file_location(
-        EXPORTING
-          iv_fullpath = <ls_item>-name
-        IMPORTING
-          ev_path     = ls_file-path
-          ev_filename = ls_file-filename ).
-
-      READ TABLE ms_files-status ASSIGNING <ls_status>
-        WITH TABLE KEY
-          path     = ls_file-path
-          filename = ls_file-filename.
-      ASSERT sy-subrc = 0.
-
-      CASE <ls_item>-value.
-        WHEN zcl_abapgit_stage=>c_method-add.
-          READ TABLE ms_files-local ASSIGNING <ls_file>
-            WITH KEY file-path     = ls_file-path
-                     file-filename = ls_file-filename.
-
-          IF sy-subrc <> 0.
-            zcx_abapgit_exception=>raise( |process_stage_list: unknown file { ls_file-path }{ ls_file-filename }| ).
-          ENDIF.
-
-          io_stage->add( iv_path     = <ls_file>-file-path
-                         iv_filename = <ls_file>-file-filename
-                         is_status   = <ls_status>
-                         iv_data     = <ls_file>-file-data ).
-        WHEN zcl_abapgit_stage=>c_method-ignore.
-          io_stage->ignore( iv_path     = ls_file-path
-                            iv_filename = ls_file-filename ).
-        WHEN zcl_abapgit_stage=>c_method-rm.
-          io_stage->rm( iv_path     = ls_file-path
-                        is_status   = <ls_status>
-                        iv_filename = ls_file-filename ).
-        WHEN zcl_abapgit_stage=>c_method-skip.
-          " Do nothing
-        WHEN OTHERS.
-          zcx_abapgit_exception=>raise( |process_stage_list: unknown method { <ls_item>-value }| ).
-      ENDCASE.
-    ENDLOOP.
 
   ENDMETHOD.
 
@@ -499,8 +442,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
       READ TABLE ms_files-status ASSIGNING <ls_status>
         WITH TABLE KEY
-          path     = <ls_local>-file-path
-          filename = <ls_local>-file-filename.
+          path     = <ls_remote>-path
+          filename = <ls_remote>-filename.
       ASSERT sy-subrc = 0.
 
       ro_html->add( render_file(
@@ -558,66 +501,154 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD stage_all.
+
+    FIELD-SYMBOLS <ls_local> LIKE LINE OF ms_files-local.
+    FIELD-SYMBOLS <ls_remote> LIKE LINE OF ms_files-remote.
+    FIELD-SYMBOLS <ls_status> LIKE LINE OF ms_files-status.
+
+    CREATE OBJECT ro_stage.
+
+    LOOP AT ms_files-local ASSIGNING <ls_local>.
+      READ TABLE ms_files-status ASSIGNING <ls_status>
+        WITH TABLE KEY
+          path     = <ls_local>-file-path
+          filename = <ls_local>-file-filename.
+      ASSERT sy-subrc = 0.
+
+      ro_stage->add(
+        iv_path     = <ls_local>-file-path
+        iv_filename = <ls_local>-file-filename
+        is_status   = <ls_status>
+        iv_data     = <ls_local>-file-data ).
+    ENDLOOP.
+
+    LOOP AT ms_files-remote ASSIGNING <ls_remote>.
+      READ TABLE ms_files-status ASSIGNING <ls_status>
+        WITH TABLE KEY
+          path     = <ls_remote>-path
+          filename = <ls_remote>-filename.
+      ASSERT sy-subrc = 0.
+
+      IF <ls_status>-lstate = zif_abapgit_definitions=>c_state-deleted
+        and <ls_status>-rstate = zif_abapgit_definitions=>c_state-unchanged.
+
+        ro_stage->rm(
+          iv_path     = <ls_remote>-path
+          iv_filename = <ls_remote>-filename
+          is_status   = <ls_status> ).
+      ENDIF.
+
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD stage_selected.
+
+    DATA: lv_string TYPE string,
+          lt_fields TYPE tihttpnvp,
+          ls_file   TYPE zif_abapgit_definitions=>ty_file.
+
+    FIELD-SYMBOLS: <ls_file> LIKE LINE OF ms_files-local,
+                   <ls_status> LIKE LINE OF ms_files-status,
+                   <ls_item> LIKE LINE OF lt_fields.
+
+    CONCATENATE LINES OF it_postdata INTO lv_string.
+    lt_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_string ).
+
+    IF lines( lt_fields ) = 0.
+      zcx_abapgit_exception=>raise( 'process_stage_list: empty list' ).
+    ENDIF.
+
+    CREATE OBJECT ro_stage.
+
+    LOOP AT lt_fields ASSIGNING <ls_item>.
+
+      zcl_abapgit_path=>split_file_location(
+        EXPORTING
+          iv_fullpath = <ls_item>-name
+        IMPORTING
+          ev_path     = ls_file-path
+          ev_filename = ls_file-filename ).
+
+      READ TABLE ms_files-status ASSIGNING <ls_status>
+        WITH TABLE KEY
+          path     = ls_file-path
+          filename = ls_file-filename.
+      ASSERT sy-subrc = 0.
+
+      CASE <ls_item>-value.
+        WHEN zcl_abapgit_stage=>c_method-add.
+          READ TABLE ms_files-local ASSIGNING <ls_file>
+            WITH KEY file-path     = ls_file-path
+                     file-filename = ls_file-filename.
+
+          IF sy-subrc <> 0.
+            zcx_abapgit_exception=>raise( |process_stage_list: unknown file { ls_file-path }{ ls_file-filename }| ).
+          ENDIF.
+
+          ro_stage->add( iv_path     = <ls_file>-file-path
+                         iv_filename = <ls_file>-file-filename
+                         is_status   = <ls_status>
+                         iv_data     = <ls_file>-file-data ).
+        WHEN zcl_abapgit_stage=>c_method-ignore.
+          ro_stage->ignore( iv_path     = ls_file-path
+                            iv_filename = ls_file-filename ).
+        WHEN zcl_abapgit_stage=>c_method-rm.
+          ro_stage->rm( iv_path     = ls_file-path
+                        is_status   = <ls_status>
+                        iv_filename = ls_file-filename ).
+        WHEN zcl_abapgit_stage=>c_method-skip.
+          " Do nothing
+        WHEN OTHERS.
+          zcx_abapgit_exception=>raise( |process_stage_list: unknown method { <ls_item>-value }| ).
+      ENDCASE.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_gui_event_handler~on_event.
 
     DATA: lo_stage  TYPE REF TO zcl_abapgit_stage,
-          lv_string TYPE string,
           lt_fields TYPE tihttpnvp.
-
-    FIELD-SYMBOLS: <ls_file> LIKE LINE OF ms_files-local.
-    FIELD-SYMBOLS: <ls_status> LIKE LINE OF ms_files-status.
-
-
-    CREATE OBJECT lo_stage.
 
     CLEAR: ei_page, ev_state.
 
     CASE iv_action.
       WHEN c_action-stage_all.
 
-        LOOP AT ms_files-local ASSIGNING <ls_file>.
-          READ TABLE ms_files-status ASSIGNING <ls_status>
-            WITH TABLE KEY
-              path = <ls_file>-file-path
-              filename = <ls_file>-file-filename.
-          ASSERT sy-subrc = 0.
-
-          lo_stage->add(
-            iv_path     = <ls_file>-file-path
-            iv_filename = <ls_file>-file-filename
-            is_status   = <ls_status>
-            iv_data     = <ls_file>-file-data ).
-        ENDLOOP.
+        lo_stage = stage_all( ).
 
         CREATE OBJECT ei_page TYPE zcl_abapgit_gui_page_commit
           EXPORTING
             io_repo  = mo_repo
             io_stage = lo_stage.
-        ev_state = zcl_abapgit_gui=>c_event_state-new_page.
 
         ev_state = zcl_abapgit_gui=>c_event_state-new_page.
 
       WHEN c_action-stage_commit.
 
-        process_stage_list(
-          it_postdata = it_postdata
-          io_stage    = lo_stage ).
+        lo_stage = stage_selected( it_postdata ).
 
         CREATE OBJECT ei_page TYPE zcl_abapgit_gui_page_commit
           EXPORTING
             io_repo  = mo_repo
             io_stage = lo_stage.
+
         ev_state = zcl_abapgit_gui=>c_event_state-new_page.
 
       WHEN c_action-stage_filter.
 
-        CONCATENATE LINES OF it_postdata INTO lv_string.
+        lt_fields = zcl_abapgit_html_action_utils=>parse_fields( concat_lines_of( table = it_postdata ) ).
 
-        lt_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_string ).
-
-        zcl_abapgit_html_action_utils=>get_field( EXPORTING iv_name  = 'filterValue'
-                                                            it_field = lt_fields
-                                                  CHANGING  cg_field = mv_filter_value ).
+        zcl_abapgit_html_action_utils=>get_field(
+          EXPORTING
+            iv_name  = 'filterValue'
+            it_field = lt_fields
+          CHANGING
+            cg_field = mv_filter_value ).
 
         ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
 


### PR DESCRIPTION
OK, final cherry on this series

1. Ctrl+enter on stage page activates current commit action 
2. Files deleted locally autoadded to the commit (potentially resolves the issue from #2944) - watch out, imho the state is sometimes deceiving @christianguenter2 
3. Stupid bug fix for remote state from the previous PR
4. Autofocus on filter field

![image](https://user-images.githubusercontent.com/15635498/67636547-75894480-f8da-11e9-88f3-6cef65a9cb28.png)

![image](https://user-images.githubusercontent.com/15635498/67636555-85088d80-f8da-11e9-8974-7807d41149b3.png)


