### PR TITLE
Gui refactoring, chapter 3

### DIFF
--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -339,6 +339,8 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
     ENDIF.
 
     CLEAR mt_event_handlers.
+    mo_html_parts->clear( ).
+
     IF mi_router IS BOUND.
       APPEND mi_router TO mt_event_handlers.
     ENDIF.

--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -21,8 +21,6 @@ CLASS zcl_abapgit_gui DEFINITION
       END OF c_action.
 
     INTERFACES zif_abapgit_gui_services.
-    ALIASES:
-      cache_asset FOR zif_abapgit_gui_services~cache_asset.
 
     METHODS go_home
       RAISING
@@ -71,14 +69,16 @@ CLASS zcl_abapgit_gui DEFINITION
         bookmark TYPE abap_bool,
       END OF ty_page_stack.
 
-    DATA: mi_cur_page       TYPE REF TO zif_abapgit_gui_renderable,
-          mt_stack          TYPE STANDARD TABLE OF ty_page_stack,
-          mt_event_handlers TYPE STANDARD TABLE OF REF TO zif_abapgit_gui_event_handler,
-          mi_router         TYPE REF TO zif_abapgit_gui_event_handler,
-          mi_asset_man      TYPE REF TO zif_abapgit_gui_asset_manager,
-          mi_hotkey_ctl     TYPE REF TO zif_abapgit_gui_hotkey_ctl,
-          mi_html_processor TYPE REF TO zif_abapgit_gui_html_processor,
-          mo_html_viewer    TYPE REF TO cl_gui_html_viewer.
+    DATA:
+      mi_cur_page       TYPE REF TO zif_abapgit_gui_renderable,
+      mt_stack          TYPE STANDARD TABLE OF ty_page_stack,
+      mt_event_handlers TYPE STANDARD TABLE OF REF TO zif_abapgit_gui_event_handler,
+      mi_router         TYPE REF TO zif_abapgit_gui_event_handler,
+      mi_asset_man      TYPE REF TO zif_abapgit_gui_asset_manager,
+      mi_hotkey_ctl     TYPE REF TO zif_abapgit_gui_hotkey_ctl,
+      mi_html_processor TYPE REF TO zif_abapgit_gui_html_processor,
+      mo_html_viewer    TYPE REF TO cl_gui_html_viewer,
+      mo_html_parts     TYPE REF TO zcl_abapgit_html_parts.
 
     METHODS startup
       RAISING
@@ -150,48 +150,9 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD cache_asset.
-
-    DATA: lv_xstr  TYPE xstring,
-          lt_xdata TYPE lvc_t_mime,
-          lv_size  TYPE int4.
-
-    ASSERT iv_text IS SUPPLIED OR iv_xdata IS SUPPLIED.
-
-    IF iv_text IS SUPPLIED. " String input
-      lv_xstr = zcl_abapgit_convert=>string_to_xstring( iv_text ).
-    ELSE. " Raw input
-      lv_xstr = iv_xdata.
-    ENDIF.
-
-    zcl_abapgit_convert=>xstring_to_bintab(
-      EXPORTING
-        iv_xstr   = lv_xstr
-      IMPORTING
-        ev_size   = lv_size
-        et_bintab = lt_xdata ).
-
-    mo_html_viewer->load_data(
-      EXPORTING
-        type         = iv_type
-        subtype      = iv_subtype
-        size         = lv_size
-        url          = iv_url
-      IMPORTING
-        assigned_url = rv_url
-      CHANGING
-        data_table   = lt_xdata
-      EXCEPTIONS
-        OTHERS       = 1 ) ##NO_TEXT.
-
-    ASSERT sy-subrc = 0. " Image data error
-
-  ENDMETHOD.
-
-
   METHOD cache_html.
 
