### PR TITLE
Issue 3053: Fix protected redefinitions

### DIFF
--- a/src/objects/zcl_abapgit_oo_class.clas.abap
+++ b/src/objects/zcl_abapgit_oo_class.clas.abap
@@ -258,6 +258,10 @@ CLASS ZCL_ABAPGIT_OO_CLASS IMPLEMENTATION.
     ls_clskey-clsname = iv_name.
 
     TRY.
+        CALL FUNCTION 'SEO_BUFFER_REFRESH'
+          EXPORTING
+            cifkey  = ls_clskey
+            version = seoc_version_active.
         CREATE OBJECT lo_update TYPE ('CL_OO_CLASS_SECTION_SOURCE')
           EXPORTING
             clskey                        = ls_clskey


### PR DESCRIPTION
During creation of classes with redefinitions in the protected section, entries in table SEOREDEF are not updated properly.

Reason: The buffer of Class Builder does not recognize the creation of the inheritance in the active version.  During the creation of the super class relationship in SEO_INHERITANCE_CREATE_F_DATA only the inactive buffer is updated. The buffer for the active version has still the state that the class has no super class.

Therefore, SEOREDEF is filled with an empty super class name. 

If the buffer is refreshed before the metadata is updated, the super class is read correctly before SEOREDEF entries are created.