### PR TITLE
Master lang only - clear descriptions for clas, intf

### DIFF
--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -358,12 +358,15 @@ CLASS zcl_abapgit_object_clas IMPLEMENTATION.
   METHOD serialize_descr.
 
     DATA: lt_descriptions TYPE zif_abapgit_definitions=>ty_seocompotx_tt,
-          lv_master_lang_only TYPE abap_bool.
+          lv_language     TYPE spras.
 
-    lv_master_lang_only = io_xml->i18n_params( )-serialize_master_lang_only.
+    IF io_xml->i18n_params( )-serialize_master_lang_only = abap_true.
+      lv_language = mv_language.
+    ENDIF.
+
     lt_descriptions = mi_object_oriented_object_fct->read_descriptions(
       iv_obejct_name = iv_clsname
-      iv_master_lang_only = lv_master_lang_only ).
+      iv_language = lv_language ).
 
     IF lines( lt_descriptions ) = 0.
       RETURN.

--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -357,9 +357,14 @@ CLASS zcl_abapgit_object_clas IMPLEMENTATION.
 
   METHOD serialize_descr.
 
-    DATA: lt_descriptions TYPE zif_abapgit_definitions=>ty_seocompotx_tt.
+    DATA: lt_descriptions TYPE zif_abapgit_definitions=>ty_seocompotx_tt,
+          lv_master_lang_only TYPE abap_bool.
 
-    lt_descriptions = mi_object_oriented_object_fct->read_descriptions( iv_clsname ).
+    lv_master_lang_only = io_xml->i18n_params( )-serialize_master_lang_only.
+    lt_descriptions = mi_object_oriented_object_fct->read_descriptions(
+      iv_obejct_name = iv_clsname
+      iv_master_lang_only = lv_master_lang_only ).
+
     IF lines( lt_descriptions ) = 0.
       RETURN.
     ENDIF.

--- a/src/objects/zcl_abapgit_object_cus0.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus0.clas.abap
@@ -175,7 +175,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CUS0 IMPLEMENTATION.
            ls_img_activity-header-ltime.
 
     IF io_xml->i18n_params( )-serialize_master_lang_only = abap_true.
