### PR TITLE
Downport, add exit, fixes #2671

### DIFF
--- a/docs/ref-exits.md
+++ b/docs/ref-exits.md
@@ -47,3 +47,7 @@ Possibility to change the default `ANONYM` ssl id to something system specific
 ### CUSTOM_SERIALIZE_ABAP_CLIF
 Allows for a custom serializer to be used for global classes' CLIF sources. See [#2321](https://github.com/larshp/abapGit/issues/2321) and [#2491](https://github.com/larshp/abapGit/pull/2491) for use cases.  
 This [example implementation](https://gist.github.com/flaiker/999c8165b89131608b05cd371529fef5) forces the old class serializer to be used for specific packages.
+
+### CUSTOM_DESERIALIZE_ABAP_CLIF
+Allows for a custom deserializer to be used for global classes' CLIF sources. See [#2671](https://github.com/larshp/abapGit/issues/2671) for use case.
+This [example implementation](https://gist.github.com/sandraros/fee3543aed40845888541554c7e87b4f) deserializes as usual except that the __exact__ source code is not deserialized (feature not available in old 7.02 kernel).

--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -330,6 +330,11 @@ CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
                       iv_package = iv_package ).
 
     deserialize_docu( io_xml ).
+
+    zcl_abapgit_objects_activation=>add(
+      iv_type = 'CLAS'
+      iv_name = ms_item-obj_name ).
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_oo_base.clas.abap
+++ b/src/objects/zcl_abapgit_oo_base.clas.abap
@@ -12,21 +12,11 @@ CLASS zcl_abapgit_oo_base DEFINITION PUBLIC ABSTRACT.
   PRIVATE SECTION.
     DATA mv_skip_test_classes TYPE abap_bool.
 
-    METHODS deserialize_abap_source_old
-      IMPORTING is_clskey TYPE seoclskey
-                it_source TYPE zif_abapgit_definitions=>ty_string_tt
-      RAISING   zcx_abapgit_exception.
-
-    METHODS deserialize_abap_source_new
-      IMPORTING is_clskey TYPE seoclskey
-                it_source TYPE zif_abapgit_definitions=>ty_string_tt
-      RAISING   zcx_abapgit_exception
-                cx_sy_dyn_call_error.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OO_BASE IMPLEMENTATION.
+CLASS zcl_abapgit_oo_base IMPLEMENTATION.
 
 
   METHOD convert_attrib_to_vseoattrib.
@@ -40,93 +30,6 @@ CLASS ZCL_ABAPGIT_OO_BASE IMPLEMENTATION.
       UNASSIGN <ls_vseoattrib>.
     ENDLOOP.
     UNASSIGN <ls_attribute>.
-  ENDMETHOD.
-
-
-  METHOD deserialize_abap_source_new.
-    DATA: lo_factory  TYPE REF TO object,
-          lo_source   TYPE REF TO object,
-          lo_settings TYPE REF TO object,
-          lr_settings TYPE REF TO data.
-
-    FIELD-SYMBOLS <lg_settings> TYPE any.
-
-
-    "Buffer needs to be refreshed,
-    "otherwise standard SAP CLIF_SOURCE reorder methods alphabetically
-    CALL FUNCTION 'SEO_BUFFER_INIT'.
-    CALL FUNCTION 'SEO_BUFFER_REFRESH'
-      EXPORTING
-        cifkey  = is_clskey
-        version = seoc_version_inactive.
-
-    CALL METHOD ('CL_OO_FACTORY')=>('CREATE_INSTANCE')
-      RECEIVING
-        result = lo_factory.
-
-    "Enable modification mode to avoid exception CX_OO_ACCESS_PERMISSON when
-    "dealing with objects in foreign namespaces (namespace role = C)
-    CALL METHOD lo_factory->('CREATE_SETTINGS')
-      EXPORTING
-        modification_mode_enabled = abap_true
-      RECEIVING
-        result                    = lo_settings.
-
-    CREATE DATA lr_settings TYPE REF TO ('IF_OO_CLIF_SOURCE_SETTINGS').
-    ASSIGN lr_settings->* TO <lg_settings>.
-
-    <lg_settings> ?= lo_settings.
-
-    CALL METHOD lo_factory->('CREATE_CLIF_SOURCE')
-      EXPORTING
-        clif_name = is_clskey-clsname
-        settings  = <lg_settings>
-      RECEIVING
-        result    = lo_source.
-
-    TRY.
-        CALL METHOD lo_source->('IF_OO_CLIF_SOURCE~LOCK').
-      CATCH cx_oo_access_permission.
-        zcx_abapgit_exception=>raise( 'source_new, access permission exception' ).
-    ENDTRY.
-
-    CALL METHOD lo_source->('IF_OO_CLIF_SOURCE~SET_SOURCE')
-      EXPORTING
-        source = it_source.
-
-    CALL METHOD lo_source->('IF_OO_CLIF_SOURCE~SAVE').
-
-    CALL METHOD lo_source->('IF_OO_CLIF_SOURCE~UNLOCK').
-
-  ENDMETHOD.
-
-
-  METHOD deserialize_abap_source_old.
-    "for backwards compatability down to 702
-
-    DATA: lo_source TYPE REF TO cl_oo_source.
-
-    CREATE OBJECT lo_source
-      EXPORTING
-        clskey             = is_clskey
-      EXCEPTIONS
-        class_not_existing = 1
-        OTHERS             = 2.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from CL_OO_SOURCE. Subrc = { sy-subrc }| ).
-    ENDIF.
-
-    TRY.
-        lo_source->access_permission( seok_access_modify ).
-        lo_source->set_source( it_source ).
-        lo_source->save( ).
-        lo_source->access_permission( seok_access_free ).
-      CATCH cx_oo_access_permission.
-        zcx_abapgit_exception=>raise( 'permission error' ).
-      CATCH cx_oo_source_save_failure.
-        zcx_abapgit_exception=>raise( 'save failure' ).
-    ENDTRY.
-
   ENDMETHOD.
 
 
@@ -168,15 +71,7 @@ CLASS ZCL_ABAPGIT_OO_BASE IMPLEMENTATION.
 
 
   METHOD zif_abapgit_oo_object_fnc~deserialize_source.
