### PR TITLE
Add adt link to objects on diff page

### DIFF
--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -92,23 +92,11 @@ CLASS zcl_abapgit_objects_super DEFINITION PUBLIC ABSTRACT.
                   io_adt                         TYPE REF TO object
         RETURNING VALUE(rv_is_adt_jump_possible) TYPE abap_bool
         RAISING   zcx_abapgit_exception.
-    CLASS-METHODS:
-      get_adt_objects_and_names
-        IMPORTING
-          iv_obj_name       TYPE zif_abapgit_definitions=>ty_item-obj_name
-          iv_obj_type       TYPE zif_abapgit_definitions=>ty_item-obj_type
-        EXPORTING
-          eo_adt_uri_mapper TYPE REF TO object
-          eo_adt_objectref  TYPE REF TO object
-          ev_program        TYPE progname
-          ev_include        TYPE progname
-        RAISING
-          zcx_abapgit_exception.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECTS_SUPER IMPLEMENTATION.
+CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
 
   METHOD check_timestamp.
@@ -222,64 +210,6 @@ CLASS ZCL_ABAPGIT_OBJECTS_SUPER IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD get_adt_objects_and_names.
-
-    DATA lv_obj_type       TYPE trobjtype.
-    DATA lv_obj_name       TYPE trobj_name.
-    DATA lo_object         TYPE REF TO cl_wb_object.
-    DATA lo_adt            TYPE REF TO object.
-    FIELD-SYMBOLS <lv_uri> TYPE string.
-
-    lv_obj_name = iv_obj_name.
-    lv_obj_type = iv_obj_type.
-
-    TRY.
-        cl_wb_object=>create_from_transport_key(
-          EXPORTING
-            p_object    = lv_obj_type
-            p_obj_name  = lv_obj_name
-          RECEIVING
-            p_wb_object = lo_object
-          EXCEPTIONS
-            OTHERS      = 1 ).
-        IF sy-subrc <> 0.
-          zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
-        ENDIF.
-
-        CALL METHOD ('CL_ADT_TOOLS_CORE_FACTORY')=>('GET_INSTANCE')
-          RECEIVING
-            result = lo_adt.
-
-        IF is_adt_jump_possible( io_object = lo_object
-                                 io_adt    = lo_adt ) = abap_false.
-          zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
-        ENDIF.
-
-        CALL METHOD lo_adt->('IF_ADT_TOOLS_CORE_FACTORY~GET_URI_MAPPER')
-          RECEIVING
-            result = eo_adt_uri_mapper.
-
-        CALL METHOD eo_adt_uri_mapper->('IF_ADT_URI_MAPPER~MAP_WB_OBJECT_TO_OBJREF')
-          EXPORTING
-            wb_object = lo_object
-          RECEIVING
-            result    = eo_adt_objectref.
-
-        ASSIGN ('EO_ADT_OBJECTREF->REF_DATA-URI') TO <lv_uri>.
-        ASSERT sy-subrc = 0.
-
-        CALL METHOD eo_adt_uri_mapper->('IF_ADT_URI_MAPPER~MAP_OBJREF_TO_INCLUDE')
-          EXPORTING
-            uri     = <lv_uri>
-          IMPORTING
-            program = ev_program
-            include = ev_include.
-
-      CATCH cx_root.
-        zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
-    ENDTRY.
-
-  ENDMETHOD.
 
 
   METHOD get_metadata.
@@ -372,61 +302,24 @@ CLASS ZCL_ABAPGIT_OBJECTS_SUPER IMPLEMENTATION.
   METHOD jump_adt.
 
     DATA: lv_adt_link       TYPE string.
