### PR TITLE
Gui refactoring part 4

### DIFF
--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -5,6 +5,12 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
 
   PUBLIC SECTION.
 
+    TYPES:
+      BEGIN OF ty_event_signature,
+        method TYPE string,
+        name   TYPE string,
+      END OF  ty_event_signature.
+
     CLASS-METHODS class_constructor.
     CLASS-METHODS render_error
       IMPORTING
@@ -89,6 +95,11 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
         VALUE(ro_html) TYPE REF TO zcl_abapgit_html
       RAISING
         zcx_abapgit_exception .
+    CLASS-METHODS render_event_as_form
+      IMPORTING
+        is_event       TYPE ty_event_signature
+      RETURNING
+        VALUE(ro_html) TYPE REF TO zcl_abapgit_html.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -328,6 +339,15 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
     ro_html->add( |{ lv_longtext }| ).
     ro_html->add( |</div>| ).
     ro_html->add( |</div>| ).
+
+  ENDMETHOD.
+
+
+  METHOD render_event_as_form.
+
+    CREATE OBJECT ro_html.
+    ro_html->add(
+      |<form id='form_{ is_event-name }' method={ is_event-method } action='sapevent:{ is_event-name }'></form>| ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_component.clas.abap
+++ b/src/ui/zcl_abapgit_gui_component.clas.abap
@@ -7,7 +7,8 @@ CLASS zcl_abapgit_gui_component DEFINITION
 
     CONSTANTS:
       BEGIN OF c_html_parts,
-        scripts TYPE string VALUE 'scripts',
+        scripts      TYPE string VALUE 'scripts',
+        hidden_forms TYPE string VALUE 'hidden_forms',
       END OF c_html_parts.
 
     METHODS constructor RAISING zcx_abapgit_exception.

--- a/src/ui/zcl_abapgit_gui_component.clas.abap
+++ b/src/ui/zcl_abapgit_gui_component.clas.abap
@@ -37,7 +37,7 @@ CLASS ZCL_ABAPGIT_GUI_COMPONENT IMPLEMENTATION.
   METHOD register_deferred_script.
     " TODO refactor to mi_gui_services getter !
     zcl_abapgit_ui_factory=>get_gui_services( )->get_html_parts( )->add_part(
-      iv_collection = zcl_abapgit_gui_component=>c_html_parts-scripts
+      iv_collection = c_html_parts-scripts
       ii_part       = ii_part ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_component.clas.abap
+++ b/src/ui/zcl_abapgit_gui_component.clas.abap
@@ -14,6 +14,13 @@ CLASS zcl_abapgit_gui_component DEFINITION
     METHODS constructor RAISING zcx_abapgit_exception.
   PROTECTED SECTION.
     DATA mi_gui_services TYPE REF TO zif_abapgit_gui_services.
+
+    METHODS register_deferred_script
+      IMPORTING
+        ii_part TYPE REF TO zif_abapgit_html
+      RAISING
+        zcx_abapgit_exception.
+
   PRIVATE SECTION.
 ENDCLASS.
 
@@ -24,5 +31,13 @@ CLASS ZCL_ABAPGIT_GUI_COMPONENT IMPLEMENTATION.
 
   METHOD constructor.
     mi_gui_services = zcl_abapgit_ui_factory=>get_gui_services( ).
+  ENDMETHOD.
+
+
+  METHOD register_deferred_script.
+    " TODO refactor to mi_gui_services getter !
+    zcl_abapgit_ui_factory=>get_gui_services( )->get_html_parts( )->add_part(
+      iv_collection = zcl_abapgit_gui_component=>c_html_parts-scripts
+      ii_part       = ii_part ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -53,7 +53,13 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
     METHODS redirect
       RETURNING VALUE(ro_html) TYPE REF TO zcl_abapgit_html.
 
-    METHODS link_hints
+    METHODS render_link_hints
+      IMPORTING
+        io_html TYPE REF TO zcl_abapgit_html
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS render_command_palettes
       IMPORTING
         io_html TYPE REF TO zcl_abapgit_html
       RAISING
@@ -173,23 +179,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD link_hints.
-
-    DATA: lv_link_hint_key TYPE char01.
-
-    lv_link_hint_key = mo_settings->get_link_hint_key( ).
-
-    IF mo_settings->get_link_hints_enabled( ) = abap_true AND lv_link_hint_key IS NOT INITIAL.
-
-      io_html->add( |activateLinkHints("{ lv_link_hint_key }");| ).
-      io_html->add( |setInitialFocusWithQuerySelector('a span', true);| ).
-      io_html->add( |enableArrowListNavigation();| ).
-
-    ENDIF.
-
-  ENDMETHOD.
-
-
   METHOD redirect.
 
     CREATE OBJECT ro_html.
@@ -200,6 +189,21 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
     ro_html->add( |<meta http-equiv="refresh" content="0; url={ ms_control-redirect_url }">| ). "#EC NOTEXT
     ro_html->add( '</head>' ).                              "#EC NOTEXT
     ro_html->add( '</html>' ).                              "#EC NOTEXT
+
+  ENDMETHOD.
+
+
+  METHOD render_command_palettes.
+
+    io_html->add( 'var gGoRepoPalette = new CommandPalette(enumerateTocAllRepos, {' ).
+    io_html->add( '  toggleKey: "F2",' ).
+    io_html->add( '  hotkeyDescription: "Go to repo ..."' ).
+    io_html->add( '});' ).
+
+    io_html->add( 'var gCommandPalette = new CommandPalette(enumerateToolbarActions, {' ).
+    io_html->add( '  toggleKey: "F1",' ).
+    io_html->add( '  hotkeyDescription: "Command ..."' ).
+    io_html->add( '});' ).
 
   ENDMETHOD.
 
@@ -256,10 +260,24 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD scripts.
+  METHOD render_link_hints.
 
-    DATA lt_script_parts TYPE zif_abapgit_html=>tty_table_of.
-    DATA li_part LIKE LINE OF lt_script_parts.
+    DATA: lv_link_hint_key TYPE char01.
+
+    lv_link_hint_key = mo_settings->get_link_hint_key( ).
+
+    IF mo_settings->get_link_hints_enabled( ) = abap_true AND lv_link_hint_key IS NOT INITIAL.
+
+      io_html->add( |activateLinkHints("{ lv_link_hint_key }");| ).
+      io_html->add( |setInitialFocusWithQuerySelector('a span', true);| ).
+      io_html->add( |enableArrowListNavigation();| ).
+
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD scripts.
 
     CREATE OBJECT ro_html.
 
@@ -267,17 +285,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE IMPLEMENTATION.
       ii_html          = ro_html
       iv_part_category = c_html_parts-scripts ).
 
-    link_hints( ro_html ).
-
-    ro_html->add( 'var gGoRepoPalette = new CommandPalette(enumerateTocAllRepos, {' ).
-    ro_html->add( '  toggleKey: "F2",' ).
-    ro_html->add( '  hotkeyDescription: "Go to repo ..."' ).
-    ro_html->add( '});' ).
-
-    ro_html->add( 'var gCommandPalette = new CommandPalette(enumerateToolbarActions, {' ).
-    ro_html->add( '  toggleKey: "F1",' ).
-    ro_html->add( '  hotkeyDescription: "Command ..."' ).
-    ro_html->add( '});' ).
+    render_link_hints( ro_html ).
+    render_command_palettes( ro_html ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -12,11 +12,13 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
       constructor RAISING zcx_abapgit_exception.
 
   PROTECTED SECTION.
-    TYPES: BEGIN OF ty_control,
-             redirect_url TYPE string,
-             page_title   TYPE string,
-             page_menu    TYPE REF TO zcl_abapgit_html_toolbar,
-           END OF  ty_control.
+
+    TYPES:
+      BEGIN OF ty_control,
+        redirect_url TYPE string,
+        page_title   TYPE string,
+        page_menu    TYPE REF TO zcl_abapgit_html_toolbar,
+      END OF  ty_control.
 
     DATA: ms_control TYPE ty_control.
 

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -30,16 +30,16 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
       RAISING
         zcx_abapgit_exception.
 
-    METHODs render_deferred_parts
-      IMPORTING
-        ii_html TYPE REF TO zif_abapgit_html
-        iv_part_category TYPE string.
-
   PRIVATE SECTION.
     DATA:
       mo_settings         TYPE REF TO zcl_abapgit_settings,
       mx_error            TYPE REF TO zcx_abapgit_exception,
       mo_exception_viewer TYPE REF TO zcl_abapgit_exception_viewer.
+
+    METHODs render_deferred_parts
+      IMPORTING
+        ii_html TYPE REF TO zif_abapgit_html
+        iv_part_category TYPE string.
 
     METHODS html_head
       RETURNING VALUE(ro_html) TYPE REF TO zcl_abapgit_html.

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -26,12 +26,6 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
       RETURNING VALUE(ro_html) TYPE REF TO zcl_abapgit_html
       RAISING   zcx_abapgit_exception.
 
-    METHODS scripts
-      RETURNING
-        VALUE(ro_html) TYPE REF TO zcl_abapgit_html
-      RAISING
-        zcx_abapgit_exception.
-
   PRIVATE SECTION.
     DATA:
       mo_settings         TYPE REF TO zcl_abapgit_settings,
@@ -80,6 +74,12 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
         zcx_abapgit_exception.
 
     METHODS render_error_message_box
+      RETURNING
+        VALUE(ro_html) TYPE REF TO zcl_abapgit_html
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS scripts
       RETURNING
         VALUE(ro_html) TYPE REF TO zcl_abapgit_html
       RAISING

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -38,7 +38,7 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
       mx_error            TYPE REF TO zcx_abapgit_exception,
       mo_exception_viewer TYPE REF TO zcl_abapgit_exception_viewer.
 
-    METHODs render_deferred_parts
+    METHODS render_deferred_parts
       IMPORTING
         ii_html TYPE REF TO zif_abapgit_html
         iv_part_category TYPE string.

--- a/src/ui/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_commit.clas.abap
@@ -29,10 +29,8 @@ CLASS zcl_abapgit_gui_page_commit DEFINITION
       EXPORTING
         !eg_fields   TYPE any .
 
-    METHODS render_content
-        REDEFINITION .
-    METHODS scripts
-        REDEFINITION .
+    METHODS render_content REDEFINITION .
+
   PRIVATE SECTION.
 
     DATA mo_repo TYPE REF TO zcl_abapgit_repo_online .
@@ -73,6 +71,13 @@ CLASS zcl_abapgit_gui_page_commit DEFINITION
         !it_stage      TYPE zcl_abapgit_stage=>ty_stage_tt
       RETURNING
         VALUE(rv_text) TYPE string .
+
+    METHODS render_scripts
+      RETURNING
+        VALUE(ro_html) TYPE REF TO zcl_abapgit_html
+      RAISING
+        zcx_abapgit_exception.
+
 ENDCLASS.
 
 
@@ -247,6 +252,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
     ro_html->add( render_stage( ) ).
     ro_html->add( '</div>' ).
 
+    register_deferred_script( render_scripts( ) ).
+
   ENDMETHOD.
 
 
@@ -381,6 +388,15 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD render_scripts.
+
+    CREATE OBJECT ro_html.
+
+    ro_html->add( 'setInitialFocus("comment");' ).
+
+  ENDMETHOD.
+
+
   METHOD render_stage.
 
     DATA: lt_stage TYPE zcl_abapgit_stage=>ty_stage_tt.
@@ -442,15 +458,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
     ro_html->add( |<label for="{ iv_name }">{ iv_label }</label>| ).
     ro_html->add( |<input id="{ iv_name }" name="{ iv_name }" type="text"{ lv_attrs }>| ).
     ro_html->add( '</div>' ).
-
-  ENDMETHOD.
-
-
-  METHOD scripts.
-
-    ro_html = super->scripts( ).
-
-    ro_html->add( 'setInitialFocus("comment");' ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_debuginfo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_debuginfo.clas.abap
@@ -11,8 +11,7 @@ CLASS zcl_abapgit_gui_page_debuginfo DEFINITION
 
   PROTECTED SECTION.
     METHODS:
-      render_content REDEFINITION,
-      scripts        REDEFINITION.
+      render_content REDEFINITION.
 
   PRIVATE SECTION.
     METHODS render_debug_info
@@ -20,6 +19,11 @@ CLASS zcl_abapgit_gui_page_debuginfo DEFINITION
       RAISING   zcx_abapgit_exception.
     METHODS render_supported_object_types
       RETURNING VALUE(rv_html) TYPE string.
+    METHODS render_scripts
+      RETURNING
+        VALUE(ro_html) TYPE REF TO zcl_abapgit_html
+      RAISING
+        zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -42,6 +46,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DEBUGINFO IMPLEMENTATION.
     ro_html->add( render_debug_info( ) ).
     ro_html->add( render_supported_object_types( ) ).
     ro_html->add( '</div>' ).
+
+    register_deferred_script( render_scripts( ) ).
 
   ENDMETHOD.
 
@@ -75,6 +81,16 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DEBUGINFO IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD render_scripts.
+
+    CREATE OBJECT ro_html.
+
+    ro_html->add( 'debugOutput("Browser: " + navigator.userAgent + ' &&
+      '"<br>Frontend time: " + new Date(), "debug_info");' ).
+
+  ENDMETHOD.
+
+
   METHOD render_supported_object_types.
 
     DATA: lv_list  TYPE string,
@@ -93,16 +109,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DEBUGINFO IMPLEMENTATION.
     ENDLOOP.
 
     rv_html = |<p>Supported objects: { lv_list }</p>|.
-
-  ENDMETHOD.
-
-
-  METHOD scripts.
-
-    ro_html = super->scripts( ).
-
-    ro_html->add( 'debugOutput("Browser: " + navigator.userAgent + ' &&
-      '"<br>Frontend time: " + new Date(), "debug_info");' ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_diff.clas.abap
@@ -61,7 +61,6 @@ CLASS zcl_abapgit_gui_page_diff DEFINITION
         RETURNING
           VALUE(rv_normalized) TYPE string,
       render_content REDEFINITION,
-      scripts REDEFINITION,
       add_menu_end
         IMPORTING
           io_menu TYPE REF TO zcl_abapgit_html_toolbar ,
@@ -181,6 +180,11 @@ CLASS zcl_abapgit_gui_page_diff DEFINITION
     METHODS render_table_head_unified
       IMPORTING
         io_html TYPE REF TO zcl_abapgit_html.
+    METHODS render_scripts
+      RETURNING
+        VALUE(ro_html) TYPE REF TO zcl_abapgit_html
+      RAISING
+        zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -572,6 +576,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
     ENDIF.
     ro_html->add( '</div>' ).
 
+    register_deferred_script( render_scripts( ) ).
+
   ENDMETHOD.
 
 
@@ -851,6 +857,33 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD render_scripts.
+
+    CREATE OBJECT ro_html.
+
+    ro_html->add( 'restoreScrollPosition();' ).
+    ro_html->add( 'var gHelper = new DiffHelper({' ).
+    ro_html->add( |  seed:        "{ mv_seed }",| ).
+    ro_html->add( '  ids: {' ).
+    ro_html->add( '    jump:        "jump",' ).
+    ro_html->add( '    diffList:    "diff-list",' ).
+    ro_html->add( '    filterMenu:  "diff-filter",' ).
+    ro_html->add( '  }' ).
+    ro_html->add( '});' ).
+
+    ro_html->add( 'addMarginBottom();' ).
+
+    ro_html->add( 'var gGoJumpPalette = new CommandPalette(enumerateJumpAllFiles, {' ).
+    ro_html->add( '  toggleKey: "F2",' ).
+    ro_html->add( '  hotkeyDescription: "Jump to file ..."' ).
+    ro_html->add( '});' ).
+
+    " Feature for selecting ABAP code by column and copy to clipboard
+    ro_html->add( 'var columnSelection = new DiffColumnSelection();' ).
+
+  ENDMETHOD.
+
+
   METHOD render_table_head.
 
     CREATE OBJECT ro_html.
@@ -894,33 +927,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DIFF IMPLEMENTATION.
     io_html->add( '<th class="num">new</th>' ).             "#EC NOTEXT
     io_html->add( '<th class="mark"></th>' ).               "#EC NOTEXT
     io_html->add( '<th>code</th>' ).                        "#EC NOTEXT
-
-  ENDMETHOD.
-
-
-  METHOD scripts.
-
-    ro_html = super->scripts( ).
-
-    ro_html->add( 'restoreScrollPosition();' ).
-    ro_html->add( 'var gHelper = new DiffHelper({' ).
-    ro_html->add( |  seed:        "{ mv_seed }",| ).
-    ro_html->add( '  ids: {' ).
-    ro_html->add( '    jump:        "jump",' ).
-    ro_html->add( '    diffList:    "diff-list",' ).
-    ro_html->add( '    filterMenu:  "diff-filter",' ).
-    ro_html->add( '  }' ).
-    ro_html->add( '});' ).
-
-    ro_html->add( 'addMarginBottom();' ).
-
-    ro_html->add( 'var gGoJumpPalette = new CommandPalette(enumerateJumpAllFiles, {' ).
-    ro_html->add( '  toggleKey: "F2",' ).
-    ro_html->add( '  hotkeyDescription: "Jump to file ..."' ).
-    ro_html->add( '});' ).
-
-    " Feature for selecting ABAP code by column and copy to clipboard
-    ro_html->add( 'var columnSelection = new DiffColumnSelection();' ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_patch.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_patch.clas.abap
@@ -31,7 +31,6 @@ CLASS zcl_abapgit_gui_page_patch DEFINITION
   PROTECTED SECTION.
     METHODS:
       render_content REDEFINITION,
-      scripts REDEFINITION,
       add_menu_end REDEFINITION,
       add_menu_begin REDEFINITION,
       render_table_head_non_unified REDEFINITION,
@@ -170,6 +169,12 @@ CLASS zcl_abapgit_gui_page_patch DEFINITION
           iv_fstate                        TYPE char1
         RETURNING
           VALUE(rv_is_patch_line_possible) TYPE abap_bool.
+
+    METHODS render_scripts
+      RETURNING
+        VALUE(ro_html) TYPE REF TO zcl_abapgit_html
+      RAISING
+        zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -578,6 +583,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_PATCH IMPLEMENTATION.
     mi_gui_services->get_hotkeys_ctl( )->register_hotkeys( me ).
     ro_html = super->render_content( ).
 
+    register_deferred_script( render_scripts( ) ).
+
   ENDMETHOD.
 
 
@@ -672,6 +679,16 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_PATCH IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD render_scripts.
+
+    CREATE OBJECT ro_html.
+
+    ro_html->add( 'preparePatch();' ).
+    ro_html->add( 'registerStagePatch();' ).
+
+  ENDMETHOD.
+
+
   METHOD render_table_head_non_unified.
 
     render_patch_head( io_html = io_html
@@ -716,16 +733,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_PATCH IMPLEMENTATION.
       ENDLOOP.
 
     ENDLOOP.
-
-  ENDMETHOD.
-
-
-  METHOD scripts.
-
-    ro_html = super->scripts( ).
-
-    ro_html->add( 'preparePatch();' ).
-    ro_html->add( 'registerStagePatch();' ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_over.clas.abap
@@ -12,8 +12,7 @@ CLASS zcl_abapgit_gui_page_repo_over DEFINITION
 
   PROTECTED SECTION.
     METHODS:
-      render_content REDEFINITION,
-      scripts REDEFINITION.
+      render_content REDEFINITION.
 
   PRIVATE SECTION.
     TYPES:
@@ -93,6 +92,12 @@ CLASS zcl_abapgit_gui_page_repo_over DEFINITION
       _add_col
         IMPORTING
           iv_descriptor TYPE string.
+
+    METHODS render_scripts
+      RETURNING
+        VALUE(ro_html) TYPE REF TO zcl_abapgit_html
+      RAISING
+        zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -241,6 +246,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
     render_table( io_html     = ro_html
                   it_overview = lt_overview ).
 
+    register_deferred_script( render_scripts( ) ).
+
   ENDMETHOD.
 
 
@@ -263,6 +270,16 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
       iv_typ = zif_abapgit_html=>c_action_type-onclick ) ).
 
     io_html->add( |</div>| ).
+
+  ENDMETHOD.
+
+
+  METHOD render_scripts.
+
+    CREATE OBJECT ro_html.
+
+    ro_html->add( 'setInitialFocus("filter");' ).
+    ro_html->add( 'var gHelper = new RepoOverViewHelper();' ).
 
   ENDMETHOD.
 
@@ -388,16 +405,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_OVER IMPLEMENTATION.
 
     ro_html->add( |<label for="{ iv_name }">{ iv_label }</label>| ).
     ro_html->add( |<input id="{ iv_name }" name="{ iv_name }" type="text"{ lv_attrs }>| ).
-
-  ENDMETHOD.
-
-
-  METHOD scripts.
-
-    ro_html = super->scripts( ).
-
-    ro_html->add( 'setInitialFocus("filter");' ).
-    ro_html->add( 'var gHelper = new RepoOverViewHelper();' ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -23,7 +23,6 @@ CLASS zcl_abapgit_gui_page_stage DEFINITION
   PROTECTED SECTION.
     METHODS:
       render_content REDEFINITION,
-      get_events     REDEFINITION,
       scripts        REDEFINITION.
 
   PRIVATE SECTION.
@@ -97,6 +96,11 @@ CLASS zcl_abapgit_gui_page_stage DEFINITION
     METHODS count_default_files_to_commit
       RETURNING
         VALUE(rv_count) TYPE i.
+    METHODS render_deferred_hidden_events
+      RETURNING
+        VALUE(ro_html) TYPE REF TO zcl_abapgit_html
+      RAISING
+        zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -226,17 +230,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD get_events.
-
-    FIELD-SYMBOLS: <ls_event> TYPE zcl_abapgit_gui_page=>ty_event.
-
-    APPEND INITIAL LINE TO rt_events ASSIGNING <ls_event>.
-    <ls_event>-method = 'post'.
-    <ls_event>-name = 'stage_commit'.
-
-  ENDMETHOD.
-
-
   METHOD get_page_patch.
 
     DATA: lo_page TYPE REF TO zcl_abapgit_gui_page_patch,
@@ -321,6 +314,20 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
     ro_html->add( '</div>' ).
 
     mi_gui_services->get_hotkeys_ctl( )->register_hotkeys( me ).
+    mi_gui_services->get_html_parts( )->add_part(
+      iv_collection = zcl_abapgit_gui_component=>c_html_parts-hidden_forms
+      ii_part       = render_deferred_hidden_events( ) ).
+
+  ENDMETHOD.
+
+
+  METHOD render_deferred_hidden_events.
+
+    DATA ls_event TYPE zcl_abapgit_gui_chunk_lib=>ty_event_signature.
+
+    ls_event-method = 'post'.
+    ls_event-name   = 'stage_commit'.
+    ro_html = zcl_abapgit_gui_chunk_lib=>render_event_as_form( ls_event ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -22,8 +22,7 @@ CLASS zcl_abapgit_gui_page_stage DEFINITION
 
   PROTECTED SECTION.
     METHODS:
-      render_content REDEFINITION,
-      scripts        REDEFINITION.
+      render_content REDEFINITION.
 
   PRIVATE SECTION.
 
@@ -97,6 +96,9 @@ CLASS zcl_abapgit_gui_page_stage DEFINITION
       RETURNING
         VALUE(rv_count) TYPE i.
     METHODS render_deferred_hidden_events
+      RETURNING
+        VALUE(ro_html) TYPE REF TO zcl_abapgit_html.
+    METHODS render_scripts
       RETURNING
         VALUE(ro_html) TYPE REF TO zcl_abapgit_html
       RAISING
@@ -317,6 +319,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
     mi_gui_services->get_html_parts( )->add_part(
       iv_collection = zcl_abapgit_gui_component=>c_html_parts-hidden_forms
       ii_part       = render_deferred_hidden_events( ) ).
+    register_deferred_script( render_scripts( ) ).
 
   ENDMETHOD.
 
@@ -499,9 +502,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD scripts.
+  METHOD render_scripts.
 
-    ro_html = super->scripts( ).
+    CREATE OBJECT ro_html.
 
     ro_html->add( 'var gStageParams = {' ).
     ro_html->add( |  seed:            "{ mv_seed }",| ). " Unique page id

--- a/src/ui/zcl_abapgit_gui_page_tag.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_tag.clas.abap
@@ -18,8 +18,7 @@ CLASS zcl_abapgit_gui_page_tag DEFINITION PUBLIC FINAL
 
   PROTECTED SECTION.
     METHODS:
-      render_content REDEFINITION,
-      scripts        REDEFINITION.
+      render_content REDEFINITION.
 
   PRIVATE SECTION.
     CONSTANTS: BEGIN OF c_tag_type,
@@ -55,6 +54,12 @@ CLASS zcl_abapgit_gui_page_tag DEFINITION PUBLIC FINAL
       parse_change_tag_type_request
         IMPORTING
           it_postdata TYPE cnht_post_data_tab.
+
+    METHODS render_scripts
+      RETURNING
+        VALUE(ro_html) TYPE REF TO zcl_abapgit_html
+      RAISING
+        zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -193,6 +198,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_TAG IMPLEMENTATION.
     ro_html->add( render_menu( ) ).
     ro_html->add( render_form( ) ).
     ro_html->add( '</div>' ).
+
+    register_deferred_script( render_scripts( ) ).
 
   ENDMETHOD.
 
@@ -334,6 +341,15 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_TAG IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD render_scripts.
+
+    CREATE OBJECT ro_html.
+
+    ro_html->add( 'setInitialFocus("name");' ).
+
+  ENDMETHOD.
+
+
   METHOD render_text_input.
 
     DATA lv_attrs TYPE string.
@@ -352,15 +368,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_TAG IMPLEMENTATION.
     ro_html->add( |<label for="{ iv_name }">{ iv_label }</label>| ).
     ro_html->add( |<input id="{ iv_name }" name="{ iv_name }" type="text"{ lv_attrs }>| ).
     ro_html->add( '</div>' ).
-
-  ENDMETHOD.
-
-
-  METHOD scripts.
-
-    ro_html = super->scripts( ).
-
-    ro_html->add( 'setInitialFocus("name");' ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
Continuation of the story with scripts.

So now all the scripts are registered as deferred parts, `scripts` method in `gui_page` is private and not redefined in subclasses. In addition `get_events` method also removed and converted to `parts` approach - called `hidden_forms` in this case.

For review: makes sense to review first 4 and the last commit for understanding. All the `refactoring page*` are similar: remove redefinition, rename method, call `register_deferred_script`

P.S. `register_deferred_script` is a shortcut for `zcl_abapgit_ui_factory=>get_gui_services( )->get_html_parts( )->add_part( iv_collection = c_html_parts-scripts ...`