-    TRY.
-        deserialize_abap_source_new(
-          is_clskey = is_key
-          it_source = it_source ).
-      CATCH cx_sy_dyn_call_error.
-        deserialize_abap_source_old(
-          is_clskey = is_key
-          it_source = it_source ).
-    ENDTRY.
+    ASSERT 0 = 1. "Subclass responsibility
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_oo_class.clas.abap
+++ b/src/objects/zcl_abapgit_oo_class.clas.abap
@@ -28,10 +28,6 @@ CLASS zcl_abapgit_oo_class DEFINITION
   PROTECTED SECTION.
   PRIVATE SECTION.
 
-    CLASS-METHODS update_source_index
-      IMPORTING
-        !iv_clsname TYPE csequence
-        !io_scanner TYPE REF TO cl_oo_source_scanner_class .
     CLASS-METHODS update_report
       IMPORTING
         !iv_program       TYPE programm
@@ -40,278 +36,12 @@ CLASS zcl_abapgit_oo_class DEFINITION
         VALUE(rv_updated) TYPE abap_bool
       RAISING
         zcx_abapgit_exception .
-    CLASS-METHODS generate_classpool
-      IMPORTING
-        !iv_name TYPE seoclsname
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS update_meta
-      IMPORTING
-        !iv_name     TYPE seoclsname
-        !iv_exposure TYPE seoexpose
-        !it_source   TYPE rswsourcet
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS determine_method_include
-      IMPORTING
-        !iv_name          TYPE seoclsname
-        !iv_method        TYPE seocpdname
-      RETURNING
-        VALUE(rv_program) TYPE programm
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS init_scanner
-      IMPORTING
-        !it_source        TYPE zif_abapgit_definitions=>ty_string_tt
-        !iv_name          TYPE seoclsname
-      RETURNING
-        VALUE(ro_scanner) TYPE REF TO cl_oo_source_scanner_class
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS update_full_class_include
-      IMPORTING
-        !iv_classname TYPE seoclsname
-        !it_source    TYPE string_table
-        !it_methods   TYPE cl_oo_source_scanner_class=>type_method_implementations .
-    CLASS-METHODS create_report
-      IMPORTING
-        !iv_program      TYPE programm
-        !it_source       TYPE string_table
-        !iv_extension    TYPE sychar02
-        !iv_program_type TYPE sychar01
-        !iv_version      TYPE r3state .
-    CLASS-METHODS update_cs_number_of_methods
-      IMPORTING
-        !iv_classname              TYPE seoclsname
-        !iv_number_of_impl_methods TYPE i .
+
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OO_CLASS IMPLEMENTATION.
-
-
-  METHOD create_report.
-    INSERT REPORT iv_program FROM it_source EXTENSION TYPE iv_extension STATE iv_version PROGRAM TYPE iv_program_type.
-    ASSERT sy-subrc = 0.
-  ENDMETHOD.
-
-
-  METHOD determine_method_include.
-
-    DATA: ls_mtdkey TYPE seocpdkey.
-
-
-    ls_mtdkey-clsname = iv_name.
-    ls_mtdkey-cpdname = iv_method.
-
-    cl_oo_classname_service=>get_method_include(
-      EXPORTING
-        mtdkey              = ls_mtdkey
-      RECEIVING
-        result              = rv_program
-      EXCEPTIONS
-        method_not_existing = 1 ).
-    IF sy-subrc = 0.
-      RETURN.
-    ENDIF.
-
-    CALL FUNCTION 'SEO_METHOD_GENERATE_INCLUDE'
-      EXPORTING
-        suppress_mtdkey_check          = abap_true
-        mtdkey                         = ls_mtdkey
-      EXCEPTIONS
-        not_existing                   = 1
-        model_only                     = 2
-        include_existing               = 3
-        method_imp_not_generated       = 4
-        method_imp_not_initialised     = 5
-        _internal_class_not_existing   = 6
-        _internal_method_overflow      = 7
-        cancelled                      = 8
-        method_is_abstract_implemented = 9
-        method_is_final_implemented    = 10
-        internal_error_insert_report   = 11
-        OTHERS                         = 12.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from SEO_METHOD_GENERATE_INCLUDE. Subrc = { sy-subrc }| ).
-    ENDIF.
-
-    rv_program = cl_oo_classname_service=>get_method_include( ls_mtdkey ).
-
-  ENDMETHOD.
-
-
-  METHOD generate_classpool.
-
-    DATA: ls_clskey TYPE seoclskey.
-
-    ls_clskey-clsname = iv_name.
-
-    CALL FUNCTION 'SEO_CLASS_GENERATE_CLASSPOOL'
-      EXPORTING
-        clskey                        = ls_clskey
-        suppress_corr                 = abap_true
-      EXCEPTIONS
-        not_existing                  = 1
-        model_only                    = 2
-        class_pool_not_generated      = 3
-        class_stment_not_generated    = 4
-        locals_not_generated          = 5
-        macros_not_generated          = 6
-        public_sec_not_generated      = 7
-        protected_sec_not_generated   = 8
-        private_sec_not_generated     = 9
-        typeref_not_generated         = 10
-        class_pool_not_initialised    = 11
-        class_stment_not_initialised  = 12
-        locals_not_initialised        = 13
-        macros_not_initialised        = 14
-        public_sec_not_initialised    = 15
-        protected_sec_not_initialised = 16
-        private_sec_not_initialised   = 17
-        typeref_not_initialised       = 18
-        _internal_class_overflow      = 19
-        OTHERS                        = 20.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error from SEO_CLASS_GENERATE_CLASSPOOL. Subrc = { sy-subrc }| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD init_scanner.
-
-    TRY.
-        ro_scanner = cl_oo_source_scanner_class=>create_class_scanner(
-          clif_name = iv_name
-          source    = it_source ).
-        ro_scanner->scan( ).
-      CATCH cx_clif_scan_error.
-        zcx_abapgit_exception=>raise( 'error initializing CLAS scanner' ).
-    ENDTRY.
-
-  ENDMETHOD.
-
-
-  METHOD update_cs_number_of_methods.
-
-    " Indirect access to keep downward compatibility
-    DATA lr_cache_entry TYPE REF TO data.
-
-    FIELD-SYMBOLS: <lg_cache_entry> TYPE any,
-                   <lg_field>       TYPE any.
-
-
-    TRY.
-        CREATE DATA lr_cache_entry TYPE ('SEO_CS_CACHE').
-      CATCH cx_sy_create_data_error.
-* does not exist in some older systems
-        RETURN.
-    ENDTRY.
-
-    ASSIGN lr_cache_entry->* TO <lg_cache_entry>.
-    ASSERT sy-subrc = 0.
-
-    ASSIGN COMPONENT 'CLSNAME' OF STRUCTURE <lg_cache_entry>
-           TO <lg_field>.
-    ASSERT sy-subrc = 0.
-    <lg_field> = iv_classname.
-
-    ASSIGN COMPONENT 'NO_OF_METHOD_IMPLS' OF STRUCTURE <lg_cache_entry>
-           TO <lg_field>.
-    ASSERT sy-subrc = 0.
-    <lg_field> = iv_number_of_impl_methods.
-
-    MODIFY ('SEO_CS_CACHE') FROM <lg_cache_entry>.
-
-  ENDMETHOD.
-
-
-  METHOD update_full_class_include.
-
-    CONSTANTS: lc_class_source_extension TYPE sychar02 VALUE 'CS',
-               lc_include_program_type   TYPE sychar01 VALUE 'I',
-               lc_active_version         TYPE r3state VALUE 'A'.
-
-
-    create_report( iv_program      = cl_oo_classname_service=>get_cs_name( iv_classname )
-                   it_source       = it_source
-                   iv_extension    = lc_class_source_extension
-                   iv_program_type = lc_include_program_type
-                   iv_version      = lc_active_version ).
-
-    " Assuming that all methods that were scanned are implemented
-    update_cs_number_of_methods( iv_classname              = iv_classname
-                                 iv_number_of_impl_methods = lines( it_methods ) ).
-
-  ENDMETHOD.
-
-
-  METHOD update_meta.
-
-    DATA: lo_update     TYPE REF TO cl_oo_class_section_source,
-          ls_clskey     TYPE seoclskey,
-          lv_scan_error TYPE abap_bool.
-
-
-    ls_clskey-clsname = iv_name.
-
-    TRY.
-        CREATE OBJECT lo_update TYPE ('CL_OO_CLASS_SECTION_SOURCE')
-          EXPORTING
-            clskey                        = ls_clskey
-            exposure                      = iv_exposure
-            state                         = 'A'
-            source                        = it_source
-            suppress_constrctr_generation = abap_true
-          EXCEPTIONS
-            class_not_existing            = 1
-            read_source_error             = 2
-            OTHERS                        = 3 ##SUBRC_OK.
-      CATCH cx_sy_dyn_call_param_not_found.
-* downport to 702, see https://github.com/larshp/abapGit/issues/933
-* this will READ REPORT instead of using it_source, which should be okay
-        CREATE OBJECT lo_update TYPE cl_oo_class_section_source
-          EXPORTING
-            clskey             = ls_clskey
-            exposure           = iv_exposure
-            state              = 'A'
-          EXCEPTIONS
-            class_not_existing = 1
-            read_source_error  = 2
-            OTHERS             = 3.
-    ENDTRY.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error instantiating CL_OO_CLASS_SECTION_SOURCE. Subrc = { sy-subrc }| ).
-    ENDIF.
-
-    lo_update->set_dark_mode( abap_true ).
-    TRY.
-        CALL METHOD lo_update->('SET_AMDP_SUPPORT')
-          EXPORTING
-            enabled = abap_true.
-      CATCH cx_sy_dyn_call_illegal_method ##NO_HANDLER.
-* AMDP not supported in this system, ignore error
-    ENDTRY.
-    lo_update->scan_section_source(
-      RECEIVING
-        scan_error             = lv_scan_error
-      EXCEPTIONS
-        scan_abap_source_error = 1
-        OTHERS                 = 2 ).
-    IF sy-subrc <> 0 OR lv_scan_error = abap_true.
-      zcx_abapgit_exception=>raise( |CLAS, error while scanning source. Subrc = { sy-subrc }| ).
-    ENDIF.
-
-* this will update the SEO* database tables
-    lo_update->revert_scan_result( ).
-
-    IF iv_exposure = seoc_exposure_public.
-      generate_classpool( iv_name ).
-    ENDIF.
-
-  ENDMETHOD.
+CLASS zcl_abapgit_oo_class IMPLEMENTATION.
 
 
   METHOD update_report.
