### PR TITLE
Get all branches, including pull request refs

### DIFF
--- a/docs/collections/_development/api.md
+++ b/docs/collections/_development/api.md
@@ -16,8 +16,6 @@ DATA(lo_repo) = zcl_abapgit_repo_srv=>get_instance( )->new_online(
   iv_package     = lv_package ).
 ```
 
-todo, how to list branches?
-
 ### Create Offline
 
 ```abap
@@ -80,10 +78,10 @@ todo, should this be refactored to the repo object instead?
 ## Branches
 
 ### List
-`zcl_abapgit_factory=>get_branch_overview( mo_repo )->get_branches( ).`
+`zcl_abapgit_git_transport=>branches( io_repo->get_url( ) ).`
 
 ### Switching
-`repo->set_branch_name( )`
+`repo->set_branch_name( lv_name )`
 
 ### Creating
 `repo->create_branch( )`

--- a/src/git/zcl_abapgit_git_branch_list.clas.abap
+++ b/src/git/zcl_abapgit_git_branch_list.clas.abap
@@ -19,12 +19,17 @@ CLASS zcl_abapgit_git_branch_list DEFINITION
     METHODS get_head_symref
       RETURNING
         VALUE(rv_head_symref) TYPE string .
+    METHODS get_all
+      RETURNING
+        VALUE(rt_branches) TYPE zif_abapgit_definitions=>ty_git_branch_list_tt
+      RAISING
+        zcx_abapgit_exception .
     METHODS get_branches_only
       RETURNING
         VALUE(rt_branches) TYPE zif_abapgit_definitions=>ty_git_branch_list_tt
       RAISING
         zcx_abapgit_exception .
-    METHODS get_tags_only           " For potential future use
+    METHODS get_tags_only             " For potential future use
       RETURNING
         VALUE(rt_tags) TYPE zif_abapgit_definitions=>ty_git_branch_list_tt
       RAISING
@@ -148,6 +153,13 @@ CLASS ZCL_ABAPGIT_GIT_BRANCH_LIST IMPLEMENTATION.
       ENDIF.
 
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD get_all.
+
+    rt_branches =  mt_branches.
 
   ENDMETHOD.
 

--- a/src/git/zcl_abapgit_git_branch_list.clas.abap
+++ b/src/git/zcl_abapgit_git_branch_list.clas.abap
@@ -24,7 +24,7 @@ CLASS zcl_abapgit_git_branch_list DEFINITION
         VALUE(rt_branches) TYPE zif_abapgit_definitions=>ty_git_branch_list_tt
       RAISING
         zcx_abapgit_exception .
-    METHODS get_tags_only         " For potential future use
+    METHODS get_tags_only           " For potential future use
       RETURNING
         VALUE(rt_tags) TYPE zif_abapgit_definitions=>ty_git_branch_list_tt
       RAISING
@@ -82,11 +82,6 @@ CLASS zcl_abapgit_git_branch_list DEFINITION
         !iv_data              TYPE string
       RETURNING
         VALUE(rv_head_symref) TYPE string .
-    CLASS-METHODS is_ignored
-      IMPORTING
-        !iv_branch_name  TYPE clike
-      RETURNING
-        VALUE(rv_ignore) TYPE abap_bool .
 ENDCLASS.
 
 
@@ -104,10 +99,14 @@ CLASS ZCL_ABAPGIT_GIT_BRANCH_LIST IMPLEMENTATION.
 
 
   METHOD constructor.
+
     parse_branch_list(
-      EXPORTING iv_data        = iv_data
-      IMPORTING et_list        = me->mt_branches
-                ev_head_symref = me->mv_head_symref ).
+      EXPORTING
+        iv_data        = iv_data
+      IMPORTING
+        et_list        = me->mt_branches
+        ev_head_symref = me->mv_head_symref ).
+
   ENDMETHOD.
 
 
@@ -185,8 +184,8 @@ CLASS ZCL_ABAPGIT_GIT_BRANCH_LIST IMPLEMENTATION.
     FIELD-SYMBOLS <ls_branch> LIKE LINE OF mt_branches.
 
     LOOP AT mt_branches ASSIGNING <ls_branch>
