### PR TITLE
Use xml syntax highlighter for html as well

### DIFF
--- a/src/syntax/zcl_abapgit_syntax_highlighter.clas.abap
+++ b/src/syntax/zcl_abapgit_syntax_highlighter.clas.abap
@@ -116,7 +116,7 @@ CLASS ZCL_ABAPGIT_SYNTAX_HIGHLIGHTER IMPLEMENTATION.
     " Create instance of highighter dynamically dependent on syntax type
     IF iv_filename CP '*.abap'.
       CREATE OBJECT ro_instance TYPE zcl_abapgit_syntax_abap.
-    ELSEIF iv_filename CP '*.xml'.
+    ELSEIF iv_filename CP '*.xml' OR iv_filename CP '*.html'.
       CREATE OBJECT ro_instance TYPE zcl_abapgit_syntax_xml.
     ELSE.
       CLEAR ro_instance.


### PR DESCRIPTION
I came upon a `w3ht.data.html` object without syntax highlighting. We can reuse the xml highlighter for html to fix it.