### PR TITLE
[WIP] OTGR: add native serialization

### DIFF
--- a/src/objects/zcl_abapgit_object_otgr.clas.abap
+++ b/src/objects/zcl_abapgit_object_otgr.clas.abap
@@ -1,0 +1,275 @@
+CLASS zcl_abapgit_object_otgr DEFINITION
+  PUBLIC
+  INHERITING FROM zcl_abapgit_objects_super
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    INTERFACES zif_abapgit_object .
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+
+    TYPES:
+      BEGIN OF ty_otgr,
+        cls_type_group TYPE cls_type_group,
+        texts          TYPE STANDARD TABLE OF cls_type_groupt WITH DEFAULT KEY,
+        elements       TYPE STANDARD TABLE OF cls_tygr_element WITH DEFAULT KEY,
+        parents        TYPE STANDARD TABLE OF cls_tygr_parent WITH DEFAULT KEY,
+      END OF ty_otgr .
+
+    METHODS instantiate_and_lock_otgr
+      RETURNING
+        VALUE(ro_otgr) TYPE REF TO cl_cls_object_type_group
+      RAISING
+        zcx_abapgit_exception .
+ENDCLASS.
+
+
+
+CLASS zcl_abapgit_object_otgr IMPLEMENTATION.
+
+  METHOD instantiate_and_lock_otgr.
+    DATA: lv_new  TYPE abap_bool,
+          lv_name TYPE cls_attribute_name.
+
+    SELECT SINGLE name FROM cls_type_group INTO lv_name WHERE name = ms_item-obj_name.
+    lv_new = boolc( sy-subrc <> 0 ).
+    lv_name = ms_item-obj_name.
+
+    TRY.
+        CREATE OBJECT ro_otgr
+          EXPORTING
+            im_name             = lv_name
+            im_new              = lv_new
+            im_activation_state = cl_pak_wb_domains=>co_activation_state-active.
+      CATCH cx_pak_invalid_data
+          cx_pak_not_authorized
+          cx_pak_invalid_state
+          cx_pak_wb_object_locked.
+        zcx_abapgit_exception=>raise( |OTGR { lv_name }: error while instantiating CL_CLS_OBJECT_TYPE_GROUP| ).
+    ENDTRY.
+
+    IF lv_new = abap_false.
+      TRY.
+          ro_otgr->if_pak_wb_object~lock_and_refresh( ).
+        CATCH cx_pak_invalid_data
+            cx_pak_not_authorized
+            cx_pak_invalid_state
+            cx_pak_wb_object_locked.
+          zcx_abapgit_exception=>raise( |OTGR { lv_name }: could not aquire lock| ).
+      ENDTRY.
+    ENDIF.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_object~changed_by.
+    SELECT SINGLE changed_by FROM cls_type_group INTO rv_user
+      WHERE name = ms_item-obj_name
+      AND activation_state = cl_pak_wb_domains=>co_activation_state-active.
+
+    IF rv_user IS INITIAL.
+      SELECT SINGLE created_by FROM cls_type_group INTO rv_user
+        WHERE name = ms_item-obj_name
+        AND activation_state = cl_pak_wb_domains=>co_activation_state-active.
+    ENDIF.
+
+    IF rv_user IS INITIAL.
+      rv_user = c_user_unknown.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_object~delete.
+    DATA: lo_otgr       TYPE REF TO cl_cls_object_type_group,
+          lx_pak_error  TYPE REF TO cx_root,
+          lv_text       TYPE string.
+
+    lo_otgr = instantiate_and_lock_otgr( ).
+
+    TRY.
+        lo_otgr->if_pak_wb_object~delete( ).
+        lo_otgr->if_pak_wb_object~save( ).
+        lo_otgr->unlock( ).
+
+      CATCH cx_pak_invalid_state cx_pak_invalid_data cx_pak_not_authorized INTO lx_pak_error.
+        lo_otgr->unlock( ).
+
+        lv_text = lx_pak_error->get_text( ).
+        zcx_abapgit_exception=>raise( |OTGR { ms_item-obj_name }: delete: { lv_text }| ).
+    ENDTRY.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_object~deserialize.
+    DATA: ls_otgr        TYPE ty_otgr,
+          lo_otgr        TYPE REF TO cl_cls_object_type_group,
+          lx_pak_error   TYPE REF TO cx_root,
+          lv_text        TYPE string.
+
+    FIELD-SYMBOLS: <ls_groupt>  LIKE LINE OF ls_otgr-texts,
+                   <ls_element> LIKE LINE OF ls_otgr-elements,
+                   <ls_parent>  LIKE LINE OF ls_otgr-parents.
+
+    io_xml->read( EXPORTING iv_name = 'OTGR'
+                  CHANGING cg_data = ls_otgr ).
+
+    LOOP AT ls_otgr-texts ASSIGNING <ls_groupt>.
+      <ls_groupt>-activation_state = cl_pak_wb_domains=>co_activation_state-inactive.
+      " Removed in the method serialize.
+      <ls_groupt>-name = ms_item-obj_name.
+    ENDLOOP.
+
+    LOOP AT ls_otgr-parents ASSIGNING <ls_parent>.
+      <ls_parent>-activation_state = cl_pak_wb_domains=>co_activation_state-inactive.
+      " Removed in the method serialize.
+      <ls_parent>-obj_type_group = ms_item-obj_name.
+    ENDLOOP.
+
+    LOOP AT ls_otgr-elements ASSIGNING <ls_element>.
+      <ls_element>-activation_state = cl_pak_wb_domains=>co_activation_state-inactive.
+      " Removed in the method serialize.
+      <ls_element>-obj_type_group = ms_item-obj_name.
+    ENDLOOP.
+
+    tadir_insert( iv_package ).
+
+    lo_otgr = instantiate_and_lock_otgr( ).
+
+    TRY.
+        lo_otgr->if_cls_object_type_group~set_proxy_filter( ls_otgr-cls_type_group-proxy_flag ).
+        lo_otgr->if_cls_object_type_group~set_elements( ls_otgr-elements ).
+        lo_otgr->if_cls_object_type_group~set_parent_groups( ls_otgr-parents ).
+
+        set_default_package( iv_package ).
+
+        lo_otgr->if_pak_wb_object~save( ).
+
+        " Cannot use set_description because it sets only the master language.
+        INSERT cls_type_groupt FROM TABLE ls_otgr-texts.
+
+        lo_otgr->if_pak_wb_object~activate( ).
+        lo_otgr->unlock( ).
+
+      CATCH cx_pak_invalid_state cx_pak_invalid_data cx_pak_not_authorized INTO lx_pak_error.
+        lo_otgr->unlock( ).
+
+        lv_text = lx_pak_error->get_text( ).
+        zcx_abapgit_exception=>raise( |OTGR { ms_item-obj_name }: deserialize: { lv_text }| ).
+    ENDTRY.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_object~exists.
+    rv_bool = cl_cls_object_type_group=>exists_object_type_group( ms_item-obj_name ).
+  ENDMETHOD.
+
+  METHOD zif_abapgit_object~get_comparator.
+    RETURN.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_object~get_deserialize_steps.
+    APPEND zif_abapgit_object=>gc_step_id-abap TO rt_steps.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_object~get_metadata.
+    rs_metadata = get_metadata( ).
+  ENDMETHOD.
+
+  METHOD zif_abapgit_object~is_active.
+    rv_active = is_active( ).
+  ENDMETHOD.
+
+  METHOD zif_abapgit_object~is_locked.
+    rv_is_locked = exists_a_lock_entry_for( iv_lock_object = 'ECLS_ATTRIBUTE'
+                                            iv_argument    = |{ ms_item-obj_name }*| ).
+  ENDMETHOD.
+
+  METHOD zif_abapgit_object~jump.
+    CALL FUNCTION 'RS_TOOL_ACCESS'
+      EXPORTING
+        operation           = 'SHOW'
+        object_name         = ms_item-obj_name
+        object_type         = ms_item-obj_type
+      EXCEPTIONS
+        not_executed        = 1
+        invalid_object_type = 2
+        OTHERS              = 3.
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error from RS_TOOL_ACCESS, CHAR| ).
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD zif_abapgit_object~serialize.
+    DATA: lv_text      TYPE string,
+          ls_otgr      TYPE ty_otgr,
+          lo_otgr      TYPE REF TO cl_cls_object_type_group,
+          lt_lang_sel  TYPE RANGE OF langu,
+          ls_lang_sel  LIKE LINE OF lt_lang_sel,
+          lx_pak_error TYPE REF TO cx_root.
+
+    FIELD-SYMBOLS: <ls_groupt>  LIKE LINE OF ls_otgr-texts,
+                   <ls_element> LIKE LINE OF ls_otgr-elements,
+                   <ls_parent>  LIKE LINE OF ls_otgr-parents.
+
+    lo_otgr = instantiate_and_lock_otgr( ).
+
+    TRY.
+        ls_otgr-cls_type_group-name = lo_otgr->if_cls_object_type_group~get_name( ).
+        ls_otgr-cls_type_group-proxy_flag = lo_otgr->if_cls_object_type_group~get_proxy_filter( ).
+        lo_otgr->get_elements( IMPORTING ex_elements = ls_otgr-elements ).
+
+        lo_otgr->unlock( ).
+
+      CATCH cx_pak_invalid_state cx_pak_invalid_data cx_pak_not_authorized INTO lx_pak_error.
+        lo_otgr->unlock( ).
+
+        lv_text = lx_pak_error->get_text( ).
+        zcx_abapgit_exception=>raise( |OTGR { ms_item-obj_name }: serialize: { lv_text }| ).
+    ENDTRY.
+
+    CLEAR: ls_otgr-cls_type_group-created_by,
+           ls_otgr-cls_type_group-created_on,
+           ls_otgr-cls_type_group-changed_by,
+           ls_otgr-cls_type_group-changed_on.
+
+    IF io_xml->i18n_params( )-serialize_master_lang_only = abap_true.
+      ls_lang_sel-low = mv_language.
+      ls_lang_sel-sign = 'I'.
+      ls_lang_sel-option = 'EQ'.
+    ENDIF.
+
+    SELECT * FROM cls_type_groupt INTO TABLE ls_otgr-texts
+      WHERE name = ms_item-obj_name
+        AND activation_state = 'A'
+        AND langu IN lt_lang_sel.
+
+    SELECT * FROM cls_tygr_parent INTO TABLE ls_otgr-parents
+      WHERE obj_type_group = ms_item-obj_name
+        AND activation_state = 'A'.
+
+    LOOP AT ls_otgr-texts ASSIGNING <ls_groupt>.
+      " Not necessary as we serialize only Active
+      CLEAR <ls_groupt>-activation_state.
+      " Not necessary as we have it in the root XML node
+      CLEAR <ls_groupt>-name.
+    ENDLOOP.
+
+    LOOP AT ls_otgr-elements ASSIGNING <ls_element>.
+      " Not necessary as we serialize only Active
+      CLEAR <ls_element>-activation_state.
+      " Not necessary as we have it in the root XML node
+      CLEAR <ls_element>-obj_type_group.
+    ENDLOOP.
+
+    LOOP AT ls_otgr-parents ASSIGNING <ls_parent>.
+      " Not necessary as we serialize only Active
+      CLEAR <ls_parent>-activation_state.
+      " Not necessary as we have it in the root XML node
+      CLEAR <ls_parent>-obj_type_group.
+    ENDLOOP.
+
+    io_xml->add( iv_name = 'OTGR'
+                 ig_data = ls_otgr ).
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/objects/zcl_abapgit_object_otgr.clas.xml
+++ b/src/objects/zcl_abapgit_object_otgr.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_OBJECT_OTGR</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>OTGR</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
CHAR objects depend on OTGR objects. Pulling a repo with CHAR + OTGR leads into activation errors of the CHAR objects because of not yet activated OTGR. I was hoping native support will get it fixed (as suggested by Marcello) but it didn't work and I am still getting the activation error. At least, we can save some github disk space by a less verbose XML format for OTGR.