### PR TITLE
CHDO: clear UZEIT and UTIME dynamically (#3256) bis

### DIFF
--- a/src/objects/zcl_abapgit_object_chdo.clas.abap
+++ b/src/objects/zcl_abapgit_object_chdo.clas.abap
@@ -234,10 +234,10 @@ CLASS zcl_abapgit_object_chdo IMPLEMENTATION.
           lt_tcdrp         TYPE STANDARD TABLE OF tcdrp,
           lt_tcdob         TYPE STANDARD TABLE OF tcdob,
           lt_tcdobt        TYPE STANDARD TABLE OF tcdobt,
-          BEGIN OF nulldatetime, " hack ro reset fields when they exist without syntax errors when they don't
+          BEGIN OF ls_nulldatetime, " hack ro reset fields when they exist without syntax errors when they don't
             udate TYPE sy-datum,
             utime TYPE sy-uzeit,
-          END OF nulldatetime.
+          END OF ls_nulldatetime.
 
     FIELD-SYMBOLS: <ls_reports_generated> LIKE LINE OF ls_change_object-reports_generated,
                    <ls_objects>           LIKE LINE OF ls_change_object-objects,
@@ -270,11 +270,11 @@ CLASS zcl_abapgit_object_chdo IMPLEMENTATION.
     ENDLOOP.
 
     LOOP AT ls_change_object-objects ASSIGNING <ls_objects>.
-      MOVE-CORRESPONDING nulldatetime TO <ls_objects>. " reset date and time
+      MOVE-CORRESPONDING ls_nulldatetime TO <ls_objects>. " reset date and time
     ENDLOOP.
 
     LOOP AT ls_change_object-objects_text ASSIGNING <ls_objects_text>.
-      MOVE-CORRESPONDING nulldatetime TO <ls_objects_text>. " reset date and time
+      MOVE-CORRESPONDING ls_nulldatetime TO <ls_objects_text>. " reset date and time
     ENDLOOP.
 
     io_xml->add( iv_name = 'CHDO'

--- a/src/objects/zcl_abapgit_object_chdo.clas.abap
+++ b/src/objects/zcl_abapgit_object_chdo.clas.abap
@@ -45,12 +45,6 @@ CLASS zcl_abapgit_object_chdo DEFINITION
            tt_change_document TYPE STANDARD TABLE OF ty_change_document.
 
     DATA: mv_object TYPE cdobjectcl.
-    METHODS:
-      clear_field
-        IMPORTING
-          iv_fieldname TYPE string
-        CHANGING
-          cs_structure TYPE any.
 
 ENDCLASS.
 
@@ -239,7 +233,12 @@ CLASS zcl_abapgit_object_chdo IMPLEMENTATION.
     DATA: ls_change_object TYPE ty_change_document,
           lt_tcdrp         TYPE STANDARD TABLE OF tcdrp,
           lt_tcdob         TYPE STANDARD TABLE OF tcdob,
-          lt_tcdobt        TYPE STANDARD TABLE OF tcdobt.
+          lt_tcdobt        TYPE STANDARD TABLE OF tcdobt,
+          BEGIN OF nulldatetime, " hack ro reset fields when they exist without syntax errors when they don't
+            udate TYPE sy-datum,
+            utime TYPE sy-uzeit,
+          END OF nulldatetime.
+
     FIELD-SYMBOLS: <ls_reports_generated> LIKE LINE OF ls_change_object-reports_generated,
                    <ls_objects>           LIKE LINE OF ls_change_object-objects,
                    <ls_objects_text>      LIKE LINE OF ls_change_object-objects_text.
@@ -271,35 +270,11 @@ CLASS zcl_abapgit_object_chdo IMPLEMENTATION.
     ENDLOOP.
 
     LOOP AT ls_change_object-objects ASSIGNING <ls_objects>.
-
-      clear_field(
-        EXPORTING
-          iv_fieldname = |UDATE|
-        CHANGING
-          cs_structure = <ls_objects> ).
-
-      clear_field(
-        EXPORTING
-          iv_fieldname = |UTIME|
-        CHANGING
-          cs_structure = <ls_objects> ).
-
+      MOVE-CORRESPONDING nulldatetime TO <ls_objects>. " reset date and time
     ENDLOOP.
 
     LOOP AT ls_change_object-objects_text ASSIGNING <ls_objects_text>.
-
-      clear_field(
-        EXPORTING
-          iv_fieldname = |UDATE|
-        CHANGING
-          cs_structure = <ls_objects_text> ).
-
-      clear_field(
-        EXPORTING
-          iv_fieldname = |UTIME|
-        CHANGING
-          cs_structure = <ls_objects_text> ).
-
+      MOVE-CORRESPONDING nulldatetime TO <ls_objects_text>. " reset date and time
     ENDLOOP.
 
     io_xml->add( iv_name = 'CHDO'
@@ -453,23 +428,6 @@ CLASS zcl_abapgit_object_chdo IMPLEMENTATION.
         zcx_abapgit_exception=>raise( |Error from TR_TADIR_INTERFACE (subrc={ sy-subrc } ).| ).
       ENDIF.
     ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD clear_field.
-
-    FIELD-SYMBOLS: <lv_field> TYPE data.
-
-    ASSIGN
-      COMPONENT iv_fieldname
-      OF STRUCTURE cs_structure
-      TO <lv_field>.
-    IF sy-subrc <> 0.
-      RETURN. " Field is not available in lower NW versions
-    ENDIF.
-
-    CLEAR: <lv_field>.
 
   ENDMETHOD.
 


### PR DESCRIPTION
Had this floating around since Monday but couldn't find the time to rebase.
Would have dropped it as I saw you posted a fix, so I tried it.

My solution is less elegant but more compact, and more importantly doesn't dump:
![image](https://user-images.githubusercontent.com/2453277/76648786-43aa0f00-6557-11ea-997e-7332b86855b5.png)