-    rv_url = cache_asset(
+    rv_url = zif_abapgit_gui_services~cache_asset(
       iv_text    = iv_text
       iv_type    = 'text'
       iv_subtype = 'html' ).
@@ -227,6 +188,8 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
         mi_router ?= io_component.
       ENDIF.
     ENDIF.
+
+    CREATE OBJECT mo_html_parts.
 
     mi_asset_man      = ii_asset_man.
     mi_hotkey_ctl     = ii_hotkey_ctl.
@@ -415,7 +378,7 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
     IF mi_asset_man IS BOUND.
       lt_assets = mi_asset_man->get_all_assets( ).
       LOOP AT lt_assets ASSIGNING <ls_asset> WHERE is_cacheable = abap_true.
-        cache_asset( iv_xdata   = <ls_asset>-content
+        zif_abapgit_gui_services~cache_asset( iv_xdata   = <ls_asset>-content
                      iv_url     = <ls_asset>-url
                      iv_type    = <ls_asset>-type
                      iv_subtype = <ls_asset>-subtype ).
@@ -432,6 +395,45 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_gui_services~cache_asset.
+
+    DATA: lv_xstr  TYPE xstring,
+          lt_xdata TYPE lvc_t_mime,
+          lv_size  TYPE int4.
+
+    ASSERT iv_text IS SUPPLIED OR iv_xdata IS SUPPLIED.
+
+    IF iv_text IS SUPPLIED. " String input
+      lv_xstr = zcl_abapgit_convert=>string_to_xstring( iv_text ).
+    ELSE. " Raw input
+      lv_xstr = iv_xdata.
+    ENDIF.
+
+    zcl_abapgit_convert=>xstring_to_bintab(
+      EXPORTING
+        iv_xstr   = lv_xstr
+      IMPORTING
+        ev_size   = lv_size
+        et_bintab = lt_xdata ).
+
+    mo_html_viewer->load_data(
+      EXPORTING
+        type         = iv_type
+        subtype      = iv_subtype
+        size         = lv_size
+        url          = iv_url
+      IMPORTING
+        assigned_url = rv_url
+      CHANGING
+        data_table   = lt_xdata
+      EXCEPTIONS
+        OTHERS       = 1 ) ##NO_TEXT.
+
+    ASSERT sy-subrc = 0. " Image data error
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_gui_services~get_current_page_name.
 
     IF mi_cur_page IS BOUND.
@@ -443,6 +445,11 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_services~get_hotkeys_ctl.
     ri_hotkey_ctl = mi_hotkey_ctl.
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_services~get_html_parts.
+    ro_parts = mo_html_parts.
   ENDMETHOD.
 
 

--- a/src/ui/core/zcl_abapgit_gui_html_processor.clas.testclasses.abap
+++ b/src/ui/core/zcl_abapgit_gui_html_processor.clas.testclasses.abap
@@ -27,6 +27,8 @@ CLASS ltcl_gui_mock IMPLEMENTATION.
   ENDMETHOD.
   METHOD zif_abapgit_gui_services~get_hotkeys_ctl.
   ENDMETHOD.
+  METHOD zif_abapgit_gui_services~get_html_parts.
+  ENDMETHOD.
 
   METHOD get_asset.
     rs_asset = ms_last_cache_signature.

--- a/src/ui/core/zcl_abapgit_html_parts.clas.abap
+++ b/src/ui/core/zcl_abapgit_html_parts.clas.abap
@@ -61,7 +61,7 @@ CLASS ZCL_ABAPGIT_HTML_PARTS IMPLEMENTATION.
 
 
   METHOD clear.
-    clear mt_part_collections.
+    CLEAR mt_part_collections.
   ENDMETHOD.
 
 

--- a/src/ui/core/zcl_abapgit_html_parts.clas.abap
+++ b/src/ui/core/zcl_abapgit_html_parts.clas.abap
@@ -13,7 +13,7 @@ CLASS zcl_abapgit_html_parts DEFINITION
       IMPORTING
         !iv_collection TYPE string
       RETURNING
-        VALUE(rt_parts) TYPE zif_abapgit_html=>tty_collection .
+        VALUE(rt_parts) TYPE zif_abapgit_html=>tty_table_of .
     METHODS get_collection_names
       RETURNING
         VALUE(rt_list) TYPE string_table .
@@ -22,12 +22,13 @@ CLASS zcl_abapgit_html_parts DEFINITION
         !iv_collection TYPE string
       RETURNING
         VALUE(rv_size) TYPE i .
+    METHODS clear.
   PROTECTED SECTION.
   PRIVATE SECTION.
     TYPES:
       BEGIN OF ty_named_collection,
         name TYPE string,
-        pile TYPE zif_abapgit_html=>tty_collection,
+        pile TYPE zif_abapgit_html=>tty_table_of,
       END OF ty_named_collection.
     TYPES:
       tty_named_collection TYPE STANDARD TABLE OF ty_named_collection WITH KEY name.
@@ -56,6 +57,11 @@ CLASS ZCL_ABAPGIT_HTML_PARTS IMPLEMENTATION.
       iv_create_if_missing = abap_true ).
     APPEND ii_part TO lr_collection->pile.
 
+  ENDMETHOD.
+
+
+  METHOD clear.
+    clear mt_part_collections.
   ENDMETHOD.
 
 

--- a/src/ui/core/zcl_abapgit_html_parts.clas.abap
+++ b/src/ui/core/zcl_abapgit_html_parts.clas.abap
@@ -1,0 +1,103 @@
+CLASS zcl_abapgit_html_parts DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    METHODS add_part
+      IMPORTING
+        !iv_collection TYPE string
+        !ii_part TYPE REF TO zif_abapgit_html .
+    METHODS get_parts
+      IMPORTING
+        !iv_collection TYPE string
+      RETURNING
+        VALUE(rt_parts) TYPE zif_abapgit_html=>tty_collection .
+    METHODS get_collection_names
+      RETURNING
+        VALUE(rt_list) TYPE string_table .
+    METHODS get_collection_size
+      IMPORTING
+        !iv_collection TYPE string
+      RETURNING
+        VALUE(rv_size) TYPE i .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    TYPES:
+      BEGIN OF ty_named_collection,
+        name TYPE string,
+        pile TYPE zif_abapgit_html=>tty_collection,
+      END OF ty_named_collection.
+    TYPES:
+      tty_named_collection TYPE STANDARD TABLE OF ty_named_collection WITH KEY name.
+
+    DATA mt_part_collections TYPE tty_named_collection.
+
+    METHODS get_collection
+      IMPORTING
+        !iv_collection TYPE string
+        !iv_create_if_missing TYPE abap_bool DEFAULT abap_false
+      RETURNING
+        VALUE(rr_collection) TYPE REF TO ty_named_collection .
+
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPGIT_HTML_PARTS IMPLEMENTATION.
+
+
+  METHOD add_part.
+
+    DATA lr_collection TYPE REF TO ty_named_collection.
+    lr_collection = get_collection(
+      iv_collection = iv_collection
+      iv_create_if_missing = abap_true ).
+    APPEND ii_part TO lr_collection->pile.
+
+  ENDMETHOD.
+
+
+  METHOD get_collection.
+
+    READ TABLE mt_part_collections REFERENCE INTO rr_collection WITH KEY name = iv_collection.
+    IF sy-subrc <> 0 AND iv_create_if_missing = abap_true.
+      APPEND INITIAL LINE TO mt_part_collections REFERENCE INTO rr_collection.
+      rr_collection->name = iv_collection.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD get_collection_names.
+
+    FIELD-SYMBOLS <ls_coll> LIKE LINE OF mt_part_collections.
+    LOOP AT mt_part_collections ASSIGNING <ls_coll>.
+      APPEND <ls_coll>-name TO rt_list.
+    ENDLOOP.
+
+  ENDMETHOD.
+
+
+  METHOD get_collection_size.
+
+    DATA lr_collection TYPE REF TO ty_named_collection.
+    lr_collection = get_collection( iv_collection ).
+    IF lr_collection IS BOUND.
+      rv_size = lines( lr_collection->pile ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD get_parts.
+
+    DATA lr_collection TYPE REF TO ty_named_collection.
+    lr_collection = get_collection( iv_collection ).
+    IF lr_collection IS BOUND.
+      rt_parts = lr_collection->pile.
+    ENDIF.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/ui/core/zcl_abapgit_html_parts.clas.testclasses.abap
+++ b/src/ui/core/zcl_abapgit_html_parts.clas.testclasses.abap
@@ -1,0 +1,87 @@
+CLASS ltcl_part_collections DEFINITION
+  FOR TESTING
+  RISK LEVEL HARMLESS
+  DURATION SHORT
+  FINAL.
+
+  PUBLIC SECTION.
+
+  PRIVATE SECTION.
+
+    METHODS test FOR TESTING.
+
+ENDCLASS.
+
+CLASS ltcl_part_collections IMPLEMENTATION.
+
+  METHOD test.
+
+    DATA lo_html1 TYPE REF TO zcl_abapgit_html.
+    DATA lo_html2 TYPE REF TO zcl_abapgit_html.
+    DATA lo_html3 TYPE REF TO zcl_abapgit_html.
+    DATA lo_html_tmp TYPE REF TO zif_abapgit_html.
+    DATA lo_parts TYPE REF TO zcl_abapgit_html_parts.
+    DATA lt_col_exp TYPE string_table.
+    DATA lt_parts_act TYPE zif_abapgit_html=>tty_collection.
+
+    CREATE OBJECT lo_html1.
+    CREATE OBJECT lo_html2.
+    CREATE OBJECT lo_html3.
+
+    CREATE OBJECT lo_parts.
+    lo_parts->add_part(
+      iv_collection = 'ABC'
+      ii_part = lo_html1 ).
+    lo_parts->add_part(
+      iv_collection = 'ABC'
+      ii_part = lo_html2 ).
+    lo_parts->add_part(
+      iv_collection = 'XYZ'
+      ii_part = lo_html3 ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_parts->get_collection_size( 'ABC' )
+      exp = 2 ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_parts->get_collection_size( 'XYZ' )
+      exp = 1 ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_parts->get_collection_size( '123' )
+      exp = 0 ).
+
+    APPEND 'ABC' TO lt_col_exp.
+    APPEND 'XYZ' TO lt_col_exp.
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_parts->get_collection_names( )
+      exp = lt_col_exp ).
+
+    lt_parts_act = lo_parts->get_parts( 'ABC' ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lines( lt_parts_act )
+      exp = 2 ).
+    READ TABLE lt_parts_act INTO lo_html_tmp INDEX 1.
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_html_tmp
+      exp = lo_html1 ).
+    READ TABLE lt_parts_act INTO lo_html_tmp INDEX 2.
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_html_tmp
+      exp = lo_html2 ).
+
+    lt_parts_act = lo_parts->get_parts( 'XYZ' ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lines( lt_parts_act )
+      exp = 1 ).
+    READ TABLE lt_parts_act INTO lo_html_tmp INDEX 1.
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_html_tmp
+      exp = lo_html3 ).
+
+    lt_parts_act = lo_parts->get_parts( '123' ).
+    cl_abap_unit_assert=>assert_initial( lt_parts_act ).
+
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/ui/core/zcl_abapgit_html_parts.clas.testclasses.abap
+++ b/src/ui/core/zcl_abapgit_html_parts.clas.testclasses.abap
@@ -22,7 +22,7 @@ CLASS ltcl_part_collections IMPLEMENTATION.
     DATA lo_html_tmp TYPE REF TO zif_abapgit_html.
     DATA lo_parts TYPE REF TO zcl_abapgit_html_parts.
     DATA lt_col_exp TYPE string_table.