-    DATA: lo_adt_uri_mapper TYPE REF TO object ##needed.
-    DATA: lo_adt_objref     TYPE REF TO object ##needed.
-    DATA: lo_adt_sub_objref TYPE REF TO object ##needed.
-    DATA: lv_program        TYPE progname.
-    DATA: lv_include        TYPE progname.
-    FIELD-SYMBOLS: <lv_uri> TYPE string.
-
-
-    get_adt_objects_and_names(
-      EXPORTING
-        iv_obj_name       = iv_obj_name
-        iv_obj_type       = iv_obj_type
-      IMPORTING
-        eo_adt_uri_mapper = lo_adt_uri_mapper
-        eo_adt_objectref  = lo_adt_objref
-        ev_program        = lv_program
-        ev_include        = lv_include ).
 
     TRY.
-        IF iv_sub_obj_name IS NOT INITIAL.
+        lv_adt_link = zcl_abapgit_adt_link=>generate(
+          iv_obj_name = iv_obj_name
+          iv_obj_type = iv_obj_type
+          iv_sub_obj_name = iv_sub_obj_name
+          iv_sub_obj_type = iv_sub_obj_type
+          iv_line_number = iv_line_number ).
 
-          IF ( lv_program <> iv_obj_name AND lv_include IS INITIAL ) OR
-             ( lv_program = lv_include AND iv_sub_obj_name IS NOT INITIAL ).
-            lv_include = iv_sub_obj_name.
-          ENDIF.
-
-          CALL METHOD lo_adt_uri_mapper->('IF_ADT_URI_MAPPER~MAP_INCLUDE_TO_OBJREF')
-            EXPORTING
-              program     = lv_program
-              include     = lv_include
-              line        = iv_line_number
-              line_offset = 0
-              end_line    = iv_line_number
-              end_offset  = 1
-            RECEIVING
-              result      = lo_adt_sub_objref.
-          IF lo_adt_sub_objref IS NOT INITIAL.
-            lo_adt_objref = lo_adt_sub_objref.
-          ENDIF.
-
-        ENDIF.
-
-        ASSIGN ('LO_ADT_OBJREF->REF_DATA-URI') TO <lv_uri>.
-        ASSERT sy-subrc = 0.
-
-        CONCATENATE 'adt://' sy-sysid <lv_uri> INTO lv_adt_link.
-
-        cl_gui_frontend_services=>execute( EXPORTING  document = lv_adt_link
-                                           EXCEPTIONS OTHERS   = 1 ).
+        cl_gui_frontend_services=>execute(
+          EXPORTING  document = lv_adt_link
+          EXCEPTIONS OTHERS   = 1 ).
 
         IF sy-subrc <> 0.
           zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
         ENDIF.
 
-      CATCH cx_root.
+      CATCH cx_root INTO DATA(cx).
         zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
     ENDTRY.
 

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -211,7 +211,6 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
 
 
-
   METHOD get_metadata.
 
     DATA: lv_class TYPE string.

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -36,7 +36,7 @@ CLASS zcl_abapgit_objects_super DEFINITION PUBLIC ABSTRACT.
         VALUE(rs_metadata) TYPE zif_abapgit_definitions=>ty_metadata .
     METHODS corr_insert
       IMPORTING
-        !iv_package TYPE devclass
+        !iv_package      TYPE devclass
         !iv_object_class TYPE any OPTIONAL
       RAISING
         zcx_abapgit_exception .
@@ -301,9 +301,11 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
   METHOD jump_adt.
 
-    DATA: lv_adt_link       TYPE string.
+    DATA: lv_adt_link   TYPE string,
+          lx_error TYPE REF TO cx_root.
 
     TRY.
+
         lv_adt_link = zcl_abapgit_adt_link=>generate(
           iv_obj_name = iv_obj_name
           iv_obj_type = iv_obj_type
@@ -316,11 +318,11 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
           EXCEPTIONS OTHERS   = 1 ).
 
         IF sy-subrc <> 0.
-          zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
+          zcx_abapgit_exception=>raise( |ADT Jump Error - failed to open link { lv_adt_link }. Subrc={ sy-subrc }| ).
         ENDIF.
 
