### PR TITLE
IOBJ: Use RSD_S_VIOBJ instead of RSD_S_VI_OBJ

### DIFF
--- a/src/objects/zcl_abapgit_object_iobj.clas.abap
+++ b/src/objects/zcl_abapgit_object_iobj.clas.abap
@@ -25,7 +25,7 @@ CLASS zcl_abapgit_object_iobj IMPLEMENTATION.
     lv_objna = ms_item-obj_name.
 
     TRY.
-        CREATE DATA lr_viobj TYPE ('RSD_S_VI_OBJ').
+        CREATE DATA lr_viobj TYPE ('RSD_S_VIOBJ').
       CATCH cx_sy_create_data_error.
         zcx_abapgit_exception=>raise( |IOBJ is not supported on this system| ).
     ENDTRY.
@@ -182,7 +182,7 @@ CLASS zcl_abapgit_object_iobj IMPLEMENTATION.
     lv_objna = ms_item-obj_name.
 
     TRY.
-        CREATE DATA lr_viobj TYPE ('RSD_S_VI_OBJ').
+        CREATE DATA lr_viobj TYPE ('RSD_S_VIOBJ').
       CATCH cx_sy_create_data_error.
         zcx_abapgit_exception=>raise( |IOBJ is not supported on this system| ).
     ENDTRY.


### PR DESCRIPTION
fixes #3120 