### PR TITLE
Remove fallback object lookup on SICF deserialization

### DIFF
--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -353,12 +353,6 @@ CLASS ZCL_ABAPGIT_OBJECT_SICF IMPLEMENTATION.
       ENDIF.
     ENDLOOP.
 
-    IF lines( lt_tadir ) = 1.
-      READ TABLE lt_tadir INDEX 1 ASSIGNING <ls_tadir>.
-      ASSERT sy-subrc = 0.
-      rs_tadir = <ls_tadir>.
-    ENDIF.
-
   ENDMETHOD.
 
 


### PR DESCRIPTION
The SICF object handler considers an SICF service's URL to be the object's primary identifier rather than the object name in TADIR. Due to the nature of how SICF nodes are created, this is quite necessary; however, this also means that the SICF handler must implement some mapping between SICF nodes (identified by URL) and TADIR entries (identified by an unpredictable UUID).

Issue #3230 reports problems when multiple SICF services within one development package are being deserialized. This problem is caused by a fallback logic in the URL-to-TADIR mapping which assumes that when exactly one SICF entry exists in TADIR (for a given package), then any SICF service being deserialized should map to that object. It follows that when >1 services within the same package are being deserialized, the first service is created correctly, and any following services will simply overwrite the one that already exists.

This PR eliminates this fallback and fixes #3230.

However, due to this change, abapGit's ability to track changes to SICF nodes will be slightly impacted: when a service's URL changes, the old and new version of the service will always appear as two distinct objects rather than one changed object. When pulling, this may create additional ICF services in the system until the repo is also reset or the previous, now "untracked", version of the service is removed manually.