-      CATCH cx_root INTO DATA(cx).
-        zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
+      CATCH cx_root INTO lx_error.
+        zcx_abapgit_exception=>raise( iv_text = 'ADT Jump Error' ix_previous = lx_error ).
     ENDTRY.
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -86,12 +86,7 @@ CLASS zcl_abapgit_objects_super DEFINITION PUBLIC ABSTRACT.
         zcx_abapgit_exception .
   PRIVATE SECTION.
 
-    CLASS-METHODS:
-      is_adt_jump_possible
-        IMPORTING io_object                      TYPE REF TO cl_wb_object
-                  io_adt                         TYPE REF TO object
-        RETURNING VALUE(rv_is_adt_jump_possible) TYPE abap_bool
-        RAISING   zcx_abapgit_exception.
+
 ENDCLASS.
 
 
@@ -251,50 +246,6 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
     ENDIF.
 
     rv_active = boolc( ms_item-inactive = abap_false ).
-  ENDMETHOD.
-
-
-  METHOD is_adt_jump_possible.
-
-    DATA: lo_wb_request         TYPE REF TO cl_wb_request,
-          lo_adt_uri_mapper_vit TYPE REF TO object,
-          lv_vit_wb_request     TYPE abap_bool.
-
-    cl_wb_request=>create_from_object_ref(
-      EXPORTING
-        p_wb_object       = io_object
-      RECEIVING
-        p_wb_request      = lo_wb_request
-      EXCEPTIONS
-        illegal_operation = 1
-        cancelled         = 2
-        OTHERS            = 3 ).
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
-    ENDIF.
-
-    TRY.
-        CALL METHOD io_adt->('IF_ADT_TOOLS_CORE_FACTORY~GET_URI_MAPPER_VIT')
-          RECEIVING
-            result = lo_adt_uri_mapper_vit.
-
-        CALL METHOD lo_adt_uri_mapper_vit->('IF_ADT_URI_MAPPER_VIT~IS_VIT_WB_REQUEST')
-          EXPORTING
-            wb_request = lo_wb_request
-          RECEIVING
-            result     = lv_vit_wb_request.
-
-        IF lv_vit_wb_request = abap_true.
-          rv_is_adt_jump_possible = abap_false.
-        ELSE.
-          rv_is_adt_jump_possible = abap_true.
-        ENDIF.
-
-      CATCH cx_root.
-        zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
-    ENDTRY.
-
   ENDMETHOD.
 
 

--- a/src/ui/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_diff.clas.abap
@@ -12,6 +12,8 @@ CLASS zcl_abapgit_gui_page_diff DEFINITION
       BEGIN OF ty_file_diff,
         path       TYPE string,
         filename   TYPE string,
+        obj_type   TYPE string,
+        obj_name   TYPE string,
         lstate     TYPE char1,
         rstate     TYPE char1,
         fstate     TYPE char1, " FILE state - Abstraction for shorter ifs
@@ -172,7 +174,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
 
 
   METHOD add_filter_sub_menu.
@@ -321,10 +323,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
   METHOD append_diff.
 
     DATA:
-      lv_offs    TYPE i,
+      lv_offs      TYPE i,
       lv_is_binary TYPE abap_bool,
-      ls_r_dummy LIKE LINE OF it_remote ##NEEDED,
-      ls_l_dummy LIKE LINE OF it_local  ##NEEDED.
+      ls_r_dummy   LIKE LINE OF it_remote ##NEEDED,
+      ls_l_dummy   LIKE LINE OF it_local  ##NEEDED.
 
     FIELD-SYMBOLS: <ls_remote> LIKE LINE OF it_remote,
                    <ls_local>  LIKE LINE OF it_local,
@@ -352,6 +354,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
     APPEND INITIAL LINE TO mt_diff_files ASSIGNING <ls_diff>.
     <ls_diff>-path     = is_status-path.
     <ls_diff>-filename = is_status-filename.