-    DATA lt_parts_act TYPE zif_abapgit_html=>tty_collection.
+    DATA lt_parts_act TYPE zif_abapgit_html=>tty_table_of.
 
     CREATE OBJECT lo_html1.
     CREATE OBJECT lo_html2.
@@ -81,6 +81,8 @@ CLASS ltcl_part_collections IMPLEMENTATION.
     lt_parts_act = lo_parts->get_parts( '123' ).
     cl_abap_unit_assert=>assert_initial( lt_parts_act ).
 
+    lo_parts->clear( ).
+    cl_abap_unit_assert=>assert_initial( lo_parts->get_collection_names( ) ).
 
   ENDMETHOD.
 

--- a/src/ui/core/zcl_abapgit_html_parts.clas.xml
+++ b/src/ui/core/zcl_abapgit_html_parts.clas.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_HTML_PARTS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapgit html parts collects</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/core/zif_abapgit_gui_services.intf.abap
+++ b/src/ui/core/zif_abapgit_gui_services.intf.abap
@@ -23,4 +23,8 @@ INTERFACE zif_abapgit_gui_services
     RETURNING
       VALUE(ri_hotkey_ctl) TYPE REF TO zif_abapgit_gui_hotkey_ctl.
 
+  METHODS get_html_parts
+    RETURNING
+      VALUE(ro_parts) TYPE REF TO zcl_abapgit_html_parts.
+
 ENDINTERFACE.

