### PR TITLE
Import BC Sets Very Late

### DIFF
--- a/src/objects/zcl_abapgit_object_scp1.clas.abap
+++ b/src/objects/zcl_abapgit_object_scp1.clas.abap
@@ -398,7 +398,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SCP1 IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~get_deserialize_steps.
-    APPEND zif_abapgit_object=>gc_step_id-abap TO rt_steps.
+    APPEND zif_abapgit_object=>gc_step_id-final TO rt_steps.
   ENDMETHOD.
 
 

--- a/src/objects/zif_abapgit_object.intf.abap
+++ b/src/objects/zif_abapgit_object.intf.abap
@@ -5,9 +5,10 @@ INTERFACE zif_abapgit_object
 
   CONSTANTS:
     BEGIN OF gc_step_id,
-      abap TYPE zif_abapgit_definitions=>ty_deserialization_step VALUE `ABAP`,
-      ddic TYPE zif_abapgit_definitions=>ty_deserialization_step VALUE `DDIC`,
-      late TYPE zif_abapgit_definitions=>ty_deserialization_step VALUE `LATE`,
+      abap  TYPE zif_abapgit_definitions=>ty_deserialization_step VALUE `ABAP`,
+      ddic  TYPE zif_abapgit_definitions=>ty_deserialization_step VALUE `DDIC`,
+      late  TYPE zif_abapgit_definitions=>ty_deserialization_step VALUE `LATE`,
+      final TYPE zif_abapgit_definitions=>ty_deserialization_step VALUE `FINAL`,
     END OF gc_step_id.
 
   CONSTANTS c_abap_version_sap_cp TYPE progdir-uccheck VALUE '5' ##NO_TEXT.

--- a/src/zcl_abapgit_objects.clas.abap
+++ b/src/zcl_abapgit_objects.clas.abap
@@ -919,6 +919,13 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
     <ls_step>-is_ddic      = abap_false.
     <ls_step>-syntax_check = abap_true.
     <ls_step>-order        = 3.
+
+    APPEND INITIAL LINE TO rt_steps ASSIGNING <ls_step>.
+    <ls_step>-step_id      = zif_abapgit_object=>gc_step_id-final.
+    <ls_step>-descr        = 'Import final objects'.
+    <ls_step>-is_ddic      = abap_false.
+    <ls_step>-syntax_check = abap_true.
+    <ls_step>-order        = 4.
   ENDMETHOD.
 
 


### PR DESCRIPTION
Since the BC Sets have dependency on Table maintenance generation i.e. object type TOBJ, the deserialize step 'ABAP' or 'LATE' will lead to inconsistency. closes #2418 
So the BC Sets are now imported in a new step called 'Final'.