@@ -334,37 +64,6 @@ CLASS ZCL_ABAPGIT_OO_CLASS IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD update_source_index.
-
-    CONSTANTS:
-      lc_version_active   TYPE r3state VALUE 'A',           "#EC NOTEXT
-      lc_version_inactive TYPE r3state VALUE 'I'.           "#EC NOTEXT
-
-    "    dynamic invocation, IF_OO_SOURCE_POS_INDEX_HELPER doesn't exist in 702.
-    DATA lo_index_helper TYPE REF TO object.
-
-    TRY.
-        CREATE OBJECT lo_index_helper TYPE ('CL_OO_SOURCE_POS_INDEX_HELPER').
-
-        CALL METHOD lo_index_helper->('IF_OO_SOURCE_POS_INDEX_HELPER~CREATE_INDEX_WITH_SCANNER')
-          EXPORTING
-            class_name = iv_clsname
-            version    = lc_version_active
-            scanner    = io_scanner.
-
-        CALL METHOD lo_index_helper->('IF_OO_SOURCE_POS_INDEX_HELPER~DELETE_INDEX')
-          EXPORTING
-            class_name = iv_clsname
-            version    = lc_version_inactive.
-
-      CATCH cx_root.
-        " it's probably okay to no update the index
-        RETURN.
-    ENDTRY.
-
-  ENDMETHOD.
-
-
   METHOD zif_abapgit_oo_object_fnc~create.
 
     DATA: lt_vseoattrib TYPE seoo_attributes_r.
@@ -379,23 +78,44 @@ CLASS ZCL_ABAPGIT_OO_CLASS IMPLEMENTATION.
                       iv_clsname    = <lv_clsname>
                       it_attributes = it_attributes ).
 