-                        WHERE type = zif_abapgit_definitions=>c_git_branch_type-lightweight_tag
-                           OR type = zif_abapgit_definitions=>c_git_branch_type-annotated_tag.
+        WHERE type = zif_abapgit_definitions=>c_git_branch_type-lightweight_tag
+        OR type = zif_abapgit_definitions=>c_git_branch_type-annotated_tag.
       APPEND <ls_branch> TO rt_tags.
     ENDLOOP.
 
@@ -203,10 +202,8 @@ CLASS ZCL_ABAPGIT_GIT_BRANCH_LIST IMPLEMENTATION.
 
     IF iv_branch_name CP 'refs/heads/*' OR iv_branch_name = zif_abapgit_definitions=>c_head_name.
       rv_type = zif_abapgit_definitions=>c_git_branch_type-branch.
-      RETURN.
-    ENDIF.
 
-    IF iv_branch_name CP 'refs/tags/*'.
+    ELSEIF iv_branch_name CP 'refs/tags/*'.
 
       lv_annotated_tag_with_suffix = iv_branch_name && '^{}'.
 
@@ -218,22 +215,6 @@ CLASS ZCL_ABAPGIT_GIT_BRANCH_LIST IMPLEMENTATION.
         rv_type = zif_abapgit_definitions=>c_git_branch_type-lightweight_tag.
       ENDIF.
 
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD is_ignored.
-
-    IF iv_branch_name = 'refs/heads/gh-pages'. " Github pages
-      rv_ignore = abap_true.
-    ENDIF.
-
-    IF iv_branch_name CP 'refs/pull/*'
-        OR iv_branch_name CP 'refs/merge-requests/*'
-        OR iv_branch_name CP 'refs/keep-around/*'
-        OR iv_branch_name CP 'refs/tmp/*'.
-      rv_ignore = abap_true.
     ENDIF.
 
   ENDMETHOD.
@@ -283,7 +264,6 @@ CLASS ZCL_ABAPGIT_GIT_BRANCH_LIST IMPLEMENTATION.
         CONTINUE.
       ENDIF.
 
-      CHECK is_ignored( lv_name ) = abap_false.
       ASSERT lv_name IS NOT INITIAL.
 
       APPEND INITIAL LINE TO et_list ASSIGNING <ls_branch>.
@@ -294,7 +274,7 @@ CLASS ZCL_ABAPGIT_GIT_BRANCH_LIST IMPLEMENTATION.
                                            it_result            = lt_result
                                            iv_current_row_index = lv_current_row_index ).
       IF <ls_branch>-name = zif_abapgit_definitions=>c_head_name OR <ls_branch>-name = ev_head_symref.
-        <ls_branch>-is_head    = abap_true.
+        <ls_branch>-is_head = abap_true.
       ENDIF.
     ENDLOOP.
 

--- a/src/git/zcl_abapgit_git_branch_list.clas.testclasses.abap
+++ b/src/git/zcl_abapgit_git_branch_list.clas.testclasses.abap
@@ -32,9 +32,9 @@ CLASS ltcl_parse IMPLEMENTATION.
 
     zcl_abapgit_git_branch_list=>parse_branch_list(
       EXPORTING
-        iv_data = lv_data
+        iv_data   = lv_data
       IMPORTING
-        et_list = lt_list ).
+        et_list   = lt_list ).
 
     cl_abap_unit_assert=>assert_not_initial( lt_list ).
 

--- a/src/git/zcl_abapgit_git_branch_list.clas.testclasses.abap
+++ b/src/git/zcl_abapgit_git_branch_list.clas.testclasses.abap
@@ -32,9 +32,9 @@ CLASS ltcl_parse IMPLEMENTATION.
 
     zcl_abapgit_git_branch_list=>parse_branch_list(
       EXPORTING
-        iv_data   = lv_data
+        iv_data = lv_data
       IMPORTING
-        et_list   = lt_list ).
+        et_list = lt_list ).
 
     cl_abap_unit_assert=>assert_not_initial( lt_list ).
 


### PR DESCRIPTION
* Do not ignore any branches, note that this is(?) safe as `ZCL_ABAPGIT_GIT_BRANCH_LIST->ZCL_ABAPGIT_GIT_BRANCH_LIST()` filters the known branches
* Add new GET_ALL method to list all branches(including pull request refs)

closes #2692 