### PR TITLE
CUS0, CUS1, CUS2 - Serialize master lang only

### DIFF
--- a/src/objects/zcl_abapgit_object_cus0.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus0.clas.abap
@@ -174,6 +174,10 @@ CLASS ZCL_ABAPGIT_OBJECT_CUS0 IMPLEMENTATION.
            ls_img_activity-header-ldate,
            ls_img_activity-header-ltime.
 
+    IF io_xml->i18n_params( )-serialize_master_lang_only = abap_true.
+      DELETE ls_img_activity-texts WHERE spras <> sy-langu.
+    ENDIF.
+
     io_xml->add( iv_name = 'CUS0'
                  ig_data = ls_img_activity ).
 

--- a/src/objects/zcl_abapgit_object_cus1.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus1.clas.abap
@@ -187,6 +187,10 @@ CLASS ZCL_ABAPGIT_OBJECT_CUS1 IMPLEMENTATION.
            ls_customzing_activity-activity_header-ldatetime,
            ls_customzing_activity-activity_header-luser.
 
+    IF io_xml->i18n_params( )-serialize_master_lang_only = abap_true.
+      DELETE ls_customzing_activity-activity_title WHERE spras <> sy-langu.
+    ENDIF.
+
     io_xml->add( iv_name = 'CUS1'
                  ig_data = ls_customzing_activity ).
 

--- a/src/objects/zcl_abapgit_object_cus2.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus2.clas.abap
@@ -163,6 +163,10 @@ CLASS ZCL_ABAPGIT_OBJECT_CUS2 IMPLEMENTATION.
            ls_customizing_attribute-header-ldatetime,
            ls_customizing_attribute-header-luser.
 
+    IF io_xml->i18n_params( )-serialize_master_lang_only = abap_true.
+      DELETE ls_customizing_attribute-titles WHERE spras <> sy-langu.
+    ENDIF.
+
     io_xml->add( iv_name = 'CUS2'
                  ig_data = ls_customizing_attribute ).
 


### PR DESCRIPTION
The "serialize master language only" setting is not respected everywhere. This PR fixes CUS0, CUS1, CUS2 object types.