-    CALL FUNCTION 'SEO_CLASS_CREATE_COMPLETE'
-      EXPORTING
-        devclass        = iv_package
-        overwrite       = iv_overwrite
-        version         = seoc_version_active
-        suppress_dialog = abap_true
-      CHANGING
-        class           = cg_properties
-        attributes      = lt_vseoattrib
-      EXCEPTIONS
-        existing        = 1
-        is_interface    = 2
-        db_error        = 3
-        component_error = 4
-        no_access       = 5
-        other           = 6
-        OTHERS          = 7.
+    TRY.
+        CALL FUNCTION 'SEO_CLASS_CREATE_COMPLETE'
+          EXPORTING
+            devclass        = iv_package
+            overwrite       = iv_overwrite
+            version         = seoc_version_active
+            suppress_dialog = abap_true
+          CHANGING
+            class           = cg_properties
+            attributes      = lt_vseoattrib
+          EXCEPTIONS
+            existing        = 1
+            is_interface    = 2
+            db_error        = 3
+            component_error = 4
+            no_access       = 5
+            other           = 6
+            OTHERS          = 7.
+      CATCH cx_sy_dyn_call_param_not_found.
+        " Old support packages of 7.02 versions don't have parameter SUPPRESS_DIALOG
+        CALL FUNCTION 'SEO_CLASS_CREATE_COMPLETE'
+          EXPORTING
+            devclass        = iv_package
+            overwrite       = iv_overwrite
+            version         = seoc_version_active
+          CHANGING
+            class           = cg_properties
+            attributes      = lt_vseoattrib
+          EXCEPTIONS
+            existing        = 1
+            is_interface    = 2
+            db_error        = 3
+            component_error = 4
+            no_access       = 5
+            other           = 6
+            OTHERS          = 7.
+    ENDTRY.
+
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( |Error from SEO_CLASS_CREATE_COMPLETE. Subrc = { sy-subrc }| ).
     ENDIF.
@@ -488,103 +208,11 @@ CLASS ZCL_ABAPGIT_OO_CLASS IMPLEMENTATION.
 
   METHOD zif_abapgit_oo_object_fnc~deserialize_source.
 
-    DATA: lv_updated TYPE abap_bool,
-          lv_program TYPE program,
-          lo_scanner TYPE REF TO cl_oo_source_scanner_class,
-          lt_methods TYPE cl_oo_source_scanner_class=>type_method_implementations,
-          lv_method  LIKE LINE OF lt_methods,
-          lt_public  TYPE seop_source_string,
-          lt_auxsrc  TYPE seop_source_string,
-          lt_source  TYPE seop_source_string.
-
-    "Buffer needs to be refreshed,
-    "otherwise standard SAP CLIF_SOURCE reorder methods alphabetically
-    CALL FUNCTION 'SEO_BUFFER_INIT'.
-    CALL FUNCTION 'SEO_BUFFER_REFRESH'
+    zcl_abapgit_oo_deserializer=>deserialize_abap_clif_source(
       EXPORTING
-        cifkey  = is_key
-        version = seoc_version_inactive.
-
-    lo_scanner = init_scanner(
-      it_source = it_source
-      iv_name   = is_key-clsname ).
-
-* public
-    lt_public = lo_scanner->get_public_section_source( ).
-    IF lt_public IS NOT INITIAL.
-      lv_program = cl_oo_classname_service=>get_pubsec_name( is_key-clsname ).
-      lv_updated = update_report( iv_program = lv_program
-                                  it_source  = lt_public ).
-      IF lv_updated = abap_true.
-        update_meta( iv_name     = is_key-clsname
-                     iv_exposure = seoc_exposure_public
-                     it_source   = lt_public ).
-      ENDIF.
-    ENDIF.
-
-* protected
-    lt_source = lo_scanner->get_protected_section_source( ).
-    IF lt_source IS NOT INITIAL.
-      lv_program = cl_oo_classname_service=>get_prosec_name( is_key-clsname ).
-      lv_updated = update_report( iv_program = lv_program
-                                  it_source  = lt_source ).
-      IF lv_updated = abap_true.
-        lt_auxsrc = lt_public.
-        APPEND LINES OF lt_source TO lt_auxsrc.
-
-        update_meta( iv_name     = is_key-clsname
-                     iv_exposure = seoc_exposure_protected
-                     it_source   = lt_auxsrc ).
-      ENDIF.
-    ENDIF.
-
-* private
-    lt_source = lo_scanner->get_private_section_source( ).
-    IF lt_source IS NOT INITIAL.
-      lv_program = cl_oo_classname_service=>get_prisec_name( is_key-clsname ).
-      lv_updated = update_report( iv_program = lv_program
-                                  it_source  = lt_source ).
-      IF lv_updated = abap_true.
-        lt_auxsrc = lt_public.
-        APPEND LINES OF lt_source TO lt_auxsrc.
-
-        update_meta( iv_name     = is_key-clsname
-                     iv_exposure = seoc_exposure_private
-                     it_source   = lt_auxsrc ).
-      ENDIF.
-    ENDIF.
-
-* methods
-    lt_methods = lo_scanner->get_method_implementations( ).
-
-    LOOP AT lt_methods INTO lv_method.
-      TRY.
-          lt_source = lo_scanner->get_method_impl_source( lv_method ).
-        CATCH cx_oo_clif_component.
-          zcx_abapgit_exception=>raise( 'error from GET_METHOD_IMPL_SOURCE' ).
-      ENDTRY.
-      lv_program = determine_method_include(
-        iv_name   = is_key-clsname
-        iv_method = lv_method ).
-
-      update_report(
-        iv_program = lv_program
-        it_source  = lt_source ).
-    ENDLOOP.
-
-* full class include
-    update_full_class_include( iv_classname = is_key-clsname
-                               it_source    = it_source
-                               it_methods   = lt_methods ).
-
-    update_source_index(
-      iv_clsname = is_key-clsname
-      io_scanner = lo_scanner ).
-
-* TODO, perhaps move this call to somewhere else, to be done while cleaning up the CLAS deserialization
-    zcl_abapgit_objects_activation=>add(
-      iv_type = 'CLAS'
-      iv_name = is_key-clsname ).
+        iv_object_type = 'CLAS'
+        is_key         = is_key
+        it_source      = it_source ).
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_oo_class.clas.abap
+++ b/src/objects/zcl_abapgit_oo_class.clas.abap
@@ -209,7 +209,6 @@ CLASS zcl_abapgit_oo_class IMPLEMENTATION.
   METHOD zif_abapgit_oo_object_fnc~deserialize_source.
 
     zcl_abapgit_oo_deserializer=>deserialize_abap_clif_source(
-      EXPORTING
         iv_object_type = 'CLAS'
         is_key         = is_key
         it_source      = it_source ).

