### PR TITLE
Don't run code inspector in parallel when disabled

### DIFF
--- a/src/zcl_abapgit_code_inspector.clas.abap
+++ b/src/zcl_abapgit_code_inspector.clas.abap
@@ -355,6 +355,6 @@ CLASS zcl_abapgit_code_inspector IMPLEMENTATION.
       rv_run_mode = co_run_mode-run_via_rfc.
     ENDIF.
 
-ENDMETHOD.
+  ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcl_abapgit_code_inspector.clas.abap
+++ b/src/zcl_abapgit_code_inspector.clas.abap
@@ -131,8 +131,6 @@ CLASS zcl_abapgit_code_inspector IMPLEMENTATION.
     " Because we want to persist them so we can run it in parallel.
     " Both are deleted afterwards.
     mv_name = |{ sy-uname }_{ sy-datum }_{ sy-uzeit }|.
-
-    " We have to disable parallelization in batch because of lock errors.
     mv_run_mode = decide_run_mode( ).
 
   ENDMETHOD.
@@ -348,6 +346,7 @@ CLASS zcl_abapgit_code_inspector IMPLEMENTATION.
     lo_settings = zcl_abapgit_persist_settings=>get_instance( )->read( ).
 
     IF sy-batch = abap_true.
+      " We have to disable parallelization in batch because of lock errors.
       rv_run_mode = co_run_mode-run_via_rfc.
     ELSEIF lo_settings->get_parallel_proc_disabled( ) = abap_false.
       rv_run_mode = co_run_mode-run_loc_parallel.

--- a/src/zcl_abapgit_code_inspector.clas.abap
+++ b/src/zcl_abapgit_code_inspector.clas.abap
@@ -40,14 +40,16 @@ CLASS zcl_abapgit_code_inspector DEFINITION
   PRIVATE SECTION.
 
     DATA mv_success TYPE abap_bool .
+
+    TYPES: t_run_mode TYPE sychar01.
     CONSTANTS:
       BEGIN OF co_run_mode,
-        run_with_popup   TYPE sychar01 VALUE 'P',
-        run_after_popup  TYPE sychar01 VALUE 'A',
-        run_via_rfc      TYPE sychar01 VALUE 'R',
-        run_in_batch     TYPE sychar01 VALUE 'B',
-        run_loc_parallel TYPE sychar01 VALUE 'L',
-        run_direct       TYPE sychar01 VALUE 'L',
+        run_with_popup   TYPE t_run_mode VALUE 'P',
+        run_after_popup  TYPE t_run_mode VALUE 'A',
+        run_via_rfc      TYPE t_run_mode VALUE 'R',
+        run_in_batch     TYPE t_run_mode VALUE 'B',
+        run_loc_parallel TYPE t_run_mode VALUE 'L',
+        run_direct       TYPE t_run_mode VALUE 'L',
       END OF co_run_mode .
     DATA mo_inspection TYPE REF TO cl_ci_inspection .
     DATA mv_name TYPE sci_objs .
@@ -66,12 +68,16 @@ CLASS zcl_abapgit_code_inspector DEFINITION
         zcx_abapgit_exception .
     METHODS create_inspection
       IMPORTING
-        !io_set              TYPE REF TO cl_ci_objectset
-        !io_variant          TYPE REF TO cl_ci_checkvariant
+        io_set               TYPE REF TO cl_ci_objectset
+        io_variant           TYPE REF TO cl_ci_checkvariant
       RETURNING
         VALUE(ro_inspection) TYPE REF TO cl_ci_inspection
       RAISING
         zcx_abapgit_exception .
+
+    METHODS decide_run_mode
+      RETURNING
+        VALUE(rv_run_mode) TYPE t_run_mode.
 ENDCLASS.
 
 
@@ -127,11 +133,7 @@ CLASS zcl_abapgit_code_inspector IMPLEMENTATION.
     mv_name = |{ sy-uname }_{ sy-datum }_{ sy-uzeit }|.
 
     " We have to disable parallelization in batch because of lock errors.
-    IF sy-batch = abap_true.
-      mv_run_mode = co_run_mode-run_via_rfc.
-    ELSE.
-      mv_run_mode = co_run_mode-run_loc_parallel.
-    ENDIF.
+    mv_run_mode = decide_run_mode( ).
 
   ENDMETHOD.
 
@@ -339,4 +341,21 @@ CLASS zcl_abapgit_code_inspector IMPLEMENTATION.
     ENDTRY.
 
   ENDMETHOD.
+
+  METHOD decide_run_mode.
+
+    DATA: lo_settings TYPE REF TO zcl_abapgit_settings.
+    lo_settings = zcl_abapgit_persist_settings=>get_instance( )->read( ).
+
+    IF sy-batch = abap_true.
+      rv_run_mode = co_run_mode-run_via_rfc.
+    ELSE.
+      IF lo_settings->get_parallel_proc_disabled( ) = abap_true.
+        rv_run_mode = co_run_mode-run_via_rfc.
+      ELSE.
+        rv_run_mode = co_run_mode-run_loc_parallel.
+      ENDIF.
+    ENDIF.
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/zcl_abapgit_code_inspector.clas.abap
+++ b/src/zcl_abapgit_code_inspector.clas.abap
@@ -349,13 +349,12 @@ CLASS zcl_abapgit_code_inspector IMPLEMENTATION.
 
     IF sy-batch = abap_true.
       rv_run_mode = co_run_mode-run_via_rfc.
+    ELSEIF lo_settings->get_parallel_proc_disabled( ) = abap_false.
+      rv_run_mode = co_run_mode-run_loc_parallel.
     ELSE.
-      IF lo_settings->get_parallel_proc_disabled( ) = abap_true.
-        rv_run_mode = co_run_mode-run_via_rfc.
-      ELSE.
-        rv_run_mode = co_run_mode-run_loc_parallel.
-      ENDIF.
+      rv_run_mode = co_run_mode-run_via_rfc.
     ENDIF.
-  ENDMETHOD.
+
+ENDMETHOD.
 
 ENDCLASS.


### PR DESCRIPTION
If this is checked in the settings,
![image](https://user-images.githubusercontent.com/5097067/81181734-2fa9e900-8fad-11ea-8df2-24827cd52c1c.png)

then code inspector/syntax check will now run synchronously.
