### PR TITLE
'Duplicates' error: show duplicate object names

### DIFF
--- a/src/zcl_abapgit_objects.clas.abap
+++ b/src/zcl_abapgit_objects.clas.abap
@@ -305,7 +305,7 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
           lv_all_duplicates TYPE string.
 
     FIELD-SYMBOLS:
-      <lv_file> like line of it_files.
+      <lv_file> LIKE LINE OF it_files.
 
     lt_files = it_files.
     SORT lt_files BY path ASCENDING filename ASCENDING.

--- a/src/zcl_abapgit_objects.clas.abap
+++ b/src/zcl_abapgit_objects.clas.abap
@@ -450,7 +450,6 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
       ls_obj_serializer_map-item      = is_item.
       ls_obj_serializer_map-metadata  = is_metadata.
       INSERT ls_obj_serializer_map INTO TABLE gt_obj_serializer_map.
-
       lv_class_name = is_metadata-class.
     ELSE.
       lv_class_name = class_name( is_item ).

--- a/src/zcl_abapgit_objects.clas.abap
+++ b/src/zcl_abapgit_objects.clas.abap
@@ -298,14 +298,29 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
   METHOD check_duplicates.
 
-    DATA: lt_files TYPE zif_abapgit_definitions=>ty_files_tt.
+    DATA: lt_files TYPE zif_abapgit_definitions=>ty_files_tt,
+          lv_path TYPE string,
+          lv_filename TYPE string,
+          lt_duplicates TYPE stringtab,
+          lv_all_duplicates TYPE string.
 
+    FIELD-SYMBOLS:
+      <lv_file> like line of it_files.
 
     lt_files = it_files.
     SORT lt_files BY path ASCENDING filename ASCENDING.
-    DELETE ADJACENT DUPLICATES FROM lt_files COMPARING path filename.
-    IF lines( lt_files ) <> lines( it_files ).
-      zcx_abapgit_exception=>raise( 'Duplicates' ).
+
+    LOOP AT lt_files ASSIGNING <lv_file>.
+      IF lv_path = <lv_file>-path AND lv_filename = <lv_file>-filename.
+        APPEND <lv_file>-path && <lv_file>-filename TO lt_duplicates.
+      ENDIF.
+      lv_path = <lv_file>-path.
+      lv_filename = <lv_file>-filename.
+    ENDLOOP.
+
+    IF lt_duplicates IS NOT INITIAL.
+      CONCATENATE LINES OF lt_duplicates INTO lv_all_duplicates SEPARATED BY `, `.
+      zcx_abapgit_exception=>raise( |Duplicates: { lv_all_duplicates }| ).
     ENDIF.
 
   ENDMETHOD.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5097067/68025638-a5a35f80-fcad-11e9-9980-7fd44fb3028d.png)

Resolves #3020, but maybe we can document the reasons for why it happens. How can you have the same filename+path twice? It only makes sense to me to have the same file in different folders.