--- a/src/objects/zcl_abapgit_oo_deserializer.clas.abap
+++ b/src/objects/zcl_abapgit_oo_deserializer.clas.abap
@@ -1,0 +1,511 @@
+CLASS zcl_abapgit_oo_deserializer DEFINITION
+  PUBLIC
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS deserialize_abap_clif_source
+      IMPORTING
+        !iv_object_type TYPE tadir-object
+        !is_key         TYPE seoclskey
+        !it_source      TYPE zif_abapgit_definitions=>ty_string_tt
+      RAISING
+        zcx_abapgit_exception .
+    METHODS constructor
+      IMPORTING
+        !is_key    TYPE seoclskey
+        !it_source TYPE zif_abapgit_definitions=>ty_string_tt
+      RAISING
+        zcx_abapgit_exception .
+    METHODS deserialize_definition
+      RAISING
+        zcx_abapgit_exception
+        cx_sy_dyn_call_error .
+    METHODS deserialize_implementation
+      RAISING
+        zcx_abapgit_exception .
+    METHODS deserialize_full_class_include
+      IMPORTING
+        !it_source TYPE zif_abapgit_definitions=>ty_string_tt
+      RAISING
+        zcx_abapgit_exception .
+    METHODS update_source_index
+      RAISING
+        zcx_abapgit_exception .
+  PROTECTED SECTION.
+
+  PRIVATE SECTION.
+
+    CLASS-METHODS init_scanner
+      IMPORTING
+        !it_source        TYPE zif_abapgit_definitions=>ty_string_tt
+        !iv_name          TYPE seoclsname
+      RETURNING
+        VALUE(ro_scanner) TYPE REF TO cl_oo_source_scanner_class
+      RAISING
+        zcx_abapgit_exception .
+
+    CLASS-METHODS update_report
+      IMPORTING
+        !iv_program       TYPE programm
+        !it_source        TYPE string_table
+      RETURNING
+        VALUE(rv_updated) TYPE abap_bool
+      RAISING
+        zcx_abapgit_exception .
+
+    CLASS-METHODS update_meta
+      IMPORTING
+        !iv_name     TYPE seoclsname
+        !iv_exposure TYPE seoexpose
+        !it_source   TYPE rswsourcet
+      RAISING
+        zcx_abapgit_exception .
+
+    CLASS-METHODS generate_classpool
+      IMPORTING
+        !iv_name TYPE seoclsname
+      RAISING
+        zcx_abapgit_exception .
+
+    CLASS-METHODS determine_method_include
+      IMPORTING
+        !iv_name          TYPE seoclsname
+        !iv_method        TYPE seocpdname
+      RETURNING
+        VALUE(rv_program) TYPE programm
+      RAISING
+        zcx_abapgit_exception .
+
+    CLASS-METHODS create_report
+      IMPORTING
+        !iv_program      TYPE programm
+        !it_source       TYPE string_table
+        !iv_extension    TYPE sychar02
+        !iv_program_type TYPE sychar01
+        !iv_version      TYPE r3state .
+
+    CLASS-METHODS update_cs_number_of_methods
+      IMPORTING
+        !iv_classname              TYPE seoclsname
+        !iv_number_of_impl_methods TYPE i .
+
+    DATA:
+      ms_key     TYPE seoclskey,
+      mo_scanner TYPE REF TO cl_oo_source_scanner_class.
+
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_oo_deserializer IMPLEMENTATION.
+
+
+  METHOD deserialize_abap_clif_source.
+
+    DATA: lo_deserializer TYPE REF TO zcl_abapgit_oo_deserializer,
+          lv_done         TYPE abap_bool.
+
+
+    lv_done = zcl_abapgit_exit=>get_instance( )->custom_deserialize_abap_clif(
+                                              iv_object_type   = iv_object_type
+                                              is_key           = is_key
+                                              it_source        = it_source ).
+    IF lv_done = abap_true.
+      RETURN.
+    ENDIF.
+
+    CREATE OBJECT lo_deserializer
+      EXPORTING
+        is_key    = is_key
+        it_source = it_source.
+
+    lo_deserializer->deserialize_definition( ).
+
+    lo_deserializer->deserialize_implementation( ).
+
+    lo_deserializer->deserialize_full_class_include( it_source = it_source ).
+
+    lo_deserializer->update_source_index( ).
+
+  ENDMETHOD.
+
+  METHOD constructor.
+
+    me->ms_key = is_key.
+
+    "Buffer needs to be refreshed,
+    "otherwise standard SAP CLIF_SOURCE reorder methods alphabetically
+    CALL FUNCTION 'SEO_BUFFER_INIT'.
+    CALL FUNCTION 'SEO_BUFFER_REFRESH'
+      EXPORTING
+        cifkey  = is_key
+        version = seoc_version_inactive.
+
+    mo_scanner = init_scanner(
+      it_source = it_source
+      iv_name   = is_key-clsname ).
+
+  ENDMETHOD.
+
+
+  METHOD create_report.
+    INSERT REPORT iv_program FROM it_source EXTENSION TYPE iv_extension STATE iv_version PROGRAM TYPE iv_program_type.
+    ASSERT sy-subrc = 0.
+  ENDMETHOD.
+
+
+  METHOD deserialize_definition.
+
+    DATA: lv_updated TYPE abap_bool,
+          lv_program TYPE program,
+          lt_public  TYPE seop_source_string,
+          lt_auxsrc  TYPE seop_source_string,
+          lt_source  TYPE seop_source_string.
+
+* public
+    lt_public = mo_scanner->get_public_section_source( ).
+    IF lt_public IS NOT INITIAL.
+      lv_program = cl_oo_classname_service=>get_pubsec_name( ms_key-clsname ).
+      lv_updated = update_report( iv_program = lv_program
+                                  it_source  = lt_public ).
+      IF lv_updated = abap_true.
+        update_meta( iv_name     = ms_key-clsname
+                     iv_exposure = seoc_exposure_public
+                     it_source   = lt_public ).
+      ENDIF.
+    ENDIF.
+
+* protected
+    lt_source = mo_scanner->get_protected_section_source( ).
+    IF lt_source IS NOT INITIAL.
+      lv_program = cl_oo_classname_service=>get_prosec_name( ms_key-clsname ).
+      lv_updated = update_report( iv_program = lv_program
+                                  it_source  = lt_source ).
+      IF lv_updated = abap_true.
+        lt_auxsrc = lt_public.
+        APPEND LINES OF lt_source TO lt_auxsrc.
+
+        update_meta( iv_name     = ms_key-clsname
+                     iv_exposure = seoc_exposure_protected
+                     it_source   = lt_auxsrc ).
+      ENDIF.
+    ENDIF.
+
+* private
+    lt_source = mo_scanner->get_private_section_source( ).
+    IF lt_source IS NOT INITIAL.
+      lv_program = cl_oo_classname_service=>get_prisec_name( ms_key-clsname ).
+      lv_updated = update_report( iv_program = lv_program
+                                  it_source  = lt_source ).
+      IF lv_updated = abap_true.
+        lt_auxsrc = lt_public.
+        APPEND LINES OF lt_source TO lt_auxsrc.
+
+        update_meta( iv_name     = ms_key-clsname
+                     iv_exposure = seoc_exposure_private
+                     it_source   = lt_auxsrc ).
+      ENDIF.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD deserialize_full_class_include.
+
+    DATA: lt_methods TYPE cl_oo_source_scanner_class=>type_method_implementations.
+    CONSTANTS: lc_class_source_extension TYPE sychar02 VALUE 'CS',
+               lc_include_program_type   TYPE sychar01 VALUE 'I',
+               lc_active_version         TYPE r3state VALUE 'A'.
+
+
+    create_report( iv_program      = cl_oo_classname_service=>get_cs_name( ms_key-clsname )
+                   it_source       = it_source
+                   iv_extension    = lc_class_source_extension
+                   iv_program_type = lc_include_program_type
+                   iv_version      = lc_active_version ).
+
+    lt_methods = mo_scanner->get_method_implementations( ).
+
+    " Assuming that all methods that were scanned are implemented
+    update_cs_number_of_methods( iv_classname              = ms_key-clsname
+                                 iv_number_of_impl_methods = lines( lt_methods ) ).
+
+  ENDMETHOD.
+
+
+  METHOD deserialize_implementation.
+
+    DATA: lv_program TYPE program,
+          lt_methods TYPE cl_oo_source_scanner_class=>type_method_implementations,
+          lv_method  LIKE LINE OF lt_methods,
+          lt_source  TYPE seop_source_string.
+
+* methods
+    lt_methods = mo_scanner->get_method_implementations( ).
+
+    LOOP AT lt_methods INTO lv_method.
+      TRY.
+          lt_source = mo_scanner->get_method_impl_source( lv_method ).
+        CATCH cx_oo_clif_component.
+          zcx_abapgit_exception=>raise( 'error from GET_METHOD_IMPL_SOURCE' ).
+      ENDTRY.
+      lv_program = determine_method_include(
+        iv_name   = ms_key-clsname
+        iv_method = lv_method ).
+
+      update_report(
+        iv_program = lv_program
+        it_source  = lt_source ).
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD determine_method_include.
+
+    DATA: ls_mtdkey TYPE seocpdkey.
+
+
+    ls_mtdkey-clsname = iv_name.
+    ls_mtdkey-cpdname = iv_method.
+
+    cl_oo_classname_service=>get_method_include(
+      EXPORTING
+        mtdkey              = ls_mtdkey
+      RECEIVING
+        result              = rv_program
+      EXCEPTIONS
+        method_not_existing = 1 ).
+    IF sy-subrc = 0.
+      RETURN.
+    ENDIF.
+
+    CALL FUNCTION 'SEO_METHOD_GENERATE_INCLUDE'
+      EXPORTING
+        suppress_mtdkey_check          = abap_true
+        mtdkey                         = ls_mtdkey
+      EXCEPTIONS
+        not_existing                   = 1
+        model_only                     = 2
+        include_existing               = 3
+        method_imp_not_generated       = 4
+        method_imp_not_initialised     = 5
+        _internal_class_not_existing   = 6
+        _internal_method_overflow      = 7
+        cancelled                      = 8
+        method_is_abstract_implemented = 9
+        method_is_final_implemented    = 10
+        internal_error_insert_report   = 11
+        OTHERS                         = 12.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from SEO_METHOD_GENERATE_INCLUDE. Subrc = { sy-subrc }| ).
+    ENDIF.
+
+    rv_program = cl_oo_classname_service=>get_method_include( ls_mtdkey ).
+
+  ENDMETHOD.
+
+
+  METHOD generate_classpool.
+
+    DATA: ls_clskey TYPE seoclskey.
+
+    ls_clskey-clsname = iv_name.
+
+    CALL FUNCTION 'SEO_CLASS_GENERATE_CLASSPOOL'
+      EXPORTING
+        clskey                        = ls_clskey
+        suppress_corr                 = abap_true
+      EXCEPTIONS
+        not_existing                  = 1
+        model_only                    = 2
+        class_pool_not_generated      = 3
+        class_stment_not_generated    = 4
+        locals_not_generated          = 5
+        macros_not_generated          = 6
+        public_sec_not_generated      = 7
+        protected_sec_not_generated   = 8
+        private_sec_not_generated     = 9
+        typeref_not_generated         = 10
+        class_pool_not_initialised    = 11
+        class_stment_not_initialised  = 12
+        locals_not_initialised        = 13
+        macros_not_initialised        = 14
+        public_sec_not_initialised    = 15
+        protected_sec_not_initialised = 16
+        private_sec_not_initialised   = 17
+        typeref_not_initialised       = 18
+        _internal_class_overflow      = 19
+        OTHERS                        = 20.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from SEO_CLASS_GENERATE_CLASSPOOL. Subrc = { sy-subrc }| ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD init_scanner.
+
+    TRY.
+        ro_scanner = cl_oo_source_scanner_class=>create_class_scanner(
+          clif_name = iv_name
+          source    = it_source ).
+        ro_scanner->scan( ).
+      CATCH cx_clif_scan_error.
+        zcx_abapgit_exception=>raise( 'error initializing CLAS scanner' ).
+    ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD update_cs_number_of_methods.
+
+    " Indirect access to keep downward compatibility
+    DATA lr_cache_entry TYPE REF TO data.
+
+    FIELD-SYMBOLS: <lg_cache_entry> TYPE any,
+                   <lg_field>       TYPE any.
+
+
+    TRY.
+        CREATE DATA lr_cache_entry TYPE ('SEO_CS_CACHE').
+      CATCH cx_sy_create_data_error.
+* does not exist in some older systems
+        RETURN.
+    ENDTRY.
+
+    ASSIGN lr_cache_entry->* TO <lg_cache_entry>.
+    ASSERT sy-subrc = 0.
+
+    ASSIGN COMPONENT 'CLSNAME' OF STRUCTURE <lg_cache_entry>
+           TO <lg_field>.
+    ASSERT sy-subrc = 0.
+    <lg_field> = iv_classname.
+
+    ASSIGN COMPONENT 'NO_OF_METHOD_IMPLS' OF STRUCTURE <lg_cache_entry>
+           TO <lg_field>.
+    ASSERT sy-subrc = 0.
+    <lg_field> = iv_number_of_impl_methods.
+
+    MODIFY ('SEO_CS_CACHE') FROM <lg_cache_entry>.
+
+  ENDMETHOD.
+
+
+  METHOD update_meta.
+
+    DATA: lo_update     TYPE REF TO cl_oo_class_section_source,
+          ls_clskey     TYPE seoclskey,
+          lv_scan_error TYPE abap_bool.
+
+
+    ls_clskey-clsname = iv_name.
+
+    TRY.
+        CREATE OBJECT lo_update TYPE ('CL_OO_CLASS_SECTION_SOURCE')
+          EXPORTING
+            clskey                        = ls_clskey
+            exposure                      = iv_exposure
+            state                         = 'A'
+            source                        = it_source
+            suppress_constrctr_generation = abap_true
+          EXCEPTIONS
+            class_not_existing            = 1
+            read_source_error             = 2
+            OTHERS                        = 3 ##SUBRC_OK.
+      CATCH cx_sy_dyn_call_param_not_found.
+* downport to 702, see https://github.com/larshp/abapGit/issues/933
+* this will READ REPORT instead of using it_source, which should be okay
+        CREATE OBJECT lo_update TYPE cl_oo_class_section_source
+          EXPORTING
+            clskey             = ls_clskey
+            exposure           = iv_exposure
+            state              = 'A'
+          EXCEPTIONS
+            class_not_existing = 1
+            read_source_error  = 2
+            OTHERS             = 3.
+    ENDTRY.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error instantiating CL_OO_CLASS_SECTION_SOURCE. Subrc = { sy-subrc }| ).
+    ENDIF.
+
+    lo_update->set_dark_mode( abap_true ).
+    TRY.
+        CALL METHOD lo_update->('SET_AMDP_SUPPORT')
+          EXPORTING
+            enabled = abap_true.
+      CATCH cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+* AMDP not supported in this system, ignore error
+    ENDTRY.
+    lo_update->scan_section_source(
+      RECEIVING
+        scan_error             = lv_scan_error
+      EXCEPTIONS
+        scan_abap_source_error = 1
+        OTHERS                 = 2 ).
+    IF sy-subrc <> 0 OR lv_scan_error = abap_true.
+      zcx_abapgit_exception=>raise( |CLAS, error while scanning source. Subrc = { sy-subrc }| ).
+    ENDIF.
+
+* this will update the SEO* database tables
+    lo_update->revert_scan_result( ).
+
+    IF iv_exposure = seoc_exposure_public.
+      generate_classpool( iv_name ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD update_report.
+
+    DATA: lt_old TYPE string_table.
+
+    READ REPORT iv_program INTO lt_old.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Fatal error. Include { iv_program } should have been created previously!| ).
+    ENDIF.
+
+    IF lt_old <> it_source.
+      INSERT REPORT iv_program FROM it_source.
+      ASSERT sy-subrc = 0.
+      rv_updated = abap_true.
+    ELSE.
+      rv_updated = abap_false.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD update_source_index.
+
+    CONSTANTS:
+      lc_version_active   TYPE r3state VALUE 'A',           "#EC NOTEXT
+      lc_version_inactive TYPE r3state VALUE 'I'.           "#EC NOTEXT
+
+    "    dynamic invocation, IF_OO_SOURCE_POS_INDEX_HELPER doesn't exist in 702.
+    DATA lo_index_helper TYPE REF TO object.
+
+    TRY.
+        CREATE OBJECT lo_index_helper TYPE ('CL_OO_SOURCE_POS_INDEX_HELPER').
+
+        CALL METHOD lo_index_helper->('IF_OO_SOURCE_POS_INDEX_HELPER~CREATE_INDEX_WITH_SCANNER')
+          EXPORTING
+            class_name = ms_key-clsname
+            version    = lc_version_active
+            scanner    = mo_scanner.
+
+        CALL METHOD lo_index_helper->('IF_OO_SOURCE_POS_INDEX_HELPER~DELETE_INDEX')
+          EXPORTING
+            class_name = ms_key-clsname
+            version    = lc_version_inactive.
+
+      CATCH cx_root.
+        " it's probably okay to no update the index
+        RETURN.
+    ENDTRY.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/objects/zcl_abapgit_oo_deserializer.clas.xml
+++ b/src/objects/zcl_abapgit_oo_deserializer.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_OO_DESERIALIZER</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>OO Deserializer</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/objects/zcl_abapgit_oo_interface.clas.abap
+++ b/src/objects/zcl_abapgit_oo_interface.clas.abap
@@ -5,14 +5,25 @@ CLASS zcl_abapgit_oo_interface DEFINITION PUBLIC
       zif_abapgit_oo_object_fnc~create REDEFINITION,
       zif_abapgit_oo_object_fnc~get_includes REDEFINITION,
       zif_abapgit_oo_object_fnc~get_interface_properties REDEFINITION,
