### PR TITLE
DOCT: consider all versions

### DIFF
--- a/src/objects/zcl_abapgit_longtexts.clas.abap
+++ b/src/objects/zcl_abapgit_longtexts.clas.abap
@@ -66,7 +66,7 @@ CLASS zcl_abapgit_longtexts DEFINITION
           iv_longtext_id      TYPE dokil-id
           it_dokil            TYPE zif_abapgit_definitions=>tty_dokil
         RETURNING
-          VALUE(rt_longtexts) TYPE zcl_abapgit_longtexts=>tty_longtexts
+          VALUE(rt_longtexts) TYPE tty_longtexts
         RAISING
           zcx_abapgit_exception.
 
@@ -167,7 +167,7 @@ CLASS zcl_abapgit_longtexts IMPLEMENTATION.
   METHOD changed_by.
 
     DATA: lt_longtexts TYPE tty_longtexts.
-    FIELD-SYMBOLS: <ls_longtext> TYPE zcl_abapgit_longtexts=>ty_longtext.
+    FIELD-SYMBOLS: <ls_longtext> TYPE ty_longtext.
 
     lt_longtexts = read( iv_object_name = iv_object_name
                          iv_longtext_id = iv_longtext_id

--- a/src/objects/zcl_abapgit_longtexts.clas.abap
+++ b/src/objects/zcl_abapgit_longtexts.clas.abap
@@ -1,7 +1,7 @@
 CLASS zcl_abapgit_longtexts DEFINITION
   PUBLIC
-  FINAL
-  CREATE PUBLIC.
+  CREATE PRIVATE
+  GLOBAL FRIENDS zcl_abapgit_factory.
 
   PUBLIC SECTION.
     METHODS:

--- a/src/objects/zcl_abapgit_longtexts.clas.abap
+++ b/src/objects/zcl_abapgit_longtexts.clas.abap
@@ -4,12 +4,26 @@ CLASS zcl_abapgit_longtexts DEFINITION
   CREATE PUBLIC.
 
   PUBLIC SECTION.
-    CLASS-METHODS:
+    METHODS:
+      constructor
+        IMPORTING
+          iv_longtexts_name TYPE string OPTIONAL,
+
+      changed_by
+        IMPORTING
+          iv_object_name TYPE sobj_name
+          iv_longtext_id TYPE dokil-id
+          it_dokil       TYPE zif_abapgit_definitions=>tty_dokil OPTIONAL
+        RETURNING
+          VALUE(rv_user) TYPE xubname
+        RAISING
+          zcx_abapgit_exception,
+
       serialize
         IMPORTING
           iv_object_name TYPE sobj_name
           iv_longtext_id TYPE dokil-id
-          it_dokil       TYPE zif_abapgit_definitions=>tty_dokil
+          it_dokil       TYPE zif_abapgit_definitions=>tty_dokil OPTIONAL
           io_xml         TYPE REF TO zcl_abapgit_xml_output
         RAISING
           zcx_abapgit_exception,
@@ -37,15 +51,41 @@ CLASS zcl_abapgit_longtexts DEFINITION
       END OF ty_longtext,
       tty_longtexts TYPE STANDARD TABLE OF ty_longtext
                          WITH NON-UNIQUE DEFAULT KEY.
+
     CONSTANTS:
       c_longtexts_name    TYPE string   VALUE 'LONGTEXTS' ##NO_TEXT,
       c_docu_state_active TYPE dokstate VALUE 'A' ##NO_TEXT.
+
+    DATA:
+      mv_longtexts_name TYPE string.
+
+    METHODS:
+      read
+        IMPORTING
+          iv_object_name      TYPE sobj_name
+          iv_longtext_id      TYPE dokil-id
+          it_dokil            TYPE zif_abapgit_definitions=>tty_dokil
+        RETURNING
+          VALUE(rt_longtexts) TYPE zcl_abapgit_longtexts=>tty_longtexts
+        RAISING
+          zcx_abapgit_exception.
 
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_LONGTEXTS IMPLEMENTATION.
+CLASS zcl_abapgit_longtexts IMPLEMENTATION.
+
+
+  METHOD constructor.
+
+    IF iv_longtexts_name IS NOT INITIAL.
+      mv_longtexts_name = iv_longtexts_name.
+    ELSE.
+      mv_longtexts_name = c_longtexts_name.
+    ENDIF.
+
+  ENDMETHOD.
 
 
   METHOD delete.
@@ -55,8 +95,8 @@ CLASS ZCL_ABAPGIT_LONGTEXTS IMPLEMENTATION.
 
     SELECT * FROM dokil
       INTO TABLE lt_dokil
-      WHERE id = iv_longtext_id
-      AND object = iv_longtext_id.
+      WHERE id     = iv_longtext_id
+      AND   object = iv_object_name.
 
     LOOP AT lt_dokil ASSIGNING <ls_dokil>.
 
@@ -87,7 +127,7 @@ CLASS ZCL_ABAPGIT_LONGTEXTS IMPLEMENTATION.
 
     io_xml->read(
       EXPORTING
-        iv_name = c_longtexts_name
+        iv_name = mv_longtexts_name
       CHANGING
         cg_data = lt_longtexts ).
 
@@ -112,12 +152,41 @@ CLASS ZCL_ABAPGIT_LONGTEXTS IMPLEMENTATION.
 
   METHOD serialize.
 
-    DATA: ls_longtext  TYPE ty_longtext,
-          lt_longtexts TYPE tty_longtexts,
-          lt_dokil     TYPE zif_abapgit_definitions=>tty_dokil.
+    DATA: lt_longtexts TYPE tty_longtexts.
+
+    lt_longtexts = read( iv_object_name = iv_object_name
+                         iv_longtext_id = iv_longtext_id
+                         it_dokil       = it_dokil ).
+
+    io_xml->add( iv_name = mv_longtexts_name
+                 ig_data = lt_longtexts ).
+
+  ENDMETHOD.
+
+
+  METHOD changed_by.
+
+    DATA: lt_longtexts TYPE tty_longtexts.
+    FIELD-SYMBOLS: <ls_longtext> TYPE zcl_abapgit_longtexts=>ty_longtext.
+
+    lt_longtexts = read( iv_object_name = iv_object_name
+                         iv_longtext_id = iv_longtext_id
+                         it_dokil       = it_dokil ).
+
+    READ TABLE lt_longtexts INDEX 1 ASSIGNING <ls_longtext>.
+    IF sy-subrc = 0.
+      rv_user = <ls_longtext>-head-tdluser.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD read.
+
+    DATA: ls_longtext TYPE ty_longtext,
+          lt_dokil    TYPE zif_abapgit_definitions=>tty_dokil.
 
     FIELD-SYMBOLS: <ls_dokil> LIKE LINE OF lt_dokil.
-
 
     IF lines( it_dokil ) > 0.
 
@@ -126,9 +195,10 @@ CLASS ZCL_ABAPGIT_LONGTEXTS IMPLEMENTATION.
     ELSEIF iv_longtext_id IS NOT INITIAL.
 
       SELECT * FROM dokil
-              INTO TABLE lt_dokil
-              WHERE id     = iv_longtext_id
-              AND   object = iv_object_name.
+               INTO TABLE lt_dokil
+               WHERE id     = iv_longtext_id
+               AND   object = iv_object_name
+               ORDER BY PRIMARY KEY.
 
     ELSE.
 
@@ -164,12 +234,10 @@ CLASS ZCL_ABAPGIT_LONGTEXTS IMPLEMENTATION.
              ls_longtext-head-tdldate,
              ls_longtext-head-tdltime.
 
-      INSERT ls_longtext INTO TABLE lt_longtexts.
+      INSERT ls_longtext INTO TABLE rt_longtexts.
 
     ENDLOOP.
 
-    io_xml->add( iv_name = c_longtexts_name
-                 ig_data = lt_longtexts ).
-
   ENDMETHOD.
+
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_doct.clas.abap
+++ b/src/objects/zcl_abapgit_object_doct.clas.abap
@@ -3,100 +3,76 @@ CLASS zcl_abapgit_object_doct DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
   PUBLIC SECTION.
     INTERFACES zif_abapgit_object.
     ALIASES mo_files FOR zif_abapgit_object~mo_files.
+    METHODS:
+      constructor
+        IMPORTING
+          is_item     TYPE zif_abapgit_definitions=>ty_item
+          iv_language TYPE spras.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
-    CONSTANTS: c_id      TYPE dokhl-id VALUE 'TX',
-               c_typ     TYPE dokhl-typ VALUE 'E',
-               c_version TYPE dokhl-dokversion VALUE '0001',
-               c_name    TYPE string VALUE 'DOC'.
+    CONSTANTS:
+      c_id      TYPE dokhl-id VALUE 'TX',
+      c_typ     TYPE dokhl-typ VALUE 'E',
+      c_version TYPE dokhl-dokversion VALUE '0001',
+      c_name    TYPE string VALUE 'DOC'.
 
-    TYPES: BEGIN OF ty_data,
-             doctitle TYPE dsyst-doktitle,
-             head     TYPE thead,
-             lines    TYPE tline_tab,
-           END OF ty_data.
+    DATA:
+      mo_longtexts TYPE REF TO zcl_abapgit_longtexts.
 
-    METHODS: read
-      RETURNING VALUE(rs_data) TYPE ty_data.
+    TYPES:
+      BEGIN OF ty_data,
+        doctitle TYPE dsyst-doktitle,
+        head     TYPE thead,
+        lines    TYPE tline_tab,
+      END OF ty_data.
 
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_DOCT IMPLEMENTATION.
+CLASS zcl_abapgit_object_doct IMPLEMENTATION.
 
+  METHOD constructor.
 
-  METHOD read.
+    super->constructor(
+        is_item     = is_item
+        iv_language = iv_language ).
 
-    DATA: lv_object TYPE dokhl-object.
-
-
-    lv_object = ms_item-obj_name.
-
-    CALL FUNCTION 'DOCU_READ'
+    CREATE OBJECT mo_longtexts
       EXPORTING
-        id       = c_id
-        langu    = mv_language
-        object   = lv_object
-        typ      = c_typ
-        version  = c_version
-      IMPORTING
-        doktitle = rs_data-doctitle
-        head     = rs_data-head
-      TABLES
-        line     = rs_data-lines.
+        iv_longtexts_name = c_name.
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_object~changed_by.
-    rv_user = read( )-head-tdluser.
+
+    rv_user = mo_longtexts->changed_by(
+                  iv_object_name = ms_item-obj_name
+                  iv_longtext_id = c_id ).
+
     IF rv_user IS INITIAL.
       rv_user = c_user_unknown.
     ENDIF.
+
   ENDMETHOD.
 
 
   METHOD zif_abapgit_object~delete.
 
-    DATA: lv_object TYPE dokhl-object.
-
-
-    lv_object = ms_item-obj_name.
-
-    CALL FUNCTION 'DOCU_DEL'
-      EXPORTING
-        id       = c_id
-        langu    = mv_language
-        object   = lv_object
-        typ      = c_typ
-      EXCEPTIONS
-        ret_code = 1
-        OTHERS   = 2.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'error from DOCU_DEL' ).
-    ENDIF.
+    mo_longtexts->delete(
+        iv_object_name = ms_item-obj_name
+        iv_longtext_id = c_id ).
 
   ENDMETHOD.
 
 
   METHOD zif_abapgit_object~deserialize.
 
