### PR TITLE
Condense messages in case of package move

### DIFF
--- a/src/zcl_abapgit_file_status.clas.abap
+++ b/src/zcl_abapgit_file_status.clas.abap
@@ -232,6 +232,12 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
         CLEAR <ls_remote>-sha1. " Mark as processed
       ELSE.             " Only L exists
         <ls_result> = build_new_local( <ls_local> ).
+        " Check if same file exists in different location
+        READ TABLE lt_remote ASSIGNING <ls_remote>
+          WITH KEY filename = <ls_local>-file-filename.
+        IF sy-subrc = 0 AND <ls_local>-file-sha1 = <ls_remote>-sha1.
+          <ls_result>-packmove = abap_true.
+        ENDIF.
       ENDIF.
       <ls_result>-inactive = <ls_local>-item-inactive.
     ENDLOOP.
@@ -281,6 +287,12 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
                                       is_remote   = <ls_remote>
                                       it_items    = lt_items_idx
                                       it_state    = lt_state_idx ).
+      " Check if same file exists in different location
+      READ TABLE it_local ASSIGNING <ls_local>
+        WITH KEY file-filename = <ls_remote>-filename.
+      IF sy-subrc = 0 AND <ls_local>-file-sha1 = <ls_remote>-sha1.
+        <ls_result>-packmove = abap_true.
+      ENDIF.
     ENDLOOP.
 
     SORT rt_results BY
@@ -348,6 +360,7 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
           ls_file         TYPE zif_abapgit_definitions=>ty_file_signature,
           lt_res_sort     LIKE it_results,
           lt_item_idx     LIKE it_results,
+          lt_move_idx     LIKE it_results,
           lo_folder_logic TYPE REF TO zcl_abapgit_folder_logic.
 
     FIELD-SYMBOLS: <ls_res1> LIKE LINE OF it_results,
@@ -359,11 +372,29 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
       RETURN.
     ENDIF.
 
+    " Find all objects which were assigned to a different package
+    LOOP AT it_results ASSIGNING <ls_res1>
+      WHERE lstate = zif_abapgit_definitions=>c_state-added AND packmove = abap_true.
+      READ TABLE lt_move_idx TRANSPORTING NO FIELDS
+        WITH KEY obj_type = <ls_res1>-obj_type obj_name = <ls_res1>-obj_name
+        BINARY SEARCH. " Sorted since it_result is sorted
+      IF sy-subrc <> 0.
+        ii_log->add( iv_msg = |Object { <ls_res1>-obj_type } { <ls_res1>-obj_name
+                       } has been assigned to a different package|
+                     iv_type = 'W'
+                     iv_rc   = '5' ) ##no_text.
+        APPEND INITIAL LINE TO lt_move_idx ASSIGNING <ls_res2>.
+        <ls_res2>-obj_type = <ls_res1>-obj_type.
+        <ls_res2>-obj_name = <ls_res1>-obj_name.
+        <ls_res2>-path     = <ls_res1>-path.
+      ENDIF.
+    ENDLOOP.
+
     " Collect object indexe
     lt_res_sort = it_results.
     SORT lt_res_sort BY obj_type ASCENDING obj_name ASCENDING.
 
-    LOOP AT it_results ASSIGNING <ls_res1> WHERE NOT obj_type IS INITIAL.
+    LOOP AT it_results ASSIGNING <ls_res1> WHERE NOT obj_type IS INITIAL AND packmove = abap_false.
       IF NOT ( <ls_res1>-obj_type = ls_item-obj_type
           AND <ls_res1>-obj_name = ls_item-obj_name ).
         APPEND INITIAL LINE TO lt_item_idx ASSIGNING <ls_res2>.
@@ -375,8 +406,8 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
     ENDLOOP.
 
     " Check files for one object is in the same folder
