### PR TITLE
Fix detection of abapGit installation

### DIFF
--- a/src/ui/zcl_abapgit_services_abapgit.clas.abap
+++ b/src/ui/zcl_abapgit_services_abapgit.clas.abap
@@ -11,6 +11,7 @@ CLASS zcl_abapgit_services_abapgit DEFINITION
                c_dotabap_homepage TYPE string   VALUE 'https://dotabap.org'               ##NO_TEXT,
                c_abapgit_package  TYPE devclass VALUE '$ABAPGIT'                              ##NO_TEXT,
                c_abapgit_url      TYPE string   VALUE 'https://github.com/larshp/abapGit.git' ##NO_TEXT,
+               c_abapgit_class    TYPE tcode    VALUE `ZCL_ABAPGIT_REPO`                      ##NO_TEXT,
                c_abapgit_tcode    TYPE tcode    VALUE `ZABAPGIT`                              ##NO_TEXT.
 
     CLASS-METHODS open_abapgit_homepage
@@ -225,7 +226,7 @@ CLASS zcl_abapgit_services_abapgit IMPLEMENTATION.
   METHOD is_installed.
 
     SELECT SINGLE devclass FROM tadir INTO rv_devclass
-      WHERE object = 'TRAN' AND obj_name = c_abapgit_tcode.
+      WHERE object = 'CLAS' AND obj_name = c_abapgit_class.
 
   ENDMETHOD.
 


### PR DESCRIPTION
Old logic was failing if transaction ZABAPGIT already existed - typically because it was created manually for the merged version. Testing for program ZABAPGIT would not be any better since that might have been used for the merged version as well. It's more reliable to check a class.