-      zif_abapgit_oo_object_fnc~delete REDEFINITION.
+      zif_abapgit_oo_object_fnc~delete REDEFINITION,
+      zif_abapgit_oo_object_fnc~deserialize_source REDEFINITION.
   PROTECTED SECTION.
   PRIVATE SECTION.
+    METHODS deserialize_abap_source_old
+      IMPORTING is_clskey TYPE seoclskey
+                it_source TYPE zif_abapgit_definitions=>ty_string_tt
+      RAISING   zcx_abapgit_exception.
+
+    METHODS deserialize_abap_source_new
+      IMPORTING is_clskey TYPE seoclskey
+                it_source TYPE zif_abapgit_definitions=>ty_string_tt
+      RAISING   zcx_abapgit_exception
+                cx_sy_dyn_call_error.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OO_INTERFACE IMPLEMENTATION.
+CLASS zcl_abapgit_oo_interface IMPLEMENTATION.
 
 
   METHOD zif_abapgit_oo_object_fnc~create.
@@ -90,4 +101,119 @@ CLASS ZCL_ABAPGIT_OO_INTERFACE IMPLEMENTATION.
       zcx_abapgit_exception=>raise( |Error from seo_clif_get. Subrc = { sy-subrc }| ).
     ENDIF.
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_oo_object_fnc~deserialize_source.
+
+    DATA: lv_done TYPE abap_bool.
+
+
+    lv_done = zcl_abapgit_exit=>get_instance( )->custom_deserialize_abap_clif(
+                                              iv_object_type = 'INTF'
+                                              is_key         = is_key
+                                              it_source      = it_source ).
+    IF lv_done = abap_true.
+      RETURN.
+    ENDIF.
+
+    TRY.
+        deserialize_abap_source_new(
+          is_clskey = is_key
+          it_source = it_source ).
+      CATCH cx_sy_dyn_call_error.
+        deserialize_abap_source_old(
+          is_clskey = is_key
+          it_source = it_source ).
+    ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD deserialize_abap_source_new.
+    DATA: lo_factory  TYPE REF TO object,
+          lo_source   TYPE REF TO object,
+          lo_settings TYPE REF TO object,
+          lr_settings TYPE REF TO data.
+
+    FIELD-SYMBOLS <lg_settings> TYPE any.
+
+
+    "Buffer needs to be refreshed,
+    "otherwise standard SAP CLIF_SOURCE reorder methods alphabetically
+    CALL FUNCTION 'SEO_BUFFER_INIT'.
+    CALL FUNCTION 'SEO_BUFFER_REFRESH'
+      EXPORTING
+        cifkey  = is_clskey
+        version = seoc_version_inactive.
+
+    CALL METHOD ('CL_OO_FACTORY')=>('CREATE_INSTANCE')
+      RECEIVING
+        result = lo_factory.
+
+    "Enable modification mode to avoid exception CX_OO_ACCESS_PERMISSON when
+    "dealing with objects in foreign namespaces (namespace role = C)
+    CALL METHOD lo_factory->('CREATE_SETTINGS')
+      EXPORTING
+        modification_mode_enabled = abap_true
+      RECEIVING
+        result                    = lo_settings.
+
+    CREATE DATA lr_settings TYPE REF TO ('IF_OO_CLIF_SOURCE_SETTINGS').
+    ASSIGN lr_settings->* TO <lg_settings>.
+
+    <lg_settings> ?= lo_settings.
+
+    CALL METHOD lo_factory->('CREATE_CLIF_SOURCE')
+      EXPORTING
+        clif_name = is_clskey-clsname
+        settings  = <lg_settings>
+      RECEIVING
+        result    = lo_source.
+
+    TRY.
+        CALL METHOD lo_source->('IF_OO_CLIF_SOURCE~LOCK').
+      CATCH cx_oo_access_permission.
+        zcx_abapgit_exception=>raise( 'source_new, access permission exception' ).
+    ENDTRY.
+
+    CALL METHOD lo_source->('IF_OO_CLIF_SOURCE~SET_SOURCE')
+      EXPORTING
+        source = it_source.
+
+    CALL METHOD lo_source->('IF_OO_CLIF_SOURCE~SAVE').
+
+    CALL METHOD lo_source->('IF_OO_CLIF_SOURCE~UNLOCK').
+
+  ENDMETHOD.
+
+
+  METHOD deserialize_abap_source_old.
+    "for backwards compatability down to 702
+
+    DATA: lo_source TYPE REF TO cl_oo_source.
+
+    CREATE OBJECT lo_source
+      EXPORTING
+        clskey             = is_clskey
+      EXCEPTIONS
+        class_not_existing = 1
+        OTHERS             = 2.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from CL_OO_SOURCE. Subrc = { sy-subrc }| ).
+    ENDIF.
+
+    TRY.
+        lo_source->access_permission( seok_access_modify ).
+        lo_source->set_source( it_source ).
+        lo_source->save( ).
+        lo_source->access_permission( seok_access_free ).
+      CATCH cx_oo_access_permission.
+        zcx_abapgit_exception=>raise( 'permission error' ).
+      CATCH cx_oo_source_save_failure.
+        zcx_abapgit_exception=>raise( 'save failure' ).
+    ENDTRY.
+
+  ENDMETHOD.
+
+
 ENDCLASS.

