### PR TITLE
Encode and decode signed commits

### DIFF
--- a/src/git/zcl_abapgit_git_pack.clas.testclasses.abap
+++ b/src/git/zcl_abapgit_git_pack.clas.testclasses.abap
@@ -231,6 +231,8 @@ CLASS ltcl_pack DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS FINAL.
         RAISING zcx_abapgit_exception,
       commit_newline FOR TESTING
         RAISING zcx_abapgit_exception,
+      signed_commit FOR TESTING
+        RAISING zcx_abapgit_exception,
       pack_short FOR TESTING
         RAISING zcx_abapgit_exception,
       pack_long FOR TESTING
@@ -474,6 +476,29 @@ CLASS ltcl_pack IMPLEMENTATION.
     ls_commit-body      = 'very informative'
                         && zif_abapgit_definitions=>c_newline
                         && zif_abapgit_definitions=>c_newline.
+
+    lv_data = zcl_abapgit_git_pack=>encode_commit( ls_commit ).
+    ls_result = zcl_abapgit_git_pack=>decode_commit( lv_data ).
+
+    cl_abap_unit_assert=>assert_equals(
+        exp = ls_commit
+        act = ls_result ).
+
+  ENDMETHOD.
+
+  METHOD signed_commit.
+
+    DATA: ls_commit TYPE zcl_abapgit_git_pack=>ty_commit,
+          ls_result TYPE zcl_abapgit_git_pack=>ty_commit,
+          lv_data   TYPE xstring.
+
+    ls_commit-tree      = c_sha.
+    ls_commit-parent    = c_sha.
+    ls_commit-author    = 'larshp <larshp@hotmail.com> 1387823471 +0100'.
+    ls_commit-committer = 'larshp <larshp@hotmail.com> 1387823471 +0100'.
+    ls_commit-body      = 'very informative'.
+    ls_commit-gpgsig    = '-----END PGP SIGNATURE-----'
+                          && |{ zif_abapgit_definitions=>c_newline } { zif_abapgit_definitions=>c_newline }|.
 
     lv_data = zcl_abapgit_git_pack=>encode_commit( ls_commit ).
     ls_result = zcl_abapgit_git_pack=>decode_commit( lv_data ).


### PR DESCRIPTION
The GPG signature in a signed commit is encoded and decoded. Necessary for fix issue [137](https://github.com/larshp/abapGitServer/issues/137) in abapGitServer.