-      DELETE ls_img_activity-texts WHERE spras <> sy-langu.
+      DELETE ls_img_activity-texts WHERE spras <> mv_language.
     ENDIF.
 
     io_xml->add( iv_name = 'CUS0'

--- a/src/objects/zcl_abapgit_object_cus1.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus1.clas.abap
@@ -188,7 +188,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CUS1 IMPLEMENTATION.
            ls_customzing_activity-activity_header-luser.
 
     IF io_xml->i18n_params( )-serialize_master_lang_only = abap_true.
-      DELETE ls_customzing_activity-activity_title WHERE spras <> sy-langu.
+      DELETE ls_customzing_activity-activity_title WHERE spras <> mv_language.
     ENDIF.
 
     io_xml->add( iv_name = 'CUS1'

--- a/src/objects/zcl_abapgit_object_cus2.clas.abap
+++ b/src/objects/zcl_abapgit_object_cus2.clas.abap
@@ -164,7 +164,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CUS2 IMPLEMENTATION.
            ls_customizing_attribute-header-luser.
 
     IF io_xml->i18n_params( )-serialize_master_lang_only = abap_true.
-      DELETE ls_customizing_attribute-titles WHERE spras <> sy-langu.
+      DELETE ls_customizing_attribute-titles WHERE spras <> mv_language.
     ENDIF.
 
     io_xml->add( iv_name = 'CUS2'

--- a/src/objects/zcl_abapgit_object_intf.clas.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.abap
@@ -137,11 +137,11 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
 
   METHOD serialize_xml.
     DATA:
-      lt_descriptions     TYPE zif_abapgit_definitions=>ty_seocompotx_tt,
-      ls_vseointerf       TYPE vseointerf,
-      ls_clskey           TYPE seoclskey,
-      lt_lines            TYPE tlinetab,
-      lv_master_lang_only TYPE abap_bool.
+      lt_descriptions TYPE zif_abapgit_definitions=>ty_seocompotx_tt,
+      ls_vseointerf   TYPE vseointerf,
+      ls_clskey       TYPE seoclskey,
+      lt_lines        TYPE tlinetab,
+      lv_language     TYPE spras.
 
 
     ls_clskey-clsname = ms_item-obj_name.
@@ -169,10 +169,13 @@ CLASS zcl_abapgit_object_intf IMPLEMENTATION.
                    ig_data = lt_lines ).
     ENDIF.
 
-    lv_master_lang_only = io_xml->i18n_params( )-serialize_master_lang_only.
+    IF io_xml->i18n_params( )-serialize_master_lang_only = abap_true.
+      lv_language = mv_language.
+    ENDIF.
+
     lt_descriptions = mi_object_oriented_object_fct->read_descriptions(
       iv_obejct_name = ls_clskey-clsname
-      iv_master_lang_only = lv_master_lang_only ).
+      iv_language = lv_language ).
 
     IF lines( lt_descriptions ) > 0.
       io_xml->add( iv_name = 'DESCRIPTIONS'

--- a/src/objects/zcl_abapgit_object_intf.clas.abap
+++ b/src/objects/zcl_abapgit_object_intf.clas.abap
@@ -33,7 +33,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_INTF IMPLEMENTATION.
+CLASS zcl_abapgit_object_intf IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -137,10 +137,11 @@ CLASS ZCL_ABAPGIT_OBJECT_INTF IMPLEMENTATION.
 
   METHOD serialize_xml.
     DATA:
-      lt_descriptions TYPE zif_abapgit_definitions=>ty_seocompotx_tt,
-      ls_vseointerf   TYPE vseointerf,
-      ls_clskey       TYPE seoclskey,
-      lt_lines        TYPE tlinetab.
+      lt_descriptions     TYPE zif_abapgit_definitions=>ty_seocompotx_tt,
+      ls_vseointerf       TYPE vseointerf,
+      ls_clskey           TYPE seoclskey,
+      lt_lines            TYPE tlinetab,
+      lv_master_lang_only TYPE abap_bool.
 
 
     ls_clskey-clsname = ms_item-obj_name.
@@ -168,7 +169,11 @@ CLASS ZCL_ABAPGIT_OBJECT_INTF IMPLEMENTATION.
                    ig_data = lt_lines ).
     ENDIF.
 
-    lt_descriptions = mi_object_oriented_object_fct->read_descriptions( ls_clskey-clsname ).
+    lv_master_lang_only = io_xml->i18n_params( )-serialize_master_lang_only.
+    lt_descriptions = mi_object_oriented_object_fct->read_descriptions(
+      iv_obejct_name = ls_clskey-clsname
+      iv_master_lang_only = lv_master_lang_only ).
+
     IF lines( lt_descriptions ) > 0.
       io_xml->add( iv_name = 'DESCRIPTIONS'
                    ig_data = lt_descriptions ).

--- a/src/objects/zcl_abapgit_oo_base.clas.abap
+++ b/src/objects/zcl_abapgit_oo_base.clas.abap
@@ -238,19 +238,20 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
 
 
   METHOD zif_abapgit_oo_object_fnc~read_descriptions.
-    CASE iv_master_lang_only.
-      WHEN abap_true.
-        SELECT * FROM seocompotx INTO TABLE rt_descriptions
-          WHERE clsname   = iv_obejct_name
-            AND langu = sy-langu
-            AND descript <> ''
-          ORDER BY PRIMARY KEY.                           "#EC CI_SUBRC
-      WHEN abap_false.
-        SELECT * FROM seocompotx INTO TABLE rt_descriptions
-           WHERE clsname   = iv_obejct_name
-             AND descript <> ''
-           ORDER BY PRIMARY KEY.                          "#EC CI_SUBRC
-    ENDCASE.
+    IF iv_language IS INITIAL.
+      " load all languages
+      SELECT * FROM seocompotx INTO TABLE rt_descriptions
+             WHERE clsname   = iv_obejct_name
+               AND descript <> ''
+             ORDER BY PRIMARY KEY.                        "#EC CI_SUBRC
+    ELSE.
+      " load master language
+      SELECT * FROM seocompotx INTO TABLE rt_descriptions
+              WHERE clsname   = iv_obejct_name
+                AND langu = iv_language
+                AND descript <> ''
+              ORDER BY PRIMARY KEY.                       "#EC CI_SUBRC
+    ENDIF.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_oo_base.clas.abap
+++ b/src/objects/zcl_abapgit_oo_base.clas.abap
@@ -238,10 +238,19 @@ CLASS zcl_abapgit_oo_base IMPLEMENTATION.
 
 
   METHOD zif_abapgit_oo_object_fnc~read_descriptions.
-    SELECT * FROM seocompotx INTO TABLE rt_descriptions
-      WHERE clsname   = iv_obejct_name
-        AND descript <> ''
-      ORDER BY PRIMARY KEY.                               "#EC CI_SUBRC
+    CASE iv_master_lang_only.
+      WHEN abap_true.
+        SELECT * FROM seocompotx INTO TABLE rt_descriptions
+          WHERE clsname   = iv_obejct_name
+            AND langu = sy-langu
+            AND descript <> ''
+          ORDER BY PRIMARY KEY.                           "#EC CI_SUBRC
+      WHEN abap_false.
+        SELECT * FROM seocompotx INTO TABLE rt_descriptions
+           WHERE clsname   = iv_obejct_name
+             AND descript <> ''
+           ORDER BY PRIMARY KEY.                          "#EC CI_SUBRC
+    ENDCASE.
   ENDMETHOD.
 
 

--- a/src/objects/zif_abapgit_oo_object_fnc.intf.abap
+++ b/src/objects/zif_abapgit_oo_object_fnc.intf.abap
@@ -123,7 +123,7 @@ INTERFACE zif_abapgit_oo_object_fnc PUBLIC.
     read_descriptions
       IMPORTING
         iv_obejct_name         TYPE seoclsname
-        iv_master_lang_only    TYPE abap_bool DEFAULT abap_false
+        iv_language            TYPE spras OPTIONAL
       RETURNING
         VALUE(rt_descriptions) TYPE zif_abapgit_definitions=>ty_seocompotx_tt,
     delete

--- a/src/objects/zif_abapgit_oo_object_fnc.intf.abap
+++ b/src/objects/zif_abapgit_oo_object_fnc.intf.abap
@@ -123,6 +123,7 @@ INTERFACE zif_abapgit_oo_object_fnc PUBLIC.
     read_descriptions
       IMPORTING
         iv_obejct_name         TYPE seoclsname
+        iv_master_lang_only    TYPE abap_bool DEFAULT abap_false
       RETURNING
         VALUE(rt_descriptions) TYPE zif_abapgit_definitions=>ty_seocompotx_tt,
     delete


### PR DESCRIPTION
Example removed part:

    \<SEOCOMPOTX>

    \<CLSNAME>cx\_blah\</CLSNAME>

    \<CMPNAME>CONSTRUCTOR\</CMPNAME>

    \<LANGU>닱\</LANGU>

    \<DESCRIPT>\[ĈŎŃŜŢŘŮĈŢŎŘ∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙∙\]\</DESCRIPT>

   \</SEOCOMPOTX>