--- a/src/zcl_abapgit_exit.clas.abap
+++ b/src/zcl_abapgit_exit.clas.abap
@@ -155,7 +155,6 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
   METHOD zif_abapgit_exit~custom_deserialize_abap_clif.
     TRY.
         rv_done = gi_exit->custom_deserialize_abap_clif(
-          EXPORTING
             iv_object_type = iv_object_type
             is_key         = is_key
             it_source      = it_source ).

--- a/src/zcl_abapgit_exit.clas.abap
+++ b/src/zcl_abapgit_exit.clas.abap
@@ -150,4 +150,18 @@ CLASS zcl_abapgit_exit IMPLEMENTATION.
       CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
     ENDTRY.
   ENDMETHOD.
+
+
+  METHOD zif_abapgit_exit~custom_deserialize_abap_clif.
+    TRY.
+        rv_done = gi_exit->custom_deserialize_abap_clif(
+          EXPORTING
+            iv_object_type = iv_object_type
+            is_key         = is_key
+            it_source      = it_source ).
+      CATCH cx_sy_ref_is_initial cx_sy_dyn_call_illegal_method ##NO_HANDLER.
+    ENDTRY.
+  ENDMETHOD.
+
+
 ENDCLASS.

--- a/src/zif_abapgit_exit.intf.abap
+++ b/src/zif_abapgit_exit.intf.abap
@@ -53,4 +53,13 @@ INTERFACE zif_abapgit_exit
       VALUE(rt_source) TYPE zif_abapgit_definitions=>ty_string_tt
     RAISING
       zcx_abapgit_exception.
