### PR TITLE
fix: ignore not supp. objects during lock check

### DIFF
--- a/src/zcl_abapgit_objects.clas.abap
+++ b/src/zcl_abapgit_objects.clas.abap
@@ -337,6 +337,12 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
     LOOP AT it_items ASSIGNING <ls_item>.
 
+      " You should remember that we ignore not supported objects here,
+      " because otherwise the process aborts which is not desired
+      IF is_supported( <ls_item> ) = abap_false.
+        CONTINUE.
+      ENDIF.
+
       li_obj = create_object( is_item     = <ls_item>
                               iv_language = iv_language ).
 


### PR DESCRIPTION
fixes #3175