### PR TITLE
Refactoring: Usage of sy-langu in Object Serializers

### DIFF
--- a/src/objects/zcl_abapgit_object_char.clas.abap
+++ b/src/objects/zcl_abapgit_object_char.clas.abap
@@ -165,7 +165,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CHAR IMPLEMENTATION.
         lo_char->if_cls_attribute~set_obj_values_have_subtypes( ls_char-cls_attribute-objs_w_subtype ).
         lo_char->if_cls_attribute~set_arbtry_val_type( ls_char-cls_attribute-arbtry_val_type ).
 
-        READ TABLE ls_char-cls_attributet INTO ls_description WITH KEY langu = sy-langu.
+        READ TABLE ls_char-cls_attributet INTO ls_description WITH KEY langu = mv_language.
         IF sy-subrc <> 0.
           READ TABLE ls_char-cls_attributet INTO ls_description INDEX 1.
         ENDIF.

--- a/src/objects/zcl_abapgit_object_cus0.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus0.clas.abap
@@ -70,7 +70,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CUS0 IMPLEMENTATION.
         cg_data = ls_img_activity ).
 
     READ TABLE ls_img_activity-texts INTO ls_text
-                                     WITH KEY spras = sy-langu.
+                                     WITH KEY spras = mv_language.
 
     CALL FUNCTION 'S_CUS_IMG_ACTIVITY_SAVE'
       EXPORTING
@@ -88,7 +88,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CUS0 IMPLEMENTATION.
         mode                = 'I'
         global_lock         = abap_true
         devclass            = iv_package
-        master_language     = sy-langu
+        master_language     = mv_language
         suppress_dialog     = abap_true
       EXCEPTIONS
         cancelled           = 1

--- a/src/objects/zcl_abapgit_object_cus1.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus1.clas.abap
@@ -106,7 +106,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CUS1 IMPLEMENTATION.
         mode                = 'I'
         global_lock         = abap_true
         devclass            = iv_package
-        master_language     = sy-langu
+        master_language     = mv_language
         suppress_dialog     = abap_true
       EXCEPTIONS
         cancelled           = 1

--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -857,7 +857,7 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
     "   FORM GROUP_CHANGE
 
     UPDATE tlibt SET areat = iv_short_text
-                 WHERE spras = sy-langu
+                 WHERE spras = mv_language
                  AND   area  = iv_group.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_scp1.clas.abap
+++ b/src/objects/zcl_abapgit_object_scp1.clas.abap
@@ -234,7 +234,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SCP1 IMPLEMENTATION.
 * copy everything to local, the function module changes the values
     ls_scp1 = is_scp1.
 
-    READ TABLE ls_scp1-scprtext INTO ls_text WITH KEY langu = sy-langu. "#EC CI_SUBRC
+    READ TABLE ls_scp1-scprtext INTO ls_text WITH KEY langu = mv_language. "#EC CI_SUBRC
 
     CALL FUNCTION 'SCPR_TEMPL_MN_TEMPLATE_SAVE'
       EXPORTING
@@ -287,7 +287,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SCP1 IMPLEMENTATION.
 * copy everything to local, the function module changes the values
     ls_scp1 = is_scp1.
 
-    READ TABLE ls_scp1-scprtext INTO ls_text WITH KEY langu = sy-langu. "#EC CI_SUBRC
+    READ TABLE ls_scp1-scprtext INTO ls_text WITH KEY langu = mv_language. "#EC CI_SUBRC
 
 * see fm SCPR_PRSET_DB_STORE, only this field and sequence is used
     LOOP AT ls_scp1-subprofs INTO ls_profs.

--- a/src/objects/zcl_abapgit_object_smim.clas.abap
+++ b/src/objects/zcl_abapgit_object_smim.clas.abap
@@ -196,7 +196,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SMIM IMPLEMENTATION.
       li_api->create_folder(
         EXPORTING
           i_url              = lv_url
-          i_language         = sy-langu
+          i_language         = mv_language
           i_dev_package      = iv_package
           i_folder_loio      = ls_skwf_io
         EXCEPTIONS

--- a/src/objects/zcl_abapgit_object_styl.clas.abap
+++ b/src/objects/zcl_abapgit_object_styl.clas.abap
@@ -146,7 +146,7 @@ CLASS ZCL_ABAPGIT_OBJECT_STYL IMPLEMENTATION.
 
     CLEAR ls_bcdata.
     ls_bcdata-fnam     = 'RSSCS-TDSPRAS'.
-    ls_bcdata-fval     = sy-langu.
+    ls_bcdata-fval     = mv_language.
     APPEND ls_bcdata TO lt_bcdata.
 
     CLEAR ls_bcdata.

--- a/src/objects/zcl_abapgit_object_ucsa.clas.abap
+++ b/src/objects/zcl_abapgit_object_ucsa.clas.abap
@@ -187,7 +187,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UCSA IMPLEMENTATION.
         CALL METHOD lo_persistence->('IF_UCON_SA_PERSIST~LOAD')
           EXPORTING
             version  = c_version-active
-            language = sy-langu.
+            language = mv_language.
 
       CATCH cx_root.
         rv_bool = abap_false.
@@ -270,7 +270,7 @@ CLASS ZCL_ABAPGIT_OBJECT_UCSA IMPLEMENTATION.
         CALL METHOD lo_persistence->('IF_UCON_SA_PERSIST~LOAD')
           EXPORTING
             version  = c_version-active
-            language = sy-langu
+            language = mv_language
           IMPORTING
             sa       = <lg_complete_comm_assembly>.
 

--- a/src/objects/zcl_abapgit_object_xinx.clas.abap
+++ b/src/objects/zcl_abapgit_object_xinx.clas.abap
@@ -321,7 +321,7 @@ CLASS zcl_abapgit_object_xinx IMPLEMENTATION.
       EXPORTING
         name          = mv_name
         id            = mv_id
-        langu         = sy-langu
+        langu         = mv_language
       IMPORTING
         dd12v_wa      = ls_extension_index-dd12v
       TABLES


### PR DESCRIPTION
- usage of `sy-langu` replaced with `mv_language` in inheriting classes of  `zcl_abapgit_objects_super`
- part of #2080 
- note: `zcl_abapgit_objects_generic` uses `sy-langu` as well. Could either refactor this in this PR or make a separate one?