+    <ls_diff>-obj_type = is_status-obj_type.
+    <ls_diff>-obj_name = is_status-obj_name.
     <ls_diff>-lstate   = is_status-lstate.
     <ls_diff>-rstate   = is_status-rstate.
 
@@ -736,7 +740,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
 
   METHOD render_diff_head.
 
-    DATA: ls_stats TYPE zif_abapgit_definitions=>ty_count.
+    DATA: ls_stats    TYPE zif_abapgit_definitions=>ty_count,
+          lv_adt_link TYPE string.
 
     CREATE OBJECT ro_html.
 
@@ -754,7 +759,22 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
       ro_html->add( |<span class="diff_banner diff_upd">~ { ls_stats-update }</span>| ).
     ENDIF.
 
-    ro_html->add( |<span class="diff_name">{ is_diff-path }{ is_diff-filename }</span>| ). "#EC NOTEXT
+    " no links for nonexistent or deleted objects
+    IF is_diff-lstate IS NOT INITIAL AND is_diff-lstate <> 'D'.
+      lv_adt_link = zcl_abapgit_html=>a(
+        iv_txt = |{ is_diff-path }{ is_diff-filename }|
+        iv_typ = zif_abapgit_html=>c_action_type-sapevent
+        iv_act = |jump?TYPE={ is_diff-obj_type }&NAME={ is_diff-obj_name }| ).
+    ENDIF.
+
+    IF lv_adt_link IS NOT INITIAL.
+      ro_html->add(
+        |<span class="diff_name">{ lv_adt_link }</span>| ). "#EC NOTEXT
+    ELSE.
+      ro_html->add(
+        |<span class="diff_name">{ is_diff-path }{ is_diff-filename }</span>| ). "#EC NOTEXT
+    ENDIF.
+
     ro_html->add( zcl_abapgit_gui_chunk_lib=>render_item_state(
       iv_lstate = is_diff-lstate
       iv_rstate = is_diff-rstate ) ).

--- a/src/utils/zcl_abapgit_adt_link.clas.abap
+++ b/src/utils/zcl_abapgit_adt_link.clas.abap
@@ -9,7 +9,7 @@ CLASS zcl_abapgit_adt_link DEFINITION
                   iv_sub_obj_name TYPE zif_abapgit_definitions=>ty_item-obj_name OPTIONAL
                   iv_sub_obj_type TYPE zif_abapgit_definitions=>ty_item-obj_type OPTIONAL
                   iv_line_number  TYPE i OPTIONAL
-        RETURNING VALUE(result)   TYPE string
+        RETURNING VALUE(rv_result)   TYPE string
         RAISING   zcx_abapgit_exception.
 
   PROTECTED SECTION.
@@ -88,7 +88,7 @@ CLASS zcl_abapgit_adt_link IMPLEMENTATION.
 
         CONCATENATE 'adt://' sy-sysid <lv_uri> INTO lv_adt_link.
 
-        result = lv_adt_link.
+        rv_result = lv_adt_link.
       CATCH cx_root.
         zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
     ENDTRY.

