### PR TITLE
Small refactorings

### DIFF
--- a/src/objects/zcl_abapgit_object_iaxu.clas.abap
+++ b/src/objects/zcl_abapgit_object_iaxu.clas.abap
@@ -84,8 +84,7 @@ CLASS zcl_abapgit_object_iaxu IMPLEMENTATION.
   METHOD zif_abapgit_object~delete.
 
     DATA: lo_xml_api TYPE REF TO cl_w3_api_xml3,
-          ls_name    TYPE iacikeyt,
-          lx_root    TYPE REF TO zcx_abapgit_exception.
+          ls_name    TYPE iacikeyt.
 
 
     ls_name = ms_item-obj_name.
@@ -124,9 +123,7 @@ CLASS zcl_abapgit_object_iaxu IMPLEMENTATION.
 
   METHOD zif_abapgit_object~exists.
 
-    DATA: ls_name  TYPE iacikeyt,
-          lv_subrc TYPE sysubrc,
-          lx_exc   TYPE REF TO zcx_abapgit_exception.
+    DATA: ls_name  TYPE iacikeyt.
 
 
     ls_name = ms_item-obj_name.

--- a/src/objects/zcl_abapgit_object_wdyn.clas.abap
+++ b/src/objects/zcl_abapgit_object_wdyn.clas.abap
@@ -69,7 +69,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_WDYN IMPLEMENTATION.
+CLASS zcl_abapgit_object_wdyn IMPLEMENTATION.
 
 
   METHOD add_fm_exception.
@@ -646,12 +646,16 @@ CLASS ZCL_ABAPGIT_OBJECT_WDYN IMPLEMENTATION.
     ls_key-component_name  = is_controller-definition-component_name.
     ls_key-controller_name = is_controller-definition-controller_name.
 
-    cl_wdy_md_controller=>recover_version(
-      EXPORTING
-        controller_key = ls_key
-        delta          = ls_delta-wdyc
-      CHANGING
-        corrnr         = lv_corrnr ).
+    TRY.
+        cl_wdy_md_controller=>recover_version(
+          EXPORTING
+            controller_key = ls_key
+            delta          = ls_delta-wdyc
+          CHANGING
+            corrnr         = lv_corrnr ).
+      CATCH cx_wdy_md_exception.
+        zcx_abapgit_exception=>raise( 'error recovering version of controller' ).
+    ENDTRY.
 
   ENDMETHOD.
 
@@ -669,12 +673,16 @@ CLASS ZCL_ABAPGIT_OBJECT_WDYN IMPLEMENTATION.
 
     ls_key-component_name = is_definition-definition-component_name.
 
-    cl_wdy_md_component=>recover_version(
-      EXPORTING
-        component_key = ls_key
-        delta         = ls_delta-wdyd
-      CHANGING
-        corrnr        = lv_corrnr ).
+    TRY.
+        cl_wdy_md_component=>recover_version(
+          EXPORTING
+            component_key = ls_key
+            delta         = ls_delta-wdyd
+          CHANGING
+            corrnr        = lv_corrnr ).
+      CATCH cx_wdy_md_exception.
+        zcx_abapgit_exception=>raise( 'error recovering version of component' ).
+    ENDTRY.
 
   ENDMETHOD.
 
@@ -690,12 +698,16 @@ CLASS ZCL_ABAPGIT_OBJECT_WDYN IMPLEMENTATION.
     ls_key-component_name = is_view-definition-component_name.
     ls_key-view_name      = is_view-definition-view_name.
 
-    cl_wdy_md_abstract_view=>recover_version(
-      EXPORTING
-        view_key = ls_key
-        delta    = ls_delta-wdyv
-      CHANGING
-        corrnr   = lv_corrnr ).
+    TRY.
+        cl_wdy_md_abstract_view=>recover_version(
+          EXPORTING
+            view_key = ls_key
+            delta    = ls_delta-wdyv
+          CHANGING
+            corrnr   = lv_corrnr ).
+      CATCH cx_wdy_md_exception.
+        zcx_abapgit_exception=>raise( 'error recovering version of abstract view' ).
+    ENDTRY.
 
   ENDMETHOD.
 


### PR DESCRIPTION
Two separate changes(relatively small, so in one single PR):

- remove unused variables in object IAXU class (fixes #3001)
- surround recover_version calls with try-catch in object WDYN class (fixes #2992)