-    DATA: ls_data TYPE ty_data.
-
-
-    io_xml->read( EXPORTING iv_name = c_name
-                  CHANGING cg_data = ls_data ).
-
-    CALL FUNCTION 'DOCU_UPDATE'
-      EXPORTING
-        head    = ls_data-head
-        state   = 'A'
-        typ     = c_typ
-        version = c_version
-      TABLES
-        line    = ls_data-lines.
+    mo_longtexts->deserialize(
+        io_xml             = io_xml
+        iv_master_language = mv_language ).
 
     tadir_insert( iv_package ).
 
@@ -195,22 +171,10 @@ CLASS ZCL_ABAPGIT_OBJECT_DOCT IMPLEMENTATION.
 
   METHOD zif_abapgit_object~serialize.
 
-    DATA: ls_data TYPE ty_data.
-
-
-    ls_data = read( ).
-
-    CLEAR: ls_data-head-tdfuser,
-           ls_data-head-tdfreles,
-           ls_data-head-tdfdate,
-           ls_data-head-tdftime,
-           ls_data-head-tdluser,
-           ls_data-head-tdlreles,
-           ls_data-head-tdldate,
-           ls_data-head-tdltime.
-
-    io_xml->add( iv_name = c_name
-                 ig_data = ls_data ).
+    mo_longtexts->serialize(
+        iv_object_name = ms_item-obj_name
+        iv_longtext_id = c_id
+        io_xml         = io_xml ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/objects/zcl_abapgit_object_doct.clas.abap
+++ b/src/objects/zcl_abapgit_object_doct.clas.abap
@@ -13,8 +13,6 @@ CLASS zcl_abapgit_object_doct DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
   PRIVATE SECTION.
     CONSTANTS:
       c_id      TYPE dokhl-id VALUE 'TX',
-      c_typ     TYPE dokhl-typ VALUE 'E',
-      c_version TYPE dokhl-dokversion VALUE '0001',
       c_name    TYPE string VALUE 'DOC'.
 
     DATA:
@@ -39,9 +37,7 @@ CLASS zcl_abapgit_object_doct IMPLEMENTATION.
         is_item     = is_item
         iv_language = iv_language ).
 