--- a/src/utils/zcl_abapgit_adt_link.clas.abap
+++ b/src/utils/zcl_abapgit_adt_link.clas.abap
@@ -1,0 +1,200 @@
+CLASS zcl_abapgit_adt_link DEFINITION
+  PUBLIC FINAL.
+
+  PUBLIC SECTION.
+    CLASS-METHODS:
+      generate
+        IMPORTING iv_obj_name     TYPE zif_abapgit_definitions=>ty_item-obj_name
+                  iv_obj_type     TYPE zif_abapgit_definitions=>ty_item-obj_type
+                  iv_sub_obj_name TYPE zif_abapgit_definitions=>ty_item-obj_name OPTIONAL
+                  iv_sub_obj_type TYPE zif_abapgit_definitions=>ty_item-obj_type OPTIONAL
+                  iv_line_number  TYPE i OPTIONAL
+        RETURNING VALUE(result)   TYPE string
+        RAISING   zcx_abapgit_exception.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    CLASS-METHODS:
+      get_adt_objects_and_names
+        IMPORTING
+          iv_obj_name       TYPE zif_abapgit_definitions=>ty_item-obj_name
+          iv_obj_type       TYPE zif_abapgit_definitions=>ty_item-obj_type
+        EXPORTING
+          eo_adt_uri_mapper TYPE REF TO object
+          eo_adt_objectref  TYPE REF TO object
+          ev_program        TYPE progname
+          ev_include        TYPE progname
+        RAISING
+          zcx_abapgit_exception.
+
+    CLASS-METHODS:
+      is_adt_jump_possible
+        IMPORTING io_object                      TYPE REF TO cl_wb_object
+                  io_adt                         TYPE REF TO object
+        RETURNING VALUE(rv_is_adt_jump_possible) TYPE abap_bool
+        RAISING   zcx_abapgit_exception.
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_adt_link IMPLEMENTATION.
+
+  METHOD generate.
+
+    DATA: lv_adt_link       TYPE string.
+    DATA: lo_adt_uri_mapper TYPE REF TO object ##needed.
+    DATA: lo_adt_objref     TYPE REF TO object ##needed.
+    DATA: lo_adt_sub_objref TYPE REF TO object ##needed.
+    DATA: lv_program        TYPE progname.
+    DATA: lv_include        TYPE progname.
+    FIELD-SYMBOLS: <lv_uri> TYPE string.
+
+    get_adt_objects_and_names(
+          EXPORTING
+            iv_obj_name       = iv_obj_name
+            iv_obj_type       = iv_obj_type
+          IMPORTING
+            eo_adt_uri_mapper = lo_adt_uri_mapper
+            eo_adt_objectref  = lo_adt_objref
+            ev_program        = lv_program
+            ev_include        = lv_include ).
+
+    TRY.
+        IF iv_sub_obj_name IS NOT INITIAL.
+
+          IF ( lv_program <> iv_obj_name AND lv_include IS INITIAL ) OR
+             ( lv_program = lv_include AND iv_sub_obj_name IS NOT INITIAL ).
+            lv_include = iv_sub_obj_name.
+          ENDIF.
+
+          CALL METHOD lo_adt_uri_mapper->('IF_ADT_URI_MAPPER~MAP_INCLUDE_TO_OBJREF')
+            EXPORTING
+              program     = lv_program
+              include     = lv_include
+              line        = iv_line_number
+              line_offset = 0
+              end_line    = iv_line_number
+              end_offset  = 1
+            RECEIVING
+              result      = lo_adt_sub_objref.
+          IF lo_adt_sub_objref IS NOT INITIAL.
+            lo_adt_objref = lo_adt_sub_objref.
+          ENDIF.
+
+        ENDIF.
+
+        ASSIGN ('LO_ADT_OBJREF->REF_DATA-URI') TO <lv_uri>.
+        ASSERT sy-subrc = 0.
+
+        CONCATENATE 'adt://' sy-sysid <lv_uri> INTO lv_adt_link.
+
+        result = lv_adt_link.
+      CATCH cx_root.
+        zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
+    ENDTRY.
+  ENDMETHOD.
+
+
+  METHOD get_adt_objects_and_names.
+
+    DATA lv_obj_type       TYPE trobjtype.
+    DATA lv_obj_name       TYPE trobj_name.
+    DATA lo_object         TYPE REF TO cl_wb_object.
+    DATA lo_adt            TYPE REF TO object.
+    FIELD-SYMBOLS <lv_uri> TYPE string.
+
+    lv_obj_name = iv_obj_name.
+    lv_obj_type = iv_obj_type.
+
+    TRY.
+        cl_wb_object=>create_from_transport_key(
+          EXPORTING
+            p_object    = lv_obj_type
+            p_obj_name  = lv_obj_name
+          RECEIVING
+            p_wb_object = lo_object
+          EXCEPTIONS
+            OTHERS      = 1 ).
+        IF sy-subrc <> 0.
+          zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
+        ENDIF.
+
+        CALL METHOD ('CL_ADT_TOOLS_CORE_FACTORY')=>('GET_INSTANCE')
+          RECEIVING
+            result = lo_adt.
+
+        IF is_adt_jump_possible( io_object = lo_object
+                                 io_adt    = lo_adt ) = abap_false.
+          zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
+        ENDIF.
+
+        CALL METHOD lo_adt->('IF_ADT_TOOLS_CORE_FACTORY~GET_URI_MAPPER')
+          RECEIVING
+            result = eo_adt_uri_mapper.
+
+        CALL METHOD eo_adt_uri_mapper->('IF_ADT_URI_MAPPER~MAP_WB_OBJECT_TO_OBJREF')
+          EXPORTING
+            wb_object = lo_object
+          RECEIVING
+            result    = eo_adt_objectref.
+
+        ASSIGN ('EO_ADT_OBJECTREF->REF_DATA-URI') TO <lv_uri>.
+        ASSERT sy-subrc = 0.
+
+        CALL METHOD eo_adt_uri_mapper->('IF_ADT_URI_MAPPER~MAP_OBJREF_TO_INCLUDE')
+          EXPORTING
+            uri     = <lv_uri>
+          IMPORTING
+            program = ev_program
+            include = ev_include.
+
+      CATCH cx_root.
+        zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
+    ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD is_adt_jump_possible.
+
+    DATA: lo_wb_request         TYPE REF TO cl_wb_request,
+          lo_adt_uri_mapper_vit TYPE REF TO object,
+          lv_vit_wb_request     TYPE abap_bool.
+
+    cl_wb_request=>create_from_object_ref(
+      EXPORTING
+        p_wb_object       = io_object
+      RECEIVING
+        p_wb_request      = lo_wb_request
+      EXCEPTIONS
+        illegal_operation = 1
+        cancelled         = 2
+        OTHERS            = 3 ).
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
+    ENDIF.
+
+    TRY.
+        CALL METHOD io_adt->('IF_ADT_TOOLS_CORE_FACTORY~GET_URI_MAPPER_VIT')
+          RECEIVING
+            result = lo_adt_uri_mapper_vit.
+
+        CALL METHOD lo_adt_uri_mapper_vit->('IF_ADT_URI_MAPPER_VIT~IS_VIT_WB_REQUEST')
+          EXPORTING
+            wb_request = lo_wb_request
+          RECEIVING
+            result     = lv_vit_wb_request.
+
+        IF lv_vit_wb_request = abap_true.
+          rv_is_adt_jump_possible = abap_false.
+        ELSE.
+          rv_is_adt_jump_possible = abap_true.
+        ENDIF.
+
+      CATCH cx_root.
+        zcx_abapgit_exception=>raise( 'ADT Jump Error' ).
+    ENDTRY.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/utils/zcl_abapgit_adt_link.clas.xml
+++ b/src/utils/zcl_abapgit_adt_link.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_ADT_LINK</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>ADT link generator</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
This PR makes ADT jump possible from the diff/patch page as well. Useful if you noticed a mistake you want to quickly fix. 

![5RXNSHC2e1](https://user-images.githubusercontent.com/5097067/69813090-ccdc4680-11f1-11ea-8b6c-7f0092e8f9d1.gif)

- Links are not rendered for locally deleted/nonexistent objects
- ADT link generation extracted to separate class

For now in draft form as I want to discuss a few things:
- links for beacons/lines as well?
- the path on the left is actually the path on remote. Is this worth changing (put object name on the local side, path on the right)?
