### PR TITLE
Some methods visibility changed as public for external tool

### DIFF
--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -7,6 +7,13 @@ CLASS zcl_abapgit_gui_router DEFINITION
 
     INTERFACES zif_abapgit_gui_event_handler.
 
+    CLASS-METHODS file_download
+      IMPORTING
+        !iv_package TYPE devclass
+        !iv_xstr    TYPE xstring
+      RAISING
+        zcx_abapgit_exception .
+
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -42,12 +49,6 @@ CLASS zcl_abapgit_gui_router DEFINITION
         !ev_state      TYPE i
       RAISING
         zcx_abapgit_exception.
-    CLASS-METHODS file_download
-      IMPORTING
-        !iv_package TYPE devclass
-        !iv_xstr    TYPE xstring
-      RAISING
-        zcx_abapgit_exception .
     METHODS git_services
       IMPORTING
         !is_event_data TYPE ty_event_data

--- a/src/zcl_abapgit_zip.clas.abap
+++ b/src/zcl_abapgit_zip.clas.abap
@@ -33,12 +33,6 @@ CLASS zcl_abapgit_zip DEFINITION
       IMPORTING iv_filename  TYPE string
                 iv_binstring TYPE xstring
       RAISING   zcx_abapgit_exception.
-
-  PROTECTED SECTION.
-
-    CLASS-DATA gv_prev TYPE string .
-  PRIVATE SECTION.
-
     CLASS-METHODS encode_files
       IMPORTING
         !it_files      TYPE zif_abapgit_definitions=>ty_files_item_tt
@@ -46,6 +40,12 @@ CLASS zcl_abapgit_zip DEFINITION
         VALUE(rv_xstr) TYPE xstring
       RAISING
         zcx_abapgit_exception .
+
+  PROTECTED SECTION.
+
+    CLASS-DATA gv_prev TYPE string .
+  PRIVATE SECTION.
+
     CLASS-METHODS filename
       IMPORTING
         !iv_str      TYPE string


### PR DESCRIPTION
Some methods visibility changed as public for external tool such as Namespace Changer: https://github.com/isisdanismanlik/NamespaceChanger