--- a/src/ui/core/zif_abapgit_html.intf.abap
+++ b/src/ui/core/zif_abapgit_html.intf.abap
@@ -15,6 +15,9 @@ INTERFACE zif_abapgit_html PUBLIC.
       crossout TYPE c VALUE 'X',
     END OF c_html_opt .
 
+  TYPES:
+    tty_collection TYPE STANDARD TABLE OF REF TO zif_abapgit_html WITH DEFAULT KEY.
+
   METHODS add
     IMPORTING
       !ig_chunk TYPE any .

--- a/src/ui/core/zif_abapgit_html.intf.abap
+++ b/src/ui/core/zif_abapgit_html.intf.abap
@@ -16,7 +16,7 @@ INTERFACE zif_abapgit_html PUBLIC.
     END OF c_html_opt .
 
   TYPES:
-    tty_collection TYPE STANDARD TABLE OF REF TO zif_abapgit_html WITH DEFAULT KEY.
+    tty_table_of TYPE STANDARD TABLE OF REF TO zif_abapgit_html WITH DEFAULT KEY.
 
   METHODS add
     IMPORTING

--- a/src/ui/zcl_abapgit_gui_component.clas.abap
+++ b/src/ui/zcl_abapgit_gui_component.clas.abap
@@ -4,6 +4,12 @@ CLASS zcl_abapgit_gui_component DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
+
+    CONSTANTS:
+      BEGIN OF c_html_parts,
+        scripts TYPE string VALUE 'scripts',
+      END OF c_html_parts.
+
     METHODS constructor RAISING zcx_abapgit_exception.
   PROTECTED SECTION.
     DATA mi_gui_services TYPE REF TO zif_abapgit_gui_services.

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -41,8 +41,10 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
       RAISING   zcx_abapgit_exception.
 
     METHODS scripts