-    CREATE OBJECT mo_longtexts
-      EXPORTING
-        iv_longtexts_name = c_name.
+    mo_longtexts = zcl_abapgit_factory=>get_longtexts( c_name ).
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -84,7 +84,9 @@ CLASS zcl_abapgit_objects_super DEFINITION PUBLIC ABSTRACT.
         VALUE(rv_active) TYPE abap_bool
       RAISING
         zcx_abapgit_exception .
+
   PRIVATE SECTION.
+    DATA mo_longtexts TYPE REF TO zcl_abapgit_longtexts.
 
 
 ENDCLASS.
@@ -120,6 +122,8 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
     ASSERT NOT ms_item IS INITIAL.
     mv_language = iv_language.
     ASSERT NOT mv_language IS INITIAL.
+
+    CREATE OBJECT mo_longtexts.
   ENDMETHOD.
 
 
@@ -163,16 +167,18 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
   METHOD delete_longtexts.
 
-    zcl_abapgit_longtexts=>delete( iv_longtext_id = iv_longtext_id
-                                   iv_object_name = ms_item-obj_name ).
+    mo_longtexts->delete(
+        iv_longtext_id = iv_longtext_id
+        iv_object_name = ms_item-obj_name  ).
 
   ENDMETHOD.
 
 
   METHOD deserialize_longtexts.
 
