### PR TITLE
Undo broken links

### DIFF
--- a/docs/collections/_development/developing-ui.md
+++ b/docs/collections/_development/developing-ui.md
@@ -4,8 +4,8 @@ order: 91
 ---
 
 This doc covers page creation, html rendering and event handling.
-- See also [UI - CSS and assets](./developing-ui-css.md).
-- See also [UI - Java script](./developing-ui-js.md).
+- See also [UI - CSS and assets](./developing-ui-css.html).
+- See also [UI - Java script](./developing-ui-js.html).
 
 ## TL;DR
 


### PR DESCRIPTION
abapGit documentation is in HTML, not in markdown. Last commit broke the abapgit.org docs.