-
-    LOOP AT it_results ASSIGNING <ls_res1> WHERE NOT obj_type IS INITIAL AND obj_type <> 'DEVC'.
+    LOOP AT it_results ASSIGNING <ls_res1>
+      WHERE NOT obj_type IS INITIAL AND obj_type <> 'DEVC' AND packmove = abap_false.
       READ TABLE lt_item_idx ASSIGNING <ls_res2>
         WITH KEY obj_type = <ls_res1>-obj_type obj_name = <ls_res1>-obj_name
         BINARY SEARCH. " Sorted above
@@ -385,14 +416,14 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
         ii_log->add( iv_msg = |Files for object { <ls_res1>-obj_type } {
                        <ls_res1>-obj_name } are not placed in the same folder|
                      iv_type = 'W'
-                     iv_rc    = '1' ) ##no_text.
+                     iv_rc   = '1' ) ##no_text.
       ENDIF.
     ENDLOOP.
 
     " Check that objects are created in package corresponding to folder
     lo_folder_logic = zcl_abapgit_folder_logic=>get_instance( ).
     LOOP AT it_results ASSIGNING <ls_res1>
-        WHERE NOT package IS INITIAL AND NOT path IS INITIAL.
+      WHERE NOT package IS INITIAL AND NOT path IS INITIAL AND packmove = abap_false.
       lv_path = lo_folder_logic->package_to_path(
         iv_top     = iv_top
         io_dot     = io_dot
@@ -401,14 +432,14 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
         ii_log->add( iv_msg = |Package and path does not match for object, {
                        <ls_res1>-obj_type } { <ls_res1>-obj_name }|
                      iv_type = 'W'
-                     iv_rc    = '2' ) ##no_text.
+                     iv_rc   = '2' ) ##no_text.
       ENDIF.
     ENDLOOP.
 
     " Check for multiple files with same filename
     SORT lt_res_sort BY filename ASCENDING.
 
-    LOOP AT lt_res_sort ASSIGNING <ls_res1> WHERE obj_type <> 'DEVC'.
+    LOOP AT lt_res_sort ASSIGNING <ls_res1> WHERE obj_type <> 'DEVC' AND packmove = abap_false.
       IF <ls_res1>-filename IS NOT INITIAL AND <ls_res1>-filename = ls_file-filename.
         ii_log->add( iv_msg  = |Multiple files with same filename, { <ls_res1>-filename }|
                      iv_type = 'W'

--- a/src/zcl_abapgit_file_status.clas.abap
+++ b/src/zcl_abapgit_file_status.clas.abap
@@ -379,8 +379,7 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
         WITH KEY obj_type = <ls_res1>-obj_type obj_name = <ls_res1>-obj_name
         BINARY SEARCH. " Sorted since it_result is sorted
       IF sy-subrc <> 0.
-        ii_log->add( iv_msg = |Object { <ls_res1>-obj_type } { <ls_res1>-obj_name
-                       } has been assigned to a different package|
+        ii_log->add( iv_msg  = |Changed package assignment for object { <ls_res1>-obj_type } { <ls_res1>-obj_name }|
                      iv_type = 'W'
                      iv_rc   = '5' ) ##no_text.
         APPEND INITIAL LINE TO lt_move_idx ASSIGNING <ls_res2>.

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -198,6 +198,7 @@ INTERFACE zif_abapgit_definitions
       match    TYPE abap_bool,
       lstate   TYPE c LENGTH 1,
       rstate   TYPE c LENGTH 1,
+      packmove TYPE abap_bool,
     END OF ty_result .
   TYPES:
     ty_results_tt TYPE STANDARD TABLE OF ty_result WITH DEFAULT KEY .


### PR DESCRIPTION
If an object is assigned to a different package, abapGit shows multiple warning messages per object and file:

![image](https://user-images.githubusercontent.com/59966492/85179324-f7224e00-b280-11ea-95b0-b55adfe6be7f.png)

In case the files are identical in old and new folder (same SHA1), the messages are reduced to one per object:

![image](https://user-images.githubusercontent.com/59966492/85179691-d73f5a00-b281-11ea-8dd5-a42392ed7f2f.png)