-    zcl_abapgit_longtexts=>deserialize( io_xml             = io_xml
-                                        iv_master_language = mv_language ).
+    mo_longtexts->deserialize(
+        io_xml             = io_xml
+        iv_master_language = mv_language ).
 
   ENDMETHOD.
 
@@ -301,10 +307,11 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
   METHOD serialize_longtexts.
 
-    zcl_abapgit_longtexts=>serialize( iv_object_name = ms_item-obj_name
-                                      iv_longtext_id = iv_longtext_id
-                                      it_dokil       = it_dokil
-                                      io_xml         = io_xml ).
+    mo_longtexts->serialize(
+        iv_object_name = ms_item-obj_name
+        iv_longtext_id = iv_longtext_id
+        it_dokil       = it_dokil
+        io_xml         = io_xml  ).
 
   ENDMETHOD.
 

--- a/src/objects/zcl_abapgit_objects_super.clas.abap
+++ b/src/objects/zcl_abapgit_objects_super.clas.abap
@@ -85,10 +85,6 @@ CLASS zcl_abapgit_objects_super DEFINITION PUBLIC ABSTRACT.
       RAISING
         zcx_abapgit_exception .
 
-  PRIVATE SECTION.
-    DATA mo_longtexts TYPE REF TO zcl_abapgit_longtexts.
-
-
 ENDCLASS.
 
 
@@ -122,8 +118,6 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
     ASSERT NOT ms_item IS INITIAL.
     mv_language = iv_language.
     ASSERT NOT mv_language IS INITIAL.
-
-    CREATE OBJECT mo_longtexts.
   ENDMETHOD.
 
 
@@ -167,7 +161,7 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
   METHOD delete_longtexts.
 