+  METHODS custom_deserialize_abap_clif
+    IMPORTING
+      iv_object_type TYPE tadir-object
+      is_key         TYPE seoclskey
+      it_source      TYPE zif_abapgit_definitions=>ty_string_tt
+    RETURNING
+      VALUE(rv_done) TYPE abap_bool
+    RAISING
+      zcx_abapgit_exception.
 ENDINTERFACE.


### PR DESCRIPTION
Solves the issue #2671

1) Non-existing parameter SUPPRESS_DIALOG in old version of SEO_CLASS_CREATE_COMPLETE
-> Catch exception cx_sy_dyn_call_param_not_found -> call again without SUPPRESS_DIALOG

2) Short dump INSERT_REPORT_NO_EXTTYPE because extension type CS is not supported in old 7.02 kernel.
-> New user exit method CUSTOM_DESERIALIZE_ABAP_CLIF 
-> I also reorganized a little bit the objects
-> Documentation of user exits updated

I also reorganized a little bit the objects:
- methods for deserializing classes are moved from ZCL_ABAPGIT_OO_CLASS to ZCL_ABAPGIT_OO_DESERIALIZER (new class, to complete the existing ZCL_ABAPGIT_OO_SERIALIZER)
- methods for deserializing interfaces are moved down from parent ZCL_ABAPGIT_OO_BASE to subclass ZCL_ABAPGIT_OO_INTERFACE - it was not required but it brings clarity
- code for activation of class is moved down from ZCL_ABAPGIT_OO_CLASS to ZCL_ABAPGIT_OBJECT_CLAS - it was not required but it brings clarity
