### PR TITLE
SAP Package: Replace ASSERT with RAISE

### DIFF
--- a/src/zcl_abapgit_sap_package.clas.abap
+++ b/src/zcl_abapgit_sap_package.clas.abap
@@ -308,7 +308,7 @@ CLASS ZCL_ABAPGIT_SAP_PACKAGE IMPLEMENTATION.
   METHOD zif_abapgit_sap_package~read_parent.
 
     SELECT SINGLE parentcl FROM tdevc INTO rv_parentcl
-      WHERE devclass = mv_package.        "#EC CI_SUBRC "#EC CI_GENBUFF
+      WHERE devclass = mv_package.        "#EC CI_GENBUFF
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( |Inconsistent package structure! Cannot find parent for { mv_package }| ).
     ENDIF.

--- a/src/zcl_abapgit_sap_package.clas.abap
+++ b/src/zcl_abapgit_sap_package.clas.abap
@@ -309,7 +309,9 @@ CLASS ZCL_ABAPGIT_SAP_PACKAGE IMPLEMENTATION.
 
     SELECT SINGLE parentcl FROM tdevc INTO rv_parentcl
       WHERE devclass = mv_package.        "#EC CI_SUBRC "#EC CI_GENBUFF
-    ASSERT sy-subrc = 0.
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Inconsistent package structure! Cannot find parent for { mv_package }| ).
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_abapgit_transport.clas.abap
+++ b/src/zcl_abapgit_transport.clas.abap
@@ -38,7 +38,9 @@ CLASS zcl_abapgit_transport DEFINITION
       IMPORTING
         !it_tadir         TYPE zif_abapgit_definitions=>ty_tadir_tt
       RETURNING
-        VALUE(rv_package) TYPE devclass .
+        VALUE(rv_package) TYPE devclass
+      RAISING
+        zcx_abapgit_exception .
     CLASS-METHODS resolve
       IMPORTING
         !it_requests    TYPE trwbo_requests

--- a/src/zif_abapgit_sap_package.intf.abap
+++ b/src/zif_abapgit_sap_package.intf.abap
@@ -6,13 +6,15 @@ INTERFACE zif_abapgit_sap_package PUBLIC.
       IMPORTING is_package TYPE scompkdtln
       RAISING   zcx_abapgit_exception,
     create_local
-      RAISING   zcx_abapgit_exception,
+      RAISING zcx_abapgit_exception,
     list_subpackages
       RETURNING VALUE(rt_list) TYPE ty_devclass_tt,
     list_superpackages
-      RETURNING VALUE(rt_list) TYPE ty_devclass_tt,
+      RETURNING VALUE(rt_list) TYPE ty_devclass_tt
+      RAISING   zcx_abapgit_exception,
     read_parent
-      RETURNING VALUE(rv_parentcl) TYPE tdevc-parentcl,
+      RETURNING VALUE(rv_parentcl) TYPE tdevc-parentcl
+      RAISING   zcx_abapgit_exception,
     create_child
       IMPORTING iv_child TYPE devclass
       RAISING   zcx_abapgit_exception,


### PR DESCRIPTION
Replacing the assertion in read_parent with exception.

Sometimes this assertion dumps when the package structure is somehow inconsistent (not caused by abapGit). Therefore my colleagues would prefer an exception, stating which package causes the inconsistency over the dump.