-    mo_longtexts->delete(
+    zcl_abapgit_factory=>get_longtexts( )->delete(
         iv_longtext_id = iv_longtext_id
         iv_object_name = ms_item-obj_name  ).
 
@@ -176,7 +170,7 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
   METHOD deserialize_longtexts.
 
-    mo_longtexts->deserialize(
+    zcl_abapgit_factory=>get_longtexts( )->deserialize(
         io_xml             = io_xml
         iv_master_language = mv_language ).
 
@@ -307,7 +301,7 @@ CLASS zcl_abapgit_objects_super IMPLEMENTATION.
 
   METHOD serialize_longtexts.
 
-    mo_longtexts->serialize(
+    zcl_abapgit_factory=>get_longtexts( )->serialize(
         iv_object_name = ms_item-obj_name
         iv_longtext_id = iv_longtext_id
         it_dokil       = it_dokil

--- a/src/zcl_abapgit_factory.clas.abap
+++ b/src/zcl_abapgit_factory.clas.abap
@@ -34,6 +34,12 @@ CLASS zcl_abapgit_factory DEFINITION
     CLASS-METHODS get_environment
       RETURNING
         VALUE(ro_environment) TYPE REF TO zif_abapgit_environment .
+    CLASS-METHODS get_longtexts
+      IMPORTING
+        iv_longtexts_name   TYPE string OPTIONAL
+      RETURNING
+        VALUE(ro_longtexts) TYPE REF TO zcl_abapgit_longtexts.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -54,17 +60,26 @@ CLASS zcl_abapgit_factory DEFINITION
       tty_code_inspector TYPE HASHED TABLE OF ty_code_inspector
                                      WITH UNIQUE KEY package .
 
+    TYPES:
+      BEGIN OF ty_longtexts,
+        longtexts_name TYPE string,
+        instance       TYPE REF TO zcl_abapgit_longtexts,
+      END OF ty_longtexts .
+    TYPES:
+      tty_longtexts TYPE HASHED TABLE OF ty_longtexts
+                         WITH UNIQUE KEY longtexts_name .
     CLASS-DATA gi_tadir TYPE REF TO zif_abapgit_tadir .
     CLASS-DATA gt_sap_package TYPE tty_sap_package .
     CLASS-DATA gt_code_inspector TYPE tty_code_inspector .
     CLASS-DATA gi_stage_logic TYPE REF TO zif_abapgit_stage_logic .
     CLASS-DATA gi_cts_api TYPE REF TO zif_abapgit_cts_api .
     CLASS-DATA go_environment TYPE REF TO zif_abapgit_environment .
+    CLASS-DATA gt_longtexts TYPE tty_longtexts.
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_FACTORY IMPLEMENTATION.
+CLASS zcl_abapgit_factory IMPLEMENTATION.
 
 
   METHOD get_branch_overview.
@@ -165,4 +180,30 @@ CLASS ZCL_ABAPGIT_FACTORY IMPLEMENTATION.
     ri_tadir = gi_tadir.
 
   ENDMETHOD.
+
+
+  METHOD get_longtexts.
+
+    DATA: ls_longtext TYPE zcl_abapgit_factory=>ty_longtexts.
+    FIELD-SYMBOLS: <ls_longtext> TYPE zcl_abapgit_factory=>ty_longtexts.
+
+    READ TABLE gt_longtexts ASSIGNING <ls_longtext>
+                            WITH TABLE KEY longtexts_name = iv_longtexts_name.
+    IF sy-subrc <> 0.
+
+      ls_longtext-longtexts_name = iv_longtexts_name.
+      CREATE OBJECT ls_longtext-instance
+        EXPORTING
+          iv_longtexts_name = iv_longtexts_name.
+
+      INSERT ls_longtext
+        INTO TABLE gt_longtexts
+        ASSIGNING <ls_longtext>.
+
+    ENDIF.
+
+    ro_longtexts = <ls_longtext>-instance.
+
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/zcl_abapgit_factory.clas.abap
+++ b/src/zcl_abapgit_factory.clas.abap
@@ -184,8 +184,8 @@ CLASS zcl_abapgit_factory IMPLEMENTATION.
 
   METHOD get_longtexts.
 
-    DATA: ls_longtext TYPE zcl_abapgit_factory=>ty_longtexts.
-    FIELD-SYMBOLS: <ls_longtext> TYPE zcl_abapgit_factory=>ty_longtexts.
+    DATA: ls_longtext TYPE ty_longtexts.
+    FIELD-SYMBOLS: <ls_longtext> TYPE ty_longtexts.
 
     READ TABLE gt_longtexts ASSIGNING <ls_longtext>
                             WITH TABLE KEY longtexts_name = iv_longtexts_name.


### PR DESCRIPTION
- DOCT now uses ZCL_ABAPGIT_LONGTEXTS
- all versions are serialized instead of hard coded 0001
- ZCL_ABAPGIT_LONGTEXTS is now instantiated with ZCL_ABAPGIT_FACTORY
- bugfix in `delete`. Before `delete` didn't work

test repo https://github.com/abapGit-tests/DOCT.git

fixes #3160 