-      RETURNING VALUE(ro_html) TYPE REF TO zcl_abapgit_html
-      RAISING   zcx_abapgit_exception.
+      RETURNING
+        VALUE(ro_html) TYPE REF TO zcl_abapgit_html
+      RAISING
+        zcx_abapgit_exception.
 
   PRIVATE SECTION.
     DATA: mo_settings         TYPE REF TO zcl_abapgit_settings,
@@ -61,12 +63,6 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
       RETURNING VALUE(ro_html) TYPE REF TO zcl_abapgit_html.
 
     METHODS link_hints
-      IMPORTING
-        io_html TYPE REF TO zcl_abapgit_html
-      RAISING
-        zcx_abapgit_exception.
-
-    METHODS insert_hotkeys_to_page
       IMPORTING
         io_html TYPE REF TO zcl_abapgit_html
       RAISING
@@ -193,34 +189,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD insert_hotkeys_to_page.
-
-    DATA lv_json TYPE string.
-    DATA lt_hotkeys TYPE zif_abapgit_gui_hotkeys=>tty_hotkey_with_descr.
-
-    FIELD-SYMBOLS: <ls_hotkey> LIKE LINE OF lt_hotkeys.
-
-    lt_hotkeys = mi_gui_services->get_hotkeys_ctl( )->get_registered_hotkeys( ).
-
-    lv_json = `{`.
-
-    LOOP AT lt_hotkeys ASSIGNING <ls_hotkey>.
-
-      IF sy-tabix > 1.
-        lv_json = lv_json && |,|.
-      ENDIF.
-
-      lv_json = lv_json && |  "{ <ls_hotkey>-hotkey }" : "{ <ls_hotkey>-action }" |.
-
-    ENDLOOP.
-
-    lv_json = lv_json && `}`.
-
-    io_html->add( |setKeyBindings({ lv_json });| ).
-
-  ENDMETHOD.
-
-
   METHOD link_hints.
 
     DATA: lv_link_hint_key TYPE char01.
@@ -302,10 +270,17 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
 
   METHOD scripts.
 
+    DATA lt_script_parts TYPE zif_abapgit_html=>tty_table_of.
+    DATA li_part LIKE LINE OF lt_script_parts.
+
     CREATE OBJECT ro_html.
 
+    lt_script_parts = mi_gui_services->get_html_parts( )->get_parts( c_html_parts-scripts ).
+    LOOP AT lt_script_parts INTO li_part.
+      ro_html->add( li_part ).
+    ENDLOOP.
+
     link_hints( ro_html ).
-    insert_hotkeys_to_page( ro_html ).
 
     ro_html->add( 'var gGoRepoPalette = new CommandPalette(enumerateTocAllRepos, {' ).
     ro_html->add( '  toggleKey: "F2",' ).

--- a/src/ui/zcl_abapgit_hotkeys.clas.abap
+++ b/src/ui/zcl_abapgit_hotkeys.clas.abap
@@ -81,7 +81,13 @@ CLASS zcl_abapgit_hotkeys DEFINITION
         RETURNING
           VALUE(rt_interface_implementations) TYPE saboo_iimpt
         RAISING
-          zcx_abapgit_exception.
+          zcx_abapgit_exception,
+
+      render_js_part
+        IMPORTING
+          it_hotkeys TYPE zif_abapgit_gui_hotkeys=>tty_hotkey_with_descr
+        RETURNING
+          VALUE(ro_html) TYPE REF TO zcl_abapgit_html.
 
 ENDCLASS.
 
@@ -253,6 +259,33 @@ CLASS ZCL_ABAPGIT_HOTKEYS IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD render_js_part.
+
+    DATA lv_json TYPE string.
+    DATA lt_hotkeys TYPE zif_abapgit_gui_hotkeys=>tty_hotkey_with_descr.
+
+    FIELD-SYMBOLS: <ls_hotkey> LIKE LINE OF lt_hotkeys.
+
+    lv_json = `{`.
+
+    LOOP AT it_hotkeys ASSIGNING <ls_hotkey>.
+
+      IF sy-tabix > 1.
+        lv_json = lv_json && |,|.
+      ENDIF.
+
+      lv_json = lv_json && |  "{ <ls_hotkey>-hotkey }" : "{ <ls_hotkey>-action }" |.
+
+    ENDLOOP.
+
+    lv_json = lv_json && `}`.
+
+    CREATE OBJECT ro_html.
+    ro_html->add( |setKeyBindings({ lv_json });| ).
+
+  ENDMETHOD.
+
+
   METHOD should_show_hint.
     IF gv_hint_was_shown = abap_false.
       rv_yes = abap_true.
@@ -325,6 +358,18 @@ CLASS ZCL_ABAPGIT_HOTKEYS IMPLEMENTATION.
 
     lt_registered_hotkeys = zif_abapgit_gui_hotkey_ctl~get_registered_hotkeys( ).
     SORT lt_registered_hotkeys BY ui_component description.
+
+    " Note
+    " normally render method should be able to call mi_gui_services->get_html_parts( )
+    " thus the class must inherit from zcl_abapgit_gui_component
+    " but problem is that component constructor calls get_gui which creates gui if it is missing
+    " and the hotkeys class itself is created during get_gui so it is infinite loop
+    " solutions: A) separate hotkeys into logic and render (which is actually a good way, but it so nicely fit together ...)
+    " B) convert mi_gui_services to a getter - which I will do but later
+
+    zcl_abapgit_ui_factory=>get_gui_services( )->get_html_parts( )->add_part(
+      iv_collection = zcl_abapgit_gui_component=>c_html_parts-scripts
+      ii_part       = render_js_part( lt_registered_hotkeys ) ).
 
     " Render hotkeys
     ri_html->add( '<ul class="hotkeys">' ).

--- a/src/ui/zcl_abapgit_hotkeys.clas.abap
+++ b/src/ui/zcl_abapgit_hotkeys.clas.abap
@@ -364,7 +364,8 @@ CLASS ZCL_ABAPGIT_HOTKEYS IMPLEMENTATION.
     " thus the class must inherit from zcl_abapgit_gui_component
     " but problem is that component constructor calls get_gui which creates gui if it is missing
     " and the hotkeys class itself is created during get_gui so it is infinite loop
-    " solutions: A) separate hotkeys into logic and render (which is actually a good way, but it so nicely fit together ...)
+    " solutions:
+    " A) separate hotkeys into logic and render (which is actually a good way, but it so nicely fit together ...)
     " B) convert mi_gui_services to a getter - which I will do but later
 
     zcl_abapgit_ui_factory=>get_gui_services( )->get_html_parts( )->add_part(

--- a/src/ui/zcl_abapgit_ui_injector.clas.locals_imp.abap
+++ b/src/ui/zcl_abapgit_ui_injector.clas.locals_imp.abap
@@ -18,4 +18,6 @@ CLASS lcl_gui_services_dummy IMPLEMENTATION.
   ENDMETHOD.
   METHOD zif_abapgit_gui_services~get_hotkeys_ctl.
   ENDMETHOD.
+  METHOD zif_abapgit_gui_services~get_html_parts.
+  ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
OK, more steps towards disentangling html components.

Main idea: 
- a new primitive - `ZCL_ABAPGIT_HTML_PARTS` - which is a collection of named sets of zcl_htmls
- a managed instance of it is accessible via `zif_abapgit_gui_services` and allows to store html chunk e.g. scripts or postponed hidden forms (stage_page) and render them later
- dev note: `zcl_abapgit_gui_component->c_html_parts` is the place to define "standard" cross-page part names

In addition one example is implemented to illustrate the flow within this PR - hotkeys script completely removed from `gui_page` and now rendered within `hotkeys` class where it should be rendered. `gui_page` is completely unaware of it which is good.

Further refactorings planned for `gui_page->get_events` (hidden forms) and maybe something else. Fill free to join :)

Ths is not the final chapter of GUI refactoring though - there is one conceptual bug I'g going to fix, see the comment in `hotkeys->render` code. And some more cleanups of `gui_page` are planned

P.S. some clutter in this PR: removed alias for `cache_asset`, could not pass by sorry.
