### PR TITLE
Dialogs: add online repo HTML form

### DIFF
--- a/src/ui/core/zcl_abapgit_html.clas.abap
+++ b/src/ui/core/zcl_abapgit_html.clas.abap
@@ -30,6 +30,11 @@ CLASS zcl_abapgit_html DEFINITION
         !iv_hint    TYPE string OPTIONAL
         !iv_class   TYPE string OPTIONAL
         !iv_onclick TYPE string OPTIONAL .
+
+    CLASS-METHODS create
+      RETURNING
+        VALUE(ro_html) TYPE REF TO zcl_abapgit_html.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -211,6 +216,11 @@ CLASS ZCL_ABAPGIT_HTML IMPLEMENTATION.
       EXPORTING
         pattern     = '<(AREA|BASE|BR|COL|COMMAND|EMBED|HR|IMG|INPUT|LINK|META|PARAM|SOURCE|!)'
         ignore_case = abap_false.
+  ENDMETHOD.
+
+
+  METHOD create.
+    CREATE OBJECT ro_html.
   ENDMETHOD.
 
 

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -3,125 +3,6 @@
  */
 
 /* GLOBALS */
-.w500px { width: 500px }
-.dialog input::placeholder { color: #ccc }
-.dialog input:-ms-input-placeholder { color: #ccc }
-
-.dialog {
-  margin: 1em 1em;
-  padding: 1em 1em;
-  /*border: 1px solid #00000015;*/
-  border: 1px solid #cbcbcb;
-  border-radius: 4px;
-  /*background-color: #ffffff60;*/
-  background-color: #f4f4f4;
-  text-align: left;
-}
-.dialog li {
-  padding: 5px 10px;
-  display: block;
-  list-style: none;
-  position: relative;
-}
-.dialog button.field-cmd {
-  float: right;
-  position: absolute;
-  top: 0px;
-  right: 0px;
-  cursor: pointer;
-}
-.dialog li.dialog-commands {
-  text-align: right;
-  margin-top: 12px;
-}
-.dialog li.dialog-commands a {
-  /*background-color: #eaeaea;*/
-  border: 1px solid #ccc;
-  cursor: pointer;
-  text-decoration: none;
-  padding: 6px 12px;
-  border-radius: 3px;
-  font-size: smaller;
-}
-.dialog li.dialog-commands input[type="submit"] {
-  padding: 6px 12px;
-  border-radius: 3px;
-  cursor: pointer;
-  border: 1px solid #ccc;
-}
-.dialog li.dialog-commands input[type="submit"].main {
-  background-color: #64a8ff;
-  border: 1px solid transparent;
-  color: #fff;
-}
-
-.dialog label {
-  display: block;
-  font-size: 90%;
-  color: #444;
-  margin-top: 6px;
-  margin-bottom: 6px;
-  padding-left: 0.5em;
-}
-.dialog label span{
-  color: #ccc;
-  float: right;
-  padding-right: 0.5em;
-}
-.dialog small {
-  color: #999;
-  display: block;
-  font-size: 75%;
-  margin-top: 4px;
-}
-.dialog input[type="text"] {
-  /*line-height: 1.5em;*/
-  height: 2.5em; /* IE is strange ... */
-}
-.dialog .radio-container {
-  display: inline-block;
-  padding: 4px;
-  border: 1px solid #ddd;
-  border-radius: 3px;
-  background-color: #FFF;  
-}
-.dialog input[type="checkbox"] + label {
-  display: inline-block;
-}
-.dialog input[type="text"] {
-  width: 100%;
-  box-sizing : border-box;
-}
-
-.dialog .radio-container input[type="radio"] {
-  visibility: hidden;
-  display: none;
-  height: 0px;
-  width: 0px;
-}
-.dialog .radio-container input[type="radio"] + label {
-  cursor: pointer;
-  width: auto;
-  margin: 0px;
-  padding: 3px 8px;
-  border-radius: 2px;
-  color: #808080;
-  border: 1px solid transparent;
-  display: inline-block;
-}
-.dialog .radio-container input[type="radio"]:checked + label {
-  border: 1px solid transparent;
-  background-color: #64a8ff;
-  color: #fff;
-}
-.dialog li.with-command input {
-  padding-right: 1.8em;
-}
-.dialog li.with-command a {
-  width: 2em;
-  margin-left: -1.8em;
-}
-
 
 body {
   overflow-x: hidden;
@@ -183,6 +64,7 @@ span.separator {
 .inline       { display: inline; }
 .hidden       { visibility: hidden; }
 .nodisplay    { display: none }
+.w500px       { width: 500px }
 
 /* PANELS */
 div.panel {
@@ -1125,3 +1007,117 @@ table.settings_tab input {
   text-align: center;
 }
 settings_tab tr:first-child td { border-top: 0px; }
+
+/* DIALOGS */
+
+.dialog input::placeholder { color: #ccc }
+.dialog input:-ms-input-placeholder { color: #ccc }
+.dialog {
+  margin: 1em 1em;
+  padding: 1em 1em;
+  border: 1px solid #cbcbcb;
+  border-radius: 4px;
+  background-color: #f4f4f4;
+  text-align: left;
+}
+.dialog li {
+  padding: 5px 10px;
+  display: block;
+  list-style: none;
+  position: relative;
+}
+.dialog button.field-cmd {
+  float: right;
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  cursor: pointer;
+}
+.dialog li.dialog-commands {
+  text-align: right;
+  margin-top: 12px;
+}
+.dialog li.dialog-commands a {
+  border: 1px solid #ccc;
+  cursor: pointer;
+  text-decoration: none;
+  padding: 6px 12px;
+  border-radius: 3px;
+  font-size: smaller;
+}
+.dialog li.dialog-commands input[type="submit"] {
+  padding: 6px 12px;
+  border-radius: 3px;
+  cursor: pointer;
+  border: 1px solid #ccc;
+}
+.dialog li.dialog-commands input[type="submit"].main {
+  background-color: #64a8ff;
+  border: 1px solid transparent;
+  color: #fff;
+}
+.dialog label {
+  display: block;
+  font-size: 90%;
+  color: #444;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  padding-left: 0.5em;
+}
+.dialog label span{
+  color: #ccc;
+  float: right;
+  padding-right: 0.5em;
+}
+.dialog small {
+  color: #999;
+  display: block;
+  font-size: 75%;
+  margin-top: 4px;
+}
+.dialog input[type="text"] {
+  /*line-height: 1.5em;*/
+  height: 2.5em; /* IE is strange ... */
+}
+.dialog .radio-container {
+  display: inline-block;
+  padding: 4px;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  background-color: #FFF;  
+}
+.dialog input[type="checkbox"] + label {
+  display: inline-block;
+}
+.dialog input[type="text"] {
+  width: 100%;
+  box-sizing : border-box;
+}
+.dialog .radio-container input[type="radio"] {
+  visibility: hidden;
+  display: none;
+  height: 0px;
+  width: 0px;
+}
+.dialog .radio-container input[type="radio"] + label {
+  cursor: pointer;
+  width: auto;
+  margin: 0px;
+  padding: 3px 8px;
+  border-radius: 2px;
+  color: #808080;
+  border: 1px solid transparent;
+  display: inline-block;
+}
+.dialog .radio-container input[type="radio"]:checked + label {
+  border: 1px solid transparent;
+  background-color: #64a8ff;
+  color: #fff;
+}
+.dialog li.with-command input {
+  padding-right: 1.8em;
+}
+.dialog li.with-command a {
+  width: 2em;
+  margin-left: -1.8em;
+}

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -1117,7 +1117,7 @@ settings_tab tr:first-child td { border-top: 0px; }
 }
 .dialog li.with-command div.input-frame {
   /*overflow: hidden;*/
-  padding-right: 1.8em;
+  padding-right: 1.9em;
 }
 .dialog li.with-command input[type="submit"] {
   /*width: 2em;*/

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -34,6 +34,16 @@
   text-align: right;
   margin-top: 12px;
 }
+.dialog li.dialog-commands a {
+  /*background-color: #eaeaea;*/
+  border: 1px solid #ccc;
+  cursor: pointer;
+  text-decoration: none;
+  padding: 6px 12px;
+  border-radius: 3px;
+  font-size: smaller;
+}
+
 .dialog label {
   display: block;
   font-size: 90%;
@@ -63,7 +73,9 @@
 }
 .dialog input[type="submit"] {
   background-color: #64a8ff;
+  border: 1px solid transparent;
   color: #fff;
+  cursor: pointer;
 }
 .dialog .radio-container {
   display: inline-block;

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -1013,11 +1013,11 @@ settings_tab tr:first-child td { border-top: 0px; }
 .dialog input::placeholder { color: #ccc }
 .dialog input:-ms-input-placeholder { color: #ccc }
 .dialog {
+  border: 1px solid #cbcbcb;
+  background-color: #f4f4f4;
   margin: 1em 1em;
   padding: 1em 1em;
-  border: 1px solid #cbcbcb;
   border-radius: 4px;
-  background-color: #f4f4f4;
   text-align: left;
 }
 .dialog li {
@@ -1039,20 +1039,20 @@ settings_tab tr:first-child td { border-top: 0px; }
   font-size: smaller;
 }
 .dialog li.dialog-commands input[type="submit"] {
+  border: 1px solid #ccc;
   padding: 6px 12px;
   border-radius: 3px;
   cursor: pointer;
-  border: 1px solid #ccc;
 }
 .dialog li.dialog-commands input[type="submit"].main {
   background-color: #64a8ff;
-  border: 1px solid transparent;
   color: #fff;
+  border: 1px solid transparent;
 }
 .dialog label {
+  color: #444;
   display: block;
   font-size: 90%;
-  color: #444;
   margin-top: 6px;
   margin-bottom: 6px;
   padding-left: 0.5em;
@@ -1071,11 +1071,11 @@ settings_tab tr:first-child td { border-top: 0px; }
   border-color: #ff5959;
 }
 .dialog .radio-container {
+  border: 1px solid #ddd;
+  background-color: white;
   display: inline-block;
   padding: 4px;
-  border: 1px solid #ddd;
   border-radius: 3px;
-  background-color: #FFF;  
 }
 .dialog input[type="checkbox"] + label {
   display: inline-block;
@@ -1092,19 +1092,19 @@ settings_tab tr:first-child td { border-top: 0px; }
   width: 0px;
 }
 .dialog .radio-container input[type="radio"] + label {
+  color: #808080;
+  border: 1px solid transparent;
   cursor: pointer;
   width: auto;
   margin: 0px;
   padding: 3px 8px;
   border-radius: 2px;
-  color: #808080;
-  border: 1px solid transparent;
   display: inline-block;
 }
 .dialog .radio-container input[type="radio"]:checked + label {
-  border: 1px solid transparent;
   background-color: #64a8ff;
   color: #fff;
+  border: 1px solid transparent;
 }
 .dialog li.with-command input[type="text"] {
   /* for a, not submit */

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -38,11 +38,14 @@
   display: block;
   font-size: 90%;
   color: #444;
-  margin-bottom: 4px;
+  margin-top: 6px;
+  margin-bottom: 6px;
   padding-left: 0.5em;
 }
 .dialog label span{
-  color: #888;
+  color: #ccc;
+  float: right;
+  padding-right: 0.5em;
 }
 .dialog small {
   color: #999;
@@ -50,8 +53,9 @@
   font-size: 75%;
   margin-top: 4px;
 }
-.dialog input {
-  line-height: 1.5em;
+.dialog input[type="text"] {
+  /*line-height: 1.5em;*/
+  height: 2.5em; /* IE is strange ... */
 }
 .dialog input[type="button"], .dialog input[type="submit"] {
   padding: 6px 12px;
@@ -98,11 +102,11 @@
   color: #fff;
 }
 .dialog li.with-command input {
-  padding-right: 2em;
+  padding-right: 1.8em;
 }
 .dialog li.with-command a {
   width: 2em;
-  margin-left: -2em;
+  margin-left: -1.8em;
 }
 
 
@@ -131,7 +135,7 @@ sup {
 }
 
 input, textarea, select {
-  padding: 3px 6px;
+  padding: 3px 0.5em;
   border: 1px solid;
 }
 input:focus, textarea:focus {

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -43,6 +43,17 @@
   border-radius: 3px;
   font-size: smaller;
 }
+.dialog li.dialog-commands input[type="submit"] {
+  padding: 6px 12px;
+  border-radius: 3px;
+  cursor: pointer;
+  border: 1px solid #ccc;
+}
+.dialog li.dialog-commands input[type="submit"].main {
+  background-color: #64a8ff;
+  border: 1px solid transparent;
+  color: #fff;
+}
 
 .dialog label {
   display: block;
@@ -66,16 +77,6 @@
 .dialog input[type="text"] {
   /*line-height: 1.5em;*/
   height: 2.5em; /* IE is strange ... */
-}
-.dialog input[type="button"], .dialog input[type="submit"] {
-  padding: 6px 12px;
-  border-radius: 3px
-}
-.dialog input[type="submit"] {
-  background-color: #64a8ff;
-  border: 1px solid transparent;
-  color: #fff;
-  cursor: pointer;
 }
 .dialog .radio-container {
   display: inline-block;

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -3,6 +3,108 @@
  */
 
 /* GLOBALS */
+.w500px { width: 500px }
+.dialog input::placeholder { color: #ccc }
+.dialog input:-ms-input-placeholder { color: #ccc }
+
+.dialog {
+  margin: 1em 1em;
+  padding: 1em 1em;
+  /*border: 1px solid #00000015;*/
+  border: 1px solid #cbcbcb;
+  border-radius: 4px;
+  /*background-color: #ffffff60;*/
+  background-color: #f4f4f4;
+  text-align: left;
+}
+.dialog li {
+  padding: 5px 10px;
+  display: block;
+  list-style: none;
+  position: relative;
+}
+.dialog button.field-cmd {
+  float: right;
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  cursor: pointer;
+}
+.dialog li.dialog-commands {
+  text-align: right;
+  margin-top: 12px;
+}
+.dialog label {
+  display: block;
+  font-size: 90%;
+  color: #444;
+  margin-bottom: 4px;
+  padding-left: 0.5em;
+}
+.dialog label span{
+  color: #888;
+}
+.dialog small {
+  color: #999;
+  display: block;
+  font-size: 75%;
+  margin-top: 4px;
+}
+.dialog input {
+  line-height: 1.5em;
+}
+.dialog input[type="button"], .dialog input[type="submit"] {
+  padding: 6px 12px;
+  border-radius: 3px
+}
+.dialog input[type="submit"] {
+  background-color: #64a8ff;
+  color: #fff;
+}
+.dialog .radio-container {
+  display: inline-block;
+  padding: 4px;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  background-color: #FFF;  
+}
+.dialog input[type="checkbox"] + label {
+  display: inline-block;
+}
+.dialog input[type="text"] {
+  width: 100%;
+  box-sizing : border-box;
+}
+
+.dialog .radio-container input[type="radio"] {
+  visibility: hidden;
+  display: none;
+  height: 0px;
+  width: 0px;
+}
+.dialog .radio-container input[type="radio"] + label {
+  cursor: pointer;
+  width: auto;
+  margin: 0px;
+  padding: 3px 8px;
+  border-radius: 2px;
+  color: #808080;
+  border: 1px solid transparent;
+  display: inline-block;
+}
+.dialog .radio-container input[type="radio"]:checked + label {
+  border: 1px solid transparent;
+  background-color: #64a8ff;
+  color: #fff;
+}
+.dialog li.with-command input {
+  padding-right: 2em;
+}
+.dialog li.with-command a {
+  width: 2em;
+  margin-left: -2em;
+}
+
 
 body {
   overflow-x: hidden;

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -1106,23 +1106,16 @@ settings_tab tr:first-child td { border-top: 0px; }
   color: #fff;
   border: 1px solid transparent;
 }
-.dialog li.with-command input[type="text"] {
-  /* for a, not submit */
-  /*padding-right: 2em;*/
+.dialog li.with-command div.input-container {
+  display: table-cell;
+  width: 100%;
 }
-.dialog li.with-command a {
-  /* for a, not submit */
-  width: 2em;
-  margin-left: -1.8em;
-}
-.dialog li.with-command div.input-frame {
-  /*overflow: hidden;*/
-  padding-right: 1.9em;
+.dialog li.with-command div.command-container {
+  display: table-cell;
 }
 .dialog li.with-command input[type="submit"] {
-  /*width: 2em;*/
-  float: right;
   height: 2.5em;
+  border-left: none;
 }
 .dialog li.with-command input[type="submit"]:hover {
   background-color: #64a8ff;

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -64,7 +64,14 @@ span.separator {
 .inline       { display: inline; }
 .hidden       { visibility: hidden; }
 .nodisplay    { display: none }
-.w500px       { width: 500px }
+.m-em5-sides  { margin-left: 0.5em; margin-right: 0.5em }
+.w600px       { width: 600px }
+.wmax600px    { max-width: 600px }
+.auto-center  { /* use with max-width */
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
 
 /* PANELS */
 div.panel {
@@ -1015,7 +1022,6 @@ settings_tab tr:first-child td { border-top: 0px; }
 .dialog {
   border: 1px solid #cbcbcb;
   background-color: #f4f4f4;
-  margin: 1em 1em;
   padding: 1em 1em;
   border-radius: 4px;
   text-align: left;
@@ -1115,7 +1121,6 @@ settings_tab tr:first-child td { border-top: 0px; }
 }
 .dialog li.with-command input[type="submit"] {
   height: 2.5em;
-  border-left: none;
 }
 .dialog li.with-command input[type="submit"]:hover {
   background-color: #64a8ff;

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -1026,13 +1026,6 @@ settings_tab tr:first-child td { border-top: 0px; }
   list-style: none;
   position: relative;
 }
-.dialog button.field-cmd {
-  float: right;
-  position: absolute;
-  top: 0px;
-  right: 0px;
-  cursor: pointer;
-}
 .dialog li.dialog-commands {
   text-align: right;
   margin-top: 12px;
@@ -1077,10 +1070,6 @@ settings_tab tr:first-child td { border-top: 0px; }
 .dialog li.error input[type="text"] {
   border-color: #ff5959;
 }
-.dialog input[type="text"] {
-  /*line-height: 1.5em;*/
-  height: 2.5em; /* IE is strange ... */
-}
 .dialog .radio-container {
   display: inline-block;
   padding: 4px;
@@ -1094,6 +1083,7 @@ settings_tab tr:first-child td { border-top: 0px; }
 .dialog input[type="text"] {
   width: 100%;
   box-sizing : border-box;
+  height: 2.5em;
 }
 .dialog .radio-container input[type="radio"] {
   visibility: hidden;
@@ -1116,10 +1106,25 @@ settings_tab tr:first-child td { border-top: 0px; }
   background-color: #64a8ff;
   color: #fff;
 }
-.dialog li.with-command input {
-  padding-right: 1.8em;
+.dialog li.with-command input[type="text"] {
+  /* for a, not submit */
+  /*padding-right: 2em;*/
 }
 .dialog li.with-command a {
+  /* for a, not submit */
   width: 2em;
   margin-left: -1.8em;
+}
+.dialog li.with-command div.input-frame {
+  /*overflow: hidden;*/
+  padding-right: 1.8em;
+}
+.dialog li.with-command input[type="submit"] {
+  /*width: 2em;*/
+  float: right;
+  height: 2.5em;
+}
+.dialog li.with-command input[type="submit"]:hover {
+  background-color: #64a8ff;
+  color: #fff;
 }

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -1064,16 +1064,18 @@ settings_tab tr:first-child td { border-top: 0px; }
   margin-bottom: 6px;
   padding-left: 0.5em;
 }
-.dialog label span{
-  color: #ccc;
-  float: right;
-  padding-right: 0.5em;
+.dialog label em {
+  color: #64a8ff;
 }
-.dialog small {
-  color: #999;
+.dialog li.error small {
+  color: #ff5959;
   display: block;
   font-size: 75%;
-  margin-top: 4px;
+  margin: 4px 0px;
+  padding-left: 0.5em;
+}
+.dialog li.error input[type="text"] {
+  border-color: #ff5959;
 }
 .dialog input[type="text"] {
   /*line-height: 1.5em;*/

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -14,6 +14,9 @@ CLASS zcl_abapgit_gui_page_addonline DEFINITION
 
     METHODS zif_abapgit_gui_event_handler~on_event REDEFINITION .
 
+    METHODS constructor
+      RAISING
+        zcx_abapgit_exception.
 
   PROTECTED SECTION.
 
@@ -27,6 +30,12 @@ ENDCLASS.
 CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
 
+  METHOD constructor.
+    super->constructor( ).
+    ms_control-page_title = 'Clone online repository'. " TODO refactor
+  ENDMETHOD.
+
+
   METHOD create.
     CREATE OBJECT ro_page.
   ENDMETHOD.
@@ -36,7 +45,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
     DATA lo_form TYPE REF TO zcl_abapgit_html_form.
 
-    CREATE OBJECT ro_html.
+    ri_html = zcl_abapgit_html=>create( ).
 
     lo_form = zcl_abapgit_html_form=>create( ).
     lo_form->text(
@@ -53,19 +62,37 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
       iv_hint        = 'SAP package for the code (should be a dedicated one)'
       iv_placeholder = 'Z... / $...' ).
     lo_form->text(
+      iv_name        = 'branch'
+      iv_side_action = 'choose-branch'
+      iv_label       = 'Branch'
+      iv_hint        = 'Switch to a specific branch on clone (default: master)'
+      iv_value       = 'master' ).
+    lo_form->text(
       iv_name        = 'display-name'
       iv_label       = 'Display name'
       iv_hint        = 'Name to show instead of original repo name (optional)' ).
+    lo_form->radio(
+      iv_name        = 'folder-logic'
+      iv_label       = 'Folder logic'
+      iv_hint        = 'Define how package folders are named in the repo (see https://docs.abapgit.org)' ).
+    lo_form->option(
+      iv_selected    = abap_true
+      iv_label       = 'Prefix'
+      iv_value       = 'prefix' ).
+    lo_form->option(
+      iv_label       = 'Full'
+      iv_value       = 'full' ).
+
     lo_form->checkbox(
       iv_name        = 'ignore-subpackages'
       iv_label       = 'Ignore subpackages'
-      iv_hint        = '??? TODO describe' ).
+      iv_hint        = 'Syncronize root package only (see https://docs.abapgit.org)' ).
     lo_form->checkbox(
       iv_name        = 'master-lang-only'
       iv_label       = 'Master language only'
       iv_hint        = 'Ignore translations, serialize just master language' ).
 
-    ro_html->add( lo_form->render(
+    ri_html->add( lo_form->render(
       iv_form_class = 'dialog w500px'
       iv_action = 'add-repo-online' ) ).
 

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -136,10 +136,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
       iv_label       = 'Branch'
       iv_hint        = 'Switch to a specific branch on clone (default: master)'
       iv_placeholder = 'master' ).
-    lo_form->text(
-      iv_name        = c_id-display_name
-      iv_label       = 'Display name'
-      iv_hint        = 'Name to show instead of original repo name (optional)' ).
     lo_form->radio(
       iv_name        = c_id-folder_logic
       iv_default_value = zif_abapgit_dot_abapgit=>c_folder_logic-prefix
@@ -151,13 +147,17 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
     lo_form->option(
       iv_label       = 'Full'
       iv_value       = zif_abapgit_dot_abapgit=>c_folder_logic-full ).
+    lo_form->text(
+      iv_name        = c_id-display_name
+      iv_label       = 'Display name'
+      iv_hint        = 'Name to show instead of original repo name (optional)' ).
     lo_form->checkbox(
       iv_name        = c_id-ignore_subpackages
       iv_label       = 'Ignore subpackages'
       iv_hint        = 'Syncronize root package only (see https://docs.abapgit.org)' ).
     lo_form->checkbox(
       iv_name        = c_id-master_lang_only
-      iv_label       = 'Master language only'
+      iv_label       = 'Serialize master language only'
       iv_hint        = 'Ignore translations, serialize just master language' ).
     lo_form->command(
       iv_label       = 'Clone online repo'
@@ -242,6 +242,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
           iv_key = c_id-package
           iv_val = zcl_abapgit_services_basis=>create_package( ) ).
         IF mo_form_data->get( c_id-package ) IS NOT INITIAL.
+          mo_validation_log = validate_form( mo_form_data ).
           ev_state = zcl_abapgit_gui=>c_event_state-re_render.
         ELSE.
           ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
@@ -253,6 +254,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
           iv_key = c_id-package
           iv_val = zcl_abapgit_ui_factory=>get_popups( )->popup_search_help( 'TDEVC-DEVCLASS' ) ).
         IF mo_form_data->get( c_id-package ) IS NOT INITIAL.
+          mo_validation_log = validate_form( mo_form_data ).
           ev_state = zcl_abapgit_gui=>c_event_state-re_render.
         ELSE.
           ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
@@ -263,6 +265,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
         mo_validation_log = validate_form( mo_form_data ).
         IF mo_validation_log->has( c_id-url ) = abap_true.
           ev_state = zcl_abapgit_gui=>c_event_state-re_render. " Display errors
+          RETURN.
         ENDIF.
         mo_form_data->set(
           iv_key = c_id-branch_name

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -23,6 +23,17 @@ CLASS zcl_abapgit_gui_page_addonline DEFINITION
     METHODS render_content REDEFINITION.
 
   PRIVATE SECTION.
+
+    CONSTANTS:
+      BEGIN OF c_event,
+        go_back TYPE string VALUE 'go-back',
+        choose_package TYPE string VALUE 'choose-package',
+        create_package TYPE string VALUE 'create-package',
+        choose_branch TYPE string VALUE 'choose-branch',
+        add_online_repo TYPE string VALUE 'add-repo-online',
+      END OF c_event.
+
+
 ENDCLASS.
 
 
@@ -57,13 +68,13 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
     lo_form->text(
       iv_name        = 'package'
       iv_required    = abap_true
-      iv_side_action = 'choose-package'
+      iv_side_action = c_event-choose_package
       iv_label       = 'Package'
       iv_hint        = 'SAP package for the code (should be a dedicated one)'
       iv_placeholder = 'Z... / $...' ).
     lo_form->text(
       iv_name        = 'branch'
-      iv_side_action = 'choose-branch'
+      iv_side_action = c_event-choose_branch
       iv_label       = 'Branch'
       iv_hint        = 'Switch to a specific branch on clone (default: master)'
       iv_value       = 'master' ).
@@ -82,7 +93,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
     lo_form->option(
       iv_label       = 'Full'
       iv_value       = 'full' ).
-
     lo_form->checkbox(
       iv_name        = 'ignore-subpackages'
       iv_label       = 'Ignore subpackages'
@@ -91,10 +101,17 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
       iv_name        = 'master-lang-only'
       iv_label       = 'Master language only'
       iv_hint        = 'Ignore translations, serialize just master language' ).
+    lo_form->set_submit_params(
+      iv_label       = 'Clone online repo'
+      iv_action      = c_event-add_online_repo ).
+    lo_form->command(
+      iv_label       = 'Create package'
+      iv_action      = c_event-create_package ).
+    lo_form->command(
+      iv_label       = 'Back'
+      iv_action      = c_event-go_back ).
 
-    ri_html->add( lo_form->render(
-      iv_form_class = 'dialog w500px'
-      iv_action = 'add-repo-online' ) ).
+    ri_html->add( lo_form->render( iv_form_class = 'dialog w500px' ) ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -240,7 +240,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
         mo_form_data->set(
           iv_key = c_id-package
-          iv_val = zcl_abapgit_services_basis=>create_package( iv_prefill_package = |{ mo_form_data->get( 'package' ) }| ) ).
+          iv_val = zcl_abapgit_services_basis=>create_package(
+            iv_prefill_package = |{ mo_form_data->get( 'package' ) }| ) ).
         IF mo_form_data->get( c_id-package ) IS NOT INITIAL.
           mo_validation_log = validate_form( mo_form_data ).
           ev_state = zcl_abapgit_gui=>c_event_state-re_render.

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -40,12 +40,34 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
     lo_form = zcl_abapgit_html_form=>create( ).
     lo_form->text(
-      iv_name = 'abc'
-      iv_label = 'abcd' ).
+      iv_name        = 'repo-url'
+      iv_required    = abap_true
+      iv_label       = 'Git repository URL'
+      iv_hint        = 'HTTPS address of the repository to clone'
+      iv_placeholder = 'https://github.com/...git' ).
+    lo_form->text(
+      iv_name        = 'package'
+      iv_required    = abap_true
+      iv_side_action = 'choose-package'
+      iv_label       = 'Package'
+      iv_hint        = 'SAP package for the code (should be a dedicated one)'
+      iv_placeholder = 'Z... / $...' ).
+    lo_form->text(
+      iv_name        = 'display-name'
+      iv_label       = 'Display name'
+      iv_hint        = 'Name to show instead of original repo name (optional)' ).
+    lo_form->checkbox(
+      iv_name        = 'ignore-subpackages'
+      iv_label       = 'Ignore subpackages'
+      iv_hint        = '??? TODO describe' ).
+    lo_form->checkbox(
+      iv_name        = 'master-lang-only'
+      iv_label       = 'Master language only'
+      iv_hint        = 'Ignore translations, serialize just master language' ).
 
     ro_html->add( lo_form->render(
-      iv_form_class = 'dialog'
-      iv_action = 'dododo' ) ).
+      iv_form_class = 'dialog w500px'
+      iv_action = 'add-repo-online' ) ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -207,28 +207,12 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
       WHEN c_event-create_package.
 
-        " Move this to services ?
-
         ms_form_data = parse_form( it_postdata ). " import data from html before re-render
-
-        DATA ls_package_data TYPE scompkdtln.
-        DATA lv_create       TYPE abap_bool.
-        DATA li_popups       TYPE REF TO zif_abapgit_popups.
-
-        li_popups = zcl_abapgit_ui_factory=>get_popups( ).
-
-        li_popups->popup_to_create_package(
-          IMPORTING
-            es_package_data = ls_package_data
-            ev_create       = lv_create ).
-        IF lv_create = abap_false.
-          ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
-        ELSE.
-          zcl_abapgit_factory=>get_sap_package( ls_package_data-devclass )->create( ls_package_data ).
-          COMMIT WORK. " Hmmm ?
-
-          ms_form_data-package = ls_package_data-devclass.
+        ms_form_data-package = zcl_abapgit_services_basis=>create_package( ).
+        IF ms_form_data-package IS NOT INITIAL.
           ev_state = zcl_abapgit_gui=>c_event_state-re_render.
+        ELSE.
+          ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
         ENDIF.
 
       WHEN c_event-choose_package.

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -1,0 +1,55 @@
+CLASS zcl_abapgit_gui_page_addonline DEFINITION
+  PUBLIC
+  INHERITING FROM zcl_abapgit_gui_page
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS create
+      RETURNING
+        VALUE(ro_page) TYPE REF TO zcl_abapgit_gui_page_addonline
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS zif_abapgit_gui_event_handler~on_event REDEFINITION .
+
+
+  PROTECTED SECTION.
+
+    METHODS render_content REDEFINITION.
+
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
+
+
+  METHOD create.
+    CREATE OBJECT ro_page.
+  ENDMETHOD.
+
+
+  METHOD render_content.
+
+    DATA lo_form TYPE REF TO zcl_abapgit_html_form.
+
+    CREATE OBJECT ro_html.
+
+    lo_form = zcl_abapgit_html_form=>create( ).
+    lo_form->text(
+      iv_name = 'abc'
+      iv_label = 'abcd' ).
+
+    ro_html->add( lo_form->render(
+      iv_form_class = 'dialog'
+      iv_action = 'dododo' ) ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_gui_event_handler~on_event.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -171,7 +171,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
       iv_action      = c_event-go_back ).
 
     ri_html->add( lo_form->render(
-      iv_form_class     = 'dialog w500px'
+      iv_form_class     = 'dialog w600px m-em5-sides' " to center add wmax600px and auto-center instead
       io_values         = mo_form_data
       io_validation_log = mo_validation_log ) ).
 

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -240,7 +240,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
         mo_form_data->set(
           iv_key = c_id-package
-          iv_val = zcl_abapgit_services_basis=>create_package( ) ).
+          iv_val = zcl_abapgit_services_basis=>create_package( iv_prefill_package = |{ mo_form_data->get( 'package' ) }| ) ).
         IF mo_form_data->get( c_id-package ) IS NOT INITIAL.
           mo_validation_log = validate_form( mo_form_data ).
           ev_state = zcl_abapgit_gui=>c_event_state-re_render.

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -15,15 +15,15 @@ CLASS zcl_abapgit_gui_page_addonline DEFINITION
 
     METHODS zif_abapgit_gui_event_handler~on_event REDEFINITION .
 
+    METHODS constructor
+      RAISING
+        zcx_abapgit_exception.
+
   PROTECTED SECTION.
 
     METHODS render_content REDEFINITION.
 
   PRIVATE SECTION.
-
-    METHODS constructor
-      RAISING
-        zcx_abapgit_exception.
 
     CONSTANTS:
       BEGIN OF c_event,
@@ -236,11 +236,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
     IF ev_state IS INITIAL. " TODO !!! Refactor this disaster !!!
       super->zif_abapgit_gui_event_handler~on_event(
-        exporting
+        EXPORTING
           iv_action = iv_action
           iv_getdata = iv_getdata
           it_postdata = it_postdata
-        importing
+        IMPORTING
           ei_page = ei_page
           ev_state = ev_state ).
     ENDIF.

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -233,34 +233,12 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
       WHEN c_event-choose_package.
 
-        " TODO Implement as an util
-
-        DATA lt_ret TYPE TABLE OF ddshretval.
-        DATA ls_ret LIKE LINE OF lt_ret.
-
-        CALL FUNCTION 'F4IF_FIELD_VALUE_REQUEST'
-          EXPORTING
-            tabname   = 'TDEVC'
-            fieldname = 'DEVCLASS'
-          TABLES
-            return_tab = lt_ret
-          EXCEPTIONS
-            OTHERS = 5.
-
-        IF sy-subrc <> 0.
-          zcx_abapgit_exception=>raise( 'Unexpected error in F4IF_FIELD_VALUE_REQUEST' ).
-        ENDIF.
-
-        IF lines( lt_ret ) = 0.
-          ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
-        ELSE.
-
-          ms_form_data = parse_form( it_postdata ). " import data from html before re-render
-
-          READ TABLE lt_ret INDEX 1 INTO ls_ret.
-          ASSERT sy-subrc = 0.
-          ms_form_data-package = ls_ret-fieldval.
+        ms_form_data = parse_form( it_postdata ). " import data from html before re-render
+        ms_form_data-package = zcl_abapgit_ui_factory=>get_popups( )->popup_search_help( 'TDEVC-DEVCLASS' ).
+        IF ms_form_data-package IS NOT INITIAL.
           ev_state = zcl_abapgit_gui=>c_event_state-re_render.
+        ELSE.
+          ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
         ENDIF.
 
       WHEN c_event-add_online_repo.

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -192,7 +192,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
   METHOD validate_form.
 
-    DATA lx TYPE REF TO zcx_abapgit_exception.
+    DATA lx_err TYPE REF TO zcx_abapgit_exception.
 
     CREATE OBJECT ro_validation_log.
 
@@ -201,12 +201,12 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
         iv_key = c_id-url
         iv_val = 'Url cannot be empty' ).
     ELSE.
-      TRY .
+      TRY.
           zcl_abapgit_url=>validate( is_form_data-url ).
-        CATCH zcx_abapgit_exception INTO lx.
+        CATCH zcx_abapgit_exception INTO lx_err.
           ro_validation_log->set(
             iv_key = c_id-url
-            iv_val = lx->get_text( ) ).
+            iv_val = lx_err->get_text( ) ).
       ENDTRY.
     ENDIF.
 
@@ -215,14 +215,14 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
         iv_key = c_id-package
         iv_val = 'Package cannot be empty' ).
     ELSE.
-      TRY .
+      TRY.
           zcl_abapgit_repo_srv=>get_instance( )->validate_package(
             iv_package    = is_form_data-package
             iv_ign_subpkg = is_form_data-ignore_subpackages ).
-        CATCH zcx_abapgit_exception INTO lx.
+        CATCH zcx_abapgit_exception INTO lx_err.
           ro_validation_log->set(
             iv_key = c_id-package
-            iv_val = lx->get_text( ) ).
+            iv_val = lx_err->get_text( ) ).
       ENDTRY.
     ENDIF.
 

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -27,13 +27,13 @@ CLASS zcl_abapgit_gui_page_addonline DEFINITION
 
     CONSTANTS:
       BEGIN OF c_id,
-        url TYPE string VALUE 'url',
-        package TYPE string VALUE 'package',
-        branch_name TYPE string VALUE 'branch_name',
-        display_name TYPE string VALUE 'display_name',
-        folder_logic TYPE string VALUE 'folder_logic',
+        url                TYPE string VALUE 'url',
+        package            TYPE string VALUE 'package',
+        branch_name        TYPE string VALUE 'branch_name',
+        display_name       TYPE string VALUE 'display_name',
+        folder_logic       TYPE string VALUE 'folder_logic',
         ignore_subpackages TYPE string VALUE 'ignore_subpackages',
-        master_lang_only TYPE string VALUE 'master_lang_only',
+        master_lang_only   TYPE string VALUE 'master_lang_only',
       END OF c_id.
 
     CONSTANTS:
@@ -45,20 +45,20 @@ CLASS zcl_abapgit_gui_page_addonline DEFINITION
         add_online_repo TYPE string VALUE 'add-repo-online',
       END OF c_event.
 
-    DATA ms_form_data TYPE zif_abapgit_services_repo=>ty_repo_params.
     DATA mo_validation_log TYPE REF TO zcl_abapgit_string_map.
+    DATA mo_form_data TYPE REF TO zcl_abapgit_string_map.
 
     METHODS parse_form
       IMPORTING
         it_post_data TYPE cnht_post_data_tab
       RETURNING
-        VALUE(rs_form_data) TYPE zif_abapgit_services_repo=>ty_repo_params
+        VALUE(ro_form_data) TYPE REF TO zcl_abapgit_string_map
       RAISING
         zcx_abapgit_exception.
 
     METHODS validate_form
       IMPORTING
-        is_form_data TYPE zif_abapgit_services_repo=>ty_repo_params
+        io_form_data TYPE REF TO zcl_abapgit_string_map
       RETURNING
         VALUE(ro_validation_log) TYPE REF TO zcl_abapgit_string_map
       RAISING
@@ -75,6 +75,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
     super->constructor( ).
     ms_control-page_title = 'Clone online repository'. " TODO refactor
     CREATE OBJECT mo_validation_log.
+    CREATE OBJECT mo_form_data.
   ENDMETHOD.
 
 
@@ -89,28 +90,22 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
     DATA ls_field LIKE LINE OF lt_form.
 
     lt_form = zcl_abapgit_html_action_utils=>parse_post_data( it_post_data ).
+    CREATE OBJECT ro_form_data.
 
     LOOP AT lt_form INTO ls_field.
       CASE ls_field-name.
-        WHEN c_id-url.
-          rs_form_data-url = ls_field-value.
-        WHEN c_id-package.
-          rs_form_data-package = ls_field-value.
-        WHEN c_id-branch_name.
-          rs_form_data-branch_name = ls_field-value.
-        WHEN c_id-display_name.
-          rs_form_data-display_name = ls_field-value.
-        WHEN c_id-folder_logic.
-          rs_form_data-folder_logic = ls_field-value.
-        WHEN c_id-ignore_subpackages.
-          rs_form_data-ignore_subpackages = boolc( ls_field-value = 'on' ).
-        WHEN c_id-master_lang_only.
-          rs_form_data-master_lang_only = boolc( ls_field-value = 'on' ).
+        WHEN c_id-url OR c_id-package OR c_id-branch_name OR c_id-display_name OR c_id-folder_logic.
+          ro_form_data->set(
+            iv_key = ls_field-name
+            iv_val = ls_field-value ).
+        WHEN c_id-ignore_subpackages OR c_id-master_lang_only. " Flags
+          ro_form_data->set(
+            iv_key = ls_field-name
+            iv_val = boolc( ls_field-value = 'on' ) ).
         WHEN OTHERS.
           zcx_abapgit_exception=>raise( |Unexpected form field [{ ls_field-name }]| ).
       ENDCASE.
     ENDLOOP.
-
 
   ENDMETHOD.
 
@@ -121,17 +116,15 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
     ri_html = zcl_abapgit_html=>create( ).
 
-    lo_form = zcl_abapgit_html_form=>create( ).
+    lo_form = zcl_abapgit_html_form=>create( iv_form_id = 'add-repo-online-form' ).
     lo_form->text(
       iv_name        = c_id-url
-      iv_value       = ms_form_data-url
       iv_required    = abap_true
       iv_label       = 'Git repository URL'
       iv_hint        = 'HTTPS address of the repository to clone'
       iv_placeholder = 'https://github.com/...git' ).
     lo_form->text(
       iv_name        = c_id-package
-      iv_value       = |{ ms_form_data-package }|
       iv_side_action = c_event-choose_package
       iv_required    = abap_true
       iv_label       = 'Package'
@@ -139,37 +132,31 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
       iv_placeholder = 'Z... / $...' ).
     lo_form->text(
       iv_name        = c_id-branch_name
-      iv_value       = ms_form_data-branch_name
       iv_side_action = c_event-choose_branch
       iv_label       = 'Branch'
       iv_hint        = 'Switch to a specific branch on clone (default: master)'
       iv_placeholder = 'master' ).
     lo_form->text(
       iv_name        = c_id-display_name
-      iv_value       = ms_form_data-display_name
       iv_label       = 'Display name'
       iv_hint        = 'Name to show instead of original repo name (optional)' ).
     lo_form->radio(
       iv_name        = c_id-folder_logic
+      iv_default_value = zif_abapgit_dot_abapgit=>c_folder_logic-prefix
       iv_label       = 'Folder logic'
       iv_hint        = 'Define how package folders are named in the repo (see https://docs.abapgit.org)' ).
     lo_form->option(
-      iv_selected    = boolc( ms_form_data-folder_logic = zif_abapgit_dot_abapgit=>c_folder_logic-prefix
-                           OR ms_form_data-folder_logic IS INITIAL  )
       iv_label       = 'Prefix'
       iv_value       = zif_abapgit_dot_abapgit=>c_folder_logic-prefix ).
     lo_form->option(
-      iv_selected    = boolc( ms_form_data-folder_logic = zif_abapgit_dot_abapgit=>c_folder_logic-full )
       iv_label       = 'Full'
       iv_value       = zif_abapgit_dot_abapgit=>c_folder_logic-full ).
     lo_form->checkbox(
       iv_name        = c_id-ignore_subpackages
-      iv_checked     = ms_form_data-ignore_subpackages
       iv_label       = 'Ignore subpackages'
       iv_hint        = 'Syncronize root package only (see https://docs.abapgit.org)' ).
     lo_form->checkbox(
       iv_name        = c_id-master_lang_only
-      iv_checked     = ms_form_data-master_lang_only
       iv_label       = 'Master language only'
       iv_hint        = 'Ignore translations, serialize just master language' ).
     lo_form->command(
@@ -185,6 +172,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
     ri_html->add( lo_form->render(
       iv_form_class     = 'dialog w500px'
+      io_values         = mo_form_data
       io_validation_log = mo_validation_log ) ).
 
   ENDMETHOD.
@@ -196,13 +184,13 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
     CREATE OBJECT ro_validation_log.
 
-    IF is_form_data-url IS INITIAL.
+    IF io_form_data->get( c_id-url ) IS INITIAL.
       ro_validation_log->set(
         iv_key = c_id-url
         iv_val = 'Url cannot be empty' ).
     ELSE.
       TRY.
-          zcl_abapgit_url=>validate( is_form_data-url ).
+          zcl_abapgit_url=>validate( io_form_data->get( c_id-url ) ).
         CATCH zcx_abapgit_exception INTO lx_err.
           ro_validation_log->set(
             iv_key = c_id-url
@@ -210,15 +198,15 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
       ENDTRY.
     ENDIF.
 
-    IF is_form_data-package IS INITIAL.
+    IF io_form_data->get( c_id-package ) IS INITIAL.
       ro_validation_log->set(
         iv_key = c_id-package
         iv_val = 'Package cannot be empty' ).
     ELSE.
       TRY.
           zcl_abapgit_repo_srv=>get_instance( )->validate_package(
-            iv_package    = is_form_data-package
-            iv_ign_subpkg = is_form_data-ignore_subpackages ).
+            iv_package    = |{ io_form_data->get( c_id-package ) }|
+            iv_ign_subpkg = |{ io_form_data->get( c_id-ignore_subpackages ) }| ).
         CATCH zcx_abapgit_exception INTO lx_err.
           ro_validation_log->set(
             iv_key = c_id-package
@@ -226,11 +214,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
       ENDTRY.
     ENDIF.
 
-    IF is_form_data-folder_logic <> zif_abapgit_dot_abapgit=>c_folder_logic-prefix
-        AND is_form_data-folder_logic <> zif_abapgit_dot_abapgit=>c_folder_logic-full.
+    IF io_form_data->get( c_id-folder_logic ) <> zif_abapgit_dot_abapgit=>c_folder_logic-prefix
+        AND io_form_data->get( c_id-folder_logic ) <> zif_abapgit_dot_abapgit=>c_folder_logic-full.
       ro_validation_log->set(
         iv_key = c_id-folder_logic
-        iv_val = |Invalid folder logic { is_form_data-folder_logic
+        iv_val = |Invalid folder logic { io_form_data->get( c_id-folder_logic )
         }. Must be { zif_abapgit_dot_abapgit=>c_folder_logic-prefix
         } or { zif_abapgit_dot_abapgit=>c_folder_logic-full } | ).
     ENDIF.
@@ -240,15 +228,20 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_event_handler~on_event.
 
+    DATA ls_repo_params TYPE zif_abapgit_services_repo=>ty_repo_params.
+
+    mo_form_data = parse_form( it_postdata ). " import data from html before re-render
+
     CASE iv_action.
       WHEN c_event-go_back.
         ev_state = zcl_abapgit_gui=>c_event_state-go_back.
 
       WHEN c_event-create_package.
 
-        ms_form_data = parse_form( it_postdata ). " import data from html before re-render
-        ms_form_data-package = zcl_abapgit_services_basis=>create_package( ).
-        IF ms_form_data-package IS NOT INITIAL.
+        mo_form_data->set(
+          iv_key = c_id-package
+          iv_val = zcl_abapgit_services_basis=>create_package( ) ).
+        IF mo_form_data->get( c_id-package ) IS NOT INITIAL.
           ev_state = zcl_abapgit_gui=>c_event_state-re_render.
         ELSE.
           ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
@@ -256,9 +249,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
       WHEN c_event-choose_package.
 
-        ms_form_data = parse_form( it_postdata ).
-        ms_form_data-package = zcl_abapgit_ui_factory=>get_popups( )->popup_search_help( 'TDEVC-DEVCLASS' ).
-        IF ms_form_data-package IS NOT INITIAL.
+        mo_form_data->set(
+          iv_key = c_id-package
+          iv_val = zcl_abapgit_ui_factory=>get_popups( )->popup_search_help( 'TDEVC-DEVCLASS' ) ).
+        IF mo_form_data->get( c_id-package ) IS NOT INITIAL.
           ev_state = zcl_abapgit_gui=>c_event_state-re_render.
         ELSE.
           ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
@@ -266,29 +260,33 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
 
       WHEN c_event-choose_branch.
 
-        ms_form_data = parse_form( it_postdata ).
-        mo_validation_log = validate_form( ms_form_data ).
+        mo_validation_log = validate_form( mo_form_data ).
         IF mo_validation_log->has( c_id-url ) = abap_true.
           ev_state = zcl_abapgit_gui=>c_event_state-re_render. " Display errors
         ENDIF.
-        ms_form_data-branch_name = zcl_abapgit_ui_factory=>get_popups( )->branch_list_popup( ms_form_data-url )-name.
-        IF ms_form_data-branch_name IS INITIAL.
+        mo_form_data->set(
+          iv_key = c_id-branch_name
+          iv_val = zcl_abapgit_ui_factory=>get_popups( )->branch_list_popup( mo_form_data->get( c_id-url ) )-name ).
+
+        IF mo_form_data->get( c_id-branch_name ) IS INITIAL.
           ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
         ELSE.
-          ms_form_data-branch_name = replace( " strip technical
-            val = ms_form_data-branch_name
-            sub = 'refs/heads/'
-            with = '' ).
+          mo_form_data->set(
+            iv_key = c_id-branch_name
+            iv_val = replace( " strip technical
+              val = mo_form_data->get( c_id-branch_name )
+              sub = 'refs/heads/'
+              with = '' ) ).
           ev_state = zcl_abapgit_gui=>c_event_state-re_render.
         ENDIF.
 
       WHEN c_event-add_online_repo.
 
-        ms_form_data = parse_form( it_postdata ).
-        mo_validation_log = validate_form( ms_form_data ).
+        mo_validation_log = validate_form( mo_form_data ).
 
         IF mo_validation_log->is_empty( ) = abap_true.
-          zcl_abapgit_services_repo=>new_online( ms_form_data ).
+          mo_form_data->to_abap( CHANGING cs_container = ls_repo_params ).
+          zcl_abapgit_services_repo=>new_online( ls_repo_params ).
           ev_state = zcl_abapgit_gui=>c_event_state-go_back.
         ELSE.
           ev_state = zcl_abapgit_gui=>c_event_state-re_render. " Display errors

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -2,7 +2,7 @@ CLASS zcl_abapgit_gui_page_addonline DEFINITION
   PUBLIC
   INHERITING FROM zcl_abapgit_gui_page
   FINAL
-  CREATE PUBLIC .
+  CREATE PRIVATE .
 
   PUBLIC SECTION.
 
@@ -14,25 +14,51 @@ CLASS zcl_abapgit_gui_page_addonline DEFINITION
 
     METHODS zif_abapgit_gui_event_handler~on_event REDEFINITION .
 
-    METHODS constructor
-      RAISING
-        zcx_abapgit_exception.
-
   PROTECTED SECTION.
 
     METHODS render_content REDEFINITION.
 
   PRIVATE SECTION.
 
+    METHODS constructor
+      RAISING
+        zcx_abapgit_exception.
+
+    TYPES:
+      BEGIN OF ty_form_data,
+        url              TYPE string,
+        package          TYPE devclass,
+        branch_name      TYPE string,
+        display_name     TYPE string,
+        folder_logic     TYPE string,
+        ignore_subpackages TYPE abap_bool,
+        master_lang_only TYPE abap_bool,
+      END OF ty_form_data .
+
     CONSTANTS:
       BEGIN OF c_event,
-        go_back TYPE string VALUE 'go-back',
-        choose_package TYPE string VALUE 'choose-package',
-        create_package TYPE string VALUE 'create-package',
-        choose_branch TYPE string VALUE 'choose-branch',
+        go_back         TYPE string VALUE 'go-back',
+        choose_package  TYPE string VALUE 'choose-package',
+        create_package  TYPE string VALUE 'create-package',
+        choose_branch   TYPE string VALUE 'choose-branch',
         add_online_repo TYPE string VALUE 'add-repo-online',
       END OF c_event.
 
+    DATA ms_form_data TYPE ty_form_data.
+
+    METHODS parse_form
+      IMPORTING
+        it_post_data TYPE cnht_post_data_tab
+      RETURNING
+        VALUE(rs_form_data) TYPE ty_form_data
+      RAISING
+        zcx_abapgit_exception.
+
+    METHODS validate_form
+      IMPORTING
+        is_form_data TYPE ty_form_data
+      RAISING
+        zcx_abapgit_exception.
 
 ENDCLASS.
 
@@ -52,6 +78,38 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD parse_form.
+
+    DATA lt_form TYPE tihttpnvp.
+    DATA ls_field LIKE LINE OF lt_form.
+
+    lt_form = zcl_abapgit_html_action_utils=>parse_post_data( it_post_data ).
+
+    LOOP AT lt_form INTO ls_field.
+      CASE ls_field-name.
+        WHEN 'repo-url'.
+          rs_form_data-url = ls_field-value.
+        WHEN 'package'.
+          rs_form_data-package = ls_field-value.
+        WHEN 'branch'.
+          rs_form_data-branch_name = ls_field-value.
+        WHEN 'display-name'.
+          rs_form_data-display_name = ls_field-value.
+        WHEN 'folder-logic'.
+          rs_form_data-folder_logic = ls_field-value.
+        WHEN 'ignore-subpackages'.
+          rs_form_data-ignore_subpackages = boolc( ls_field-value = 'on' ).
+        WHEN 'master-lang-only'.
+          rs_form_data-master_lang_only = boolc( ls_field-value = 'on' ).
+        WHEN OTHERS.
+          zcx_abapgit_exception=>raise( |Unexpected form field [{ ls_field-name }]| ).
+      ENDCASE.
+    ENDLOOP.
+
+
+  ENDMETHOD.
+
+
   METHOD render_content.
 
     DATA lo_form TYPE REF TO zcl_abapgit_html_form.
@@ -64,6 +122,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
       iv_required    = abap_true
       iv_label       = 'Git repository URL'
       iv_hint        = 'HTTPS address of the repository to clone'
+      iv_value       = |{ ms_form_data-url }|
       iv_placeholder = 'https://github.com/...git' ).
     lo_form->text(
       iv_name        = 'package'
@@ -71,37 +130,44 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
       iv_side_action = c_event-choose_package
       iv_label       = 'Package'
       iv_hint        = 'SAP package for the code (should be a dedicated one)'
+      iv_value       = |{ ms_form_data-package }|
       iv_placeholder = 'Z... / $...' ).
     lo_form->text(
       iv_name        = 'branch'
       iv_side_action = c_event-choose_branch
       iv_label       = 'Branch'
       iv_hint        = 'Switch to a specific branch on clone (default: master)'
-      iv_value       = 'master' ).
+      iv_value       = |{ ms_form_data-branch_name }|
+      iv_placeholder = 'master' ).
     lo_form->text(
       iv_name        = 'display-name'
       iv_label       = 'Display name'
+      iv_value       = |{ ms_form_data-display_name }|
       iv_hint        = 'Name to show instead of original repo name (optional)' ).
     lo_form->radio(
       iv_name        = 'folder-logic'
       iv_label       = 'Folder logic'
       iv_hint        = 'Define how package folders are named in the repo (see https://docs.abapgit.org)' ).
     lo_form->option(
-      iv_selected    = abap_true
+      iv_selected    = boolc( ms_form_data-folder_logic = 'prefix' OR ms_form_data-folder_logic IS INITIAL  )
       iv_label       = 'Prefix'
       iv_value       = 'prefix' ).
     lo_form->option(
+      iv_selected    = boolc( ms_form_data-folder_logic = 'full' )
       iv_label       = 'Full'
       iv_value       = 'full' ).
     lo_form->checkbox(
       iv_name        = 'ignore-subpackages'
       iv_label       = 'Ignore subpackages'
+      iv_checked     = ms_form_data-ignore_subpackages
       iv_hint        = 'Syncronize root package only (see https://docs.abapgit.org)' ).
     lo_form->checkbox(
       iv_name        = 'master-lang-only'
       iv_label       = 'Master language only'
+      iv_checked     = ms_form_data-master_lang_only
       iv_hint        = 'Ignore translations, serialize just master language' ).
-    lo_form->set_submit_params(
+    lo_form->command(
+      iv_is_main     = abap_true
       iv_label       = 'Clone online repo'
       iv_action      = c_event-add_online_repo ).
     lo_form->command(
@@ -109,6 +175,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
       iv_action      = c_event-create_package ).
     lo_form->command(
       iv_label       = 'Back'
+      iv_as_a        = abap_true " ignore required fields
       iv_action      = c_event-go_back ).
 
     ri_html->add( lo_form->render( iv_form_class = 'dialog w500px' ) ).
@@ -116,6 +183,103 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD validate_form.
+
+    IF is_form_data-url IS INITIAL.
+      zcx_abapgit_exception=>raise( 'Url cannot be empty' ).
+    ENDIF.
+
+    zcl_abapgit_url=>validate( |{ is_form_data-url }| ).
+
+    IF is_form_data-package IS INITIAL.
+      zcx_abapgit_exception=>raise( 'Package cannot be empty' ).
+    ENDIF.
+
+    zcl_abapgit_repo_srv=>get_instance( )->validate_package(
+      iv_package    = is_form_data-package
+      iv_ign_subpkg = is_form_data-ignore_subpackages ).
+
+    IF is_form_data-folder_logic <> zif_abapgit_dot_abapgit=>c_folder_logic-prefix
+        AND is_form_data-folder_logic <> zif_abapgit_dot_abapgit=>c_folder_logic-full.
+      zcx_abapgit_exception=>raise( |Invalid folder logic { is_form_data-folder_logic }. | &&
+        |Choose either { zif_abapgit_dot_abapgit=>c_folder_logic-prefix } | &&
+        |or { zif_abapgit_dot_abapgit=>c_folder_logic-full } | ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_gui_event_handler~on_event.
+
+    CASE iv_action.
+      WHEN c_event-go_back.
+        ev_state = zcl_abapgit_gui=>c_event_state-go_back.
+
+      WHEN c_event-create_package.
+
+        " Move this to services ?
+
+        DATA ls_package_data TYPE scompkdtln.
+        DATA lv_create       TYPE abap_bool.
+        DATA li_popups       TYPE REF TO zif_abapgit_popups.
+
+        li_popups = zcl_abapgit_ui_factory=>get_popups( ).
+
+        li_popups->popup_to_create_package(
+          IMPORTING
+            es_package_data = ls_package_data
+            ev_create       = lv_create ).
+        IF lv_create = abap_false.
+          ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
+        ELSE.
+          zcl_abapgit_factory=>get_sap_package( ls_package_data-devclass )->create( ls_package_data ).
+          COMMIT WORK. " Hmmm ?
+
+          ms_form_data-package = ls_package_data-devclass.
+          ev_state = zcl_abapgit_gui=>c_event_state-re_render.
+        ENDIF.
+
+      WHEN c_event-choose_package.
+
+        " Is it already implemented somewhere in AG ?
+
+        DATA lt_ret TYPE TABLE OF ddshretval.
+        DATA ls_ret LIKE LINE OF lt_ret.
+
+        CALL FUNCTION 'F4IF_FIELD_VALUE_REQUEST'
+          EXPORTING
+            tabname   = 'TDEVC'
+            fieldname = 'DEVCLASS'
+          TABLES
+            return_tab = lt_ret
+          EXCEPTIONS
+            OTHERS = 5.
+
+        IF sy-subrc <> 0.
+          zcx_abapgit_exception=>raise( 'Unexpected error in F4IF_FIELD_VALUE_REQUEST' ).
+        ENDIF.
+
+        IF lines( lt_ret ) = 0.
+          ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
+        ELSE.
+          READ TABLE lt_ret INDEX 1 INTO ls_ret.
+          ASSERT sy-subrc = 0.
+          ms_form_data-package = ls_ret-fieldval.
+          ev_state = zcl_abapgit_gui=>c_event_state-re_render.
+        ENDIF.
+
+      WHEN c_event-add_online_repo.
+
+        DATA ls_form_data TYPE ty_form_data.
+
+        ls_form_data = parse_form( it_postdata ).
+        validate_form( ls_form_data ).
+
+        " ZCL_ABAPGIT_SERVICES_REPO=>NEW_ONLINE
+
+        ev_state = zcl_abapgit_gui=>c_event_state-go_back.
+
+    ENDCASE.
+
   ENDMETHOD.
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.xml
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_GUI_PAGE_ADDONLINE</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapgit GUI add repo online page</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -87,6 +87,8 @@ CLASS zcl_abapgit_gui_page_main IMPLEMENTATION.
                   iv_act = zif_abapgit_definitions=>c_action-repo_newonline ) ##NO_TEXT.
     ro_menu->add( iv_txt = '+ Offline'
                   iv_act = zif_abapgit_definitions=>c_action-repo_newoffline ) ##NO_TEXT.
+    ro_menu->add( iv_txt = 'test add'
+                  iv_act = 'test_add' ) ##NO_TEXT.
 
     ro_menu->add( iv_txt = 'Advanced'
                   io_sub = lo_advsub ) ##NO_TEXT.

--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -87,8 +87,6 @@ CLASS zcl_abapgit_gui_page_main IMPLEMENTATION.
                   iv_act = zif_abapgit_definitions=>c_action-repo_newonline ) ##NO_TEXT.
     ro_menu->add( iv_txt = '+ Offline'
                   iv_act = zif_abapgit_definitions=>c_action-repo_newoffline ) ##NO_TEXT.
-    ro_menu->add( iv_txt = 'test add'
-                  iv_act = 'test_add' ) ##NO_TEXT.
 
     ro_menu->add( iv_txt = 'Advanced'
                   io_sub = lo_advsub ) ##NO_TEXT.

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -126,7 +126,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_router IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
 
 
   METHOD abapgit_services_actions.
@@ -497,8 +497,8 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
         zcl_abapgit_services_repo=>remove( lv_key ).
         ev_state = zcl_abapgit_gui=>c_event_state-re_render.
       WHEN zif_abapgit_definitions=>c_action-repo_newonline.
-        zcl_abapgit_services_repo=>new_online( lv_url ).
-        ev_state = zcl_abapgit_gui=>c_event_state-re_render.
+        ei_page  = zcl_abapgit_gui_page_addonline=>create( ).
+        ev_state = zcl_abapgit_gui=>c_event_state-new_page.
       WHEN zif_abapgit_definitions=>c_action-repo_refresh_checksums.          " Rebuild local checksums
         zcl_abapgit_services_repo=>refresh_local_checksums( lv_key ).
         ev_state = zcl_abapgit_gui=>c_event_state-re_render.

--- a/src/ui/zcl_abapgit_html_action_utils.clas.abap
+++ b/src/ui/zcl_abapgit_html_action_utils.clas.abap
@@ -4,6 +4,11 @@ CLASS zcl_abapgit_html_action_utils DEFINITION
 
   PUBLIC SECTION.
 
+    CLASS-METHODS parse_post_data
+      IMPORTING
+        !it_post_data TYPE cnht_post_data_tab
+      RETURNING
+        VALUE(rt_fields) TYPE tihttpnvp .
     CLASS-METHODS parse_fields
       IMPORTING
         !iv_string       TYPE clike
@@ -356,6 +361,16 @@ CLASS ZCL_ABAPGIT_HTML_ACTION_UTILS IMPLEMENTATION.
 
     rt_fields = parse_fields( iv_string ).
     field_keys_to_upper( CHANGING ct_fields = rt_fields ).
+
+  ENDMETHOD.
+
+
+  METHOD parse_post_data.
+
+    DATA lv_serialized_post_data TYPE string.
+
+    CONCATENATE LINES OF it_post_data INTO lv_serialized_post_data.
+    rt_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_serialized_post_data ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_html_action_utils.clas.abap
+++ b/src/ui/zcl_abapgit_html_action_utils.clas.abap
@@ -370,7 +370,7 @@ CLASS ZCL_ABAPGIT_HTML_ACTION_UTILS IMPLEMENTATION.
     DATA lv_serialized_post_data TYPE string.
 
     CONCATENATE LINES OF it_post_data INTO lv_serialized_post_data.
-    rt_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_serialized_post_data ).
+    rt_fields = parse_fields( lv_serialized_post_data ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -291,12 +291,14 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
         IF lv_error IS NOT INITIAL.
           ii_html->add( |<small>{ lv_error }</small>| ).
         ENDIF.
+        IF is_field-side_action IS NOT INITIAL.
+          ii_html->add( |<input type="submit" value="&#x2026;" formaction="sapevent:{ is_field-side_action }">| ).
+          ii_html->add( '<div class="input-frame">' ). " Ugly :(
+        ENDIF.
         ii_html->add( |<input type="text" name="{ is_field-name }" id="{
           is_field-name }"{ is_field-placeholder }{ is_field-value }{ is_field-dblclick }>| ).
         IF is_field-side_action IS NOT INITIAL.
-          ii_html->add_a(
-            iv_txt = '&#x2026;'
-            iv_act = is_field-side_action ).
+          ii_html->add( '</div>' ).
         ENDIF.
         ii_html->add( '</li>' ).
 

--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -294,13 +294,18 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
         IF lv_error IS NOT INITIAL.
           ii_html->add( |<small>{ lv_error }</small>| ).
         ENDIF.
+
         IF is_field-side_action IS NOT INITIAL.
-          ii_html->add( |<input type="submit" value="&#x2026;" formaction="sapevent:{ is_field-side_action }">| ).
-          ii_html->add( '<div class="input-frame">' ). " Ugly :(
+          ii_html->add( '<div class="input-container">' ). " Ugly :(
         ENDIF.
+
         ii_html->add( |<input type="text" name="{ is_field-name }" id="{
           is_field-name }"{ is_field-placeholder } value="{ lv_value }"{ is_field-dblclick }>| ).
+
         IF is_field-side_action IS NOT INITIAL.
+          ii_html->add( '</div>' ).
+          ii_html->add( '<div class="command-container">' ).
+          ii_html->add( |<input type="submit" value="&#x2026;" formaction="sapevent:{ is_field-side_action }">| ).
           ii_html->add( '</div>' ).
         ENDIF.
 

--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -273,7 +273,7 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
     lv_error      = is_field-error. " direct error has a priority, but maybe remove it of not used ...
     lv_item_class = is_field-item_class.
 
-    IF lv_error IS INITIAL and io_validation_log IS BOUND.
+    IF lv_error IS INITIAL AND io_validation_log IS BOUND.
       lv_error = io_validation_log->get( is_field-name ).
     ENDIF.
     IF lv_error IS NOT INITIAL.
@@ -287,7 +287,8 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
       WHEN c_field_type-text.
 
         ii_html->add( |<li{ lv_item_class }>| ).
-        ii_html->add( |<label for="{ is_field-name }"{ is_field-hint }>{ is_field-label }{ is_field-required }</label>| ).
+        ii_html->add( |<label for="{ is_field-name }"{ is_field-hint }>{
+          is_field-label }{ is_field-required }</label>| ).
         IF lv_error IS NOT INITIAL.
           ii_html->add( |<small>{ lv_error }</small>| ).
         ENDIF.
@@ -309,7 +310,8 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
           ii_html->add( |<small>{ lv_error }</small>| ).
         ENDIF.
         ii_html->add( |<input type="checkbox" name="{ is_field-name }" id="{ is_field-name }"{ is_field-checked }>| ).
-        ii_html->add( |<label for="{ is_field-name }"{ is_field-hint }>{ is_field-label }{ is_field-required }</label>| ).
+        ii_html->add( |<label for="{ is_field-name }"{ is_field-hint }>{
+          is_field-label }{ is_field-required }</label>| ).
         ii_html->add( '</li>' ).
 
       WHEN c_field_type-radio.

--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -279,7 +279,7 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
       WHEN c_field_type-checkbox.
 
         ii_html->add( |<li{ is_field-item_class }>| ).
-        ii_html->add( |<input type="checkbox" name="{ is_field-name }" id="{ is_field-name }{ is_field-checked }">| ).
+        ii_html->add( |<input type="checkbox" name="{ is_field-name }" id="{ is_field-name }"{ is_field-checked }>| ).
         ii_html->add( |<label for="{ is_field-name }"{ is_field-hint }>{ is_field-label }</label>| ).
         ii_html->add( '</li>' ).
 

--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -244,9 +244,10 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
       IF is_cmd-is_main = abap_true.
         lv_main_submit = ' class="main"'.
       ELSE.
-        clear lv_main_submit.
+        CLEAR lv_main_submit.
       ENDIF.
-      ii_html->add( |<input type="submit" value="{ is_cmd-label }"{ lv_main_submit } formaction="sapevent:{ is_cmd-action }">| ).
+      ii_html->add( |<input type="submit" value="{
+        is_cmd-label }"{ lv_main_submit } formaction="sapevent:{ is_cmd-action }">| ).
     ENDIF.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -1,0 +1,118 @@
+CLASS zcl_abapgit_html_form DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PRIVATE .
+
+  PUBLIC SECTION.
+
+
+    CLASS-METHODS create
+      RETURNING
+        VALUE(ro_form) TYPE REF TO zcl_abapgit_html_form.
+
+    METHODS render
+      IMPORTING
+        iv_form_class TYPE string
+        iv_action TYPE string
+      RETURNING
+        VALUE(ri_html) TYPE REF TO zif_abapgit_html.
+
+    METHODS text
+      IMPORTING
+        iv_label TYPE string
+        iv_name TYPE string
+        iv_value TYPE string OPTIONAL
+        iv_hint TYPE string OPTIONAL
+        iv_required TYPE abap_bool DEFAULT abap_false
+        iv_placeholder TYPE string OPTIONAL
+        iv_side_action TYPE string OPTIONAL.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+
+    CONSTANTS:
+      BEGIN OF c_field_type,
+        text TYPE i VALUE 1,
+        radio TYPE i VALUE 2,
+        checkbox TYPE i VALUE 3,
+      END OF c_field_type.
+
+    DATA mo_fields TYPE REF TO zcl_abapgit_html.
+    DATA mo_commands TYPE REF TO zcl_abapgit_html.
+    DATA mv_last_field_type TYPE i.
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
+
+
+  METHOD create.
+
+    CREATE OBJECT ro_form.
+    CREATE OBJECT ro_form->mo_fields.
+    CREATE OBJECT ro_form->mo_commands.
+
+  ENDMETHOD.
+
+
+  METHOD render.
+
+    CREATE OBJECT ri_html TYPE zcl_abapgit_html.
+
+    ri_html->add( |<ul class="{ iv_form_class }">| ).
+    ri_html->add( |<form action="sapevent:{ iv_action }" method="post">| ).
+    ri_html->add( mo_fields ).
+    ri_html->add( |<li>| ).
+    ri_html->add( mo_commands ).
+    ri_html->add( |</li>| ).
+    ri_html->add( |</form>| ).
+    ri_html->add( |</ul>| ).
+
+  ENDMETHOD.
+
+
+  METHOD text.
+
+    DATA lv_title TYPE string.
+    DATA lv_infomark TYPE string.
+    DATA lv_placeholder TYPE string.
+    DATA lv_required TYPE string.
+    DATA lv_with_command TYPE string.
+    DATA lv_value TYPE string.
+
+    mv_last_field_type = c_field_type-text.
+
+    IF iv_hint IS NOT INITIAL.
+      lv_title = | title="{ iv_hint }"|.
+      lv_infomark = ' <span>&#x1f6c8;</span>'.
+    ENDIF.
+
+    IF iv_side_action IS NOT INITIAL.
+      lv_with_command = ' class="with-command"'.
+    ENDIF.
+
+    IF iv_required = abap_true.
+      lv_required = ' required'.
+    ENDIF.
+
+    IF iv_placeholder IS NOT INITIAL.
+      lv_placeholder = | placeholder="{ iv_placeholder }"|.
+    ENDIF.
+
+    IF iv_value IS NOT INITIAL.
+      lv_value = | value="{ iv_value }"|.
+    ENDIF.
+
+    mo_fields->add( |<li>{ lv_with_command }| ).
+    mo_fields->add( |<label for="{ iv_name }"{ lv_title }>{ iv_label }{ lv_infomark }</label>| ).
+    mo_fields->add( |<input type="text" name="{ iv_name }" id="{ iv_name }"{ lv_required }{ lv_placeholder }{ lv_value }>| ).
+    IF iv_side_action IS NOT INITIAL.
+      mo_fields->add_a(
+        iv_txt = '&#x2026;'
+        iv_act = iv_side_action ).
+    ENDIF.
+    mo_fields->add( '</li>' ).
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/ui/zcl_abapgit_html_form.clas.xml
+++ b/src/ui/zcl_abapgit_html_form.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_HTML_FORM</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapgit html form component</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -742,6 +742,39 @@ CLASS ZCL_ABAPGIT_POPUPS IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD zif_abapgit_popups~popup_search_help.
+
+    DATA lt_ret TYPE TABLE OF ddshretval.
+    DATA ls_ret LIKE LINE OF lt_ret.
+    DATA lv_tabname TYPE dfies-tabname.
+    DATA lv_fieldname TYPE dfies-fieldname.
+
+    SPLIT iv_tab_field AT '-' INTO lv_tabname lv_fieldname.
+    lv_tabname = to_upper( lv_tabname ).
+    lv_fieldname = to_upper( lv_fieldname ).
+
+    CALL FUNCTION 'F4IF_FIELD_VALUE_REQUEST'
+      EXPORTING
+        tabname   = lv_tabname
+        fieldname = lv_fieldname
+      TABLES
+        return_tab = lt_ret
+      EXCEPTIONS
+        OTHERS = 5.
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |F4IF_FIELD_VALUE_REQUEST error [{ iv_tab_field }]| ).
+    ENDIF.
+
+    IF lines( lt_ret ) > 0.
+      READ TABLE lt_ret INDEX 1 INTO ls_ret.
+      ASSERT sy-subrc = 0.
+      rv_value = ls_ret-fieldval.
+    ENDIF.
+
+  ENDMETHOD.
+
+
   METHOD zif_abapgit_popups~popup_to_confirm.
 
     CALL FUNCTION 'POPUP_TO_CONFIRM'

--- a/src/ui/zcl_abapgit_services_basis.clas.abap
+++ b/src/ui/zcl_abapgit_services_basis.clas.abap
@@ -5,6 +5,8 @@ CLASS zcl_abapgit_services_basis DEFINITION
 
   PUBLIC SECTION.
     CLASS-METHODS create_package
+      IMPORTING
+        iv_prefill_package TYPE devclass OPTIONAL
       RETURNING
         VALUE(rv_package) TYPE devclass
       RAISING
@@ -23,6 +25,8 @@ CLASS ZCL_ABAPGIT_SERVICES_BASIS IMPLEMENTATION.
 
     DATA ls_package_data TYPE scompkdtln.
     DATA lv_create       TYPE abap_bool.
+
+    ls_package_data-devclass = to_upper( iv_prefill_package ).
 
     zcl_abapgit_ui_factory=>get_popups( )->popup_to_create_package(
       IMPORTING

--- a/src/ui/zcl_abapgit_services_basis.clas.abap
+++ b/src/ui/zcl_abapgit_services_basis.clas.abap
@@ -1,0 +1,39 @@
+CLASS zcl_abapgit_services_basis DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+    CLASS-METHODS create_package
+      RETURNING
+        VALUE(rv_package) TYPE devclass
+      RAISING
+        zcx_abapgit_exception.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPGIT_SERVICES_BASIS IMPLEMENTATION.
+
+
+  METHOD create_package.
+
+    DATA ls_package_data TYPE scompkdtln.
+    DATA lv_create       TYPE abap_bool.
+
+    zcl_abapgit_ui_factory=>get_popups( )->popup_to_create_package(
+      IMPORTING
+        es_package_data = ls_package_data
+        ev_create       = lv_create ).
+
+    IF lv_create = abap_true.
+      zcl_abapgit_factory=>get_sap_package( ls_package_data-devclass )->create( ls_package_data ).
+      rv_package = ls_package_data-devclass.
+      COMMIT WORK.
+    ENDIF.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/ui/zcl_abapgit_services_basis.clas.xml
+++ b/src/ui/zcl_abapgit_services_basis.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_SERVICES_BASIS</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit basis services</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -177,7 +177,7 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
 
   METHOD new_online.
 
-    DATA: ls_popup    TYPE zif_abapgit_popups=>ty_popup,
+    DATA:
           lo_repo     TYPE REF TO zcl_abapgit_repo,
           li_repo_srv TYPE REF TO zif_abapgit_repo_srv,
           lv_reason   TYPE string.

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -182,40 +182,33 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
           li_repo_srv TYPE REF TO zif_abapgit_repo_srv,
           lv_reason   TYPE string.
 
-    ls_popup = zcl_abapgit_ui_factory=>get_popups( )->repo_popup( iv_url ).
-    IF ls_popup-cancel = abap_true.
-      RAISE EXCEPTION TYPE zcx_abapgit_cancel.
-    ENDIF.
-
     " make sure package is not already in use for a different repository
     " 702: chaining calls with exp&imp parameters causes syntax error
     li_repo_srv = zcl_abapgit_repo_srv=>get_instance( ).
     li_repo_srv->get_repo_from_package(
       EXPORTING
-        iv_package = ls_popup-package
+        iv_package = is_repo_params-package
       IMPORTING
         eo_repo    = lo_repo
         ev_reason  = lv_reason ).
 
     IF lo_repo IS BOUND.
-      MESSAGE lv_reason TYPE 'S'.
-    ELSE.
-      ro_repo = zcl_abapgit_repo_srv=>get_instance( )->new_online(
-        iv_url              = ls_popup-url
-        iv_branch_name      = ls_popup-branch_name
-        iv_package          = ls_popup-package
-        iv_display_name     = ls_popup-display_name
-        iv_folder_logic     = ls_popup-folder_logic
-        iv_ign_subpkg       = ls_popup-ign_subpkg
-        iv_master_lang_only = ls_popup-master_lang_only ).
-
-      toggle_favorite( ro_repo->get_key( ) ).
-
-      lo_repo ?= ro_repo.
+      zcx_abapgit_exception=>raise( lv_reason ).
     ENDIF.
 
+    ro_repo = zcl_abapgit_repo_srv=>get_instance( )->new_online(
+      iv_url              = is_repo_params-url
+      iv_branch_name      = is_repo_params-branch_name
+      iv_package          = is_repo_params-package
+      iv_display_name     = is_repo_params-display_name
+      iv_folder_logic     = is_repo_params-folder_logic
+      iv_ign_subpkg       = is_repo_params-ignore_subpackages
+      iv_master_lang_only = is_repo_params-master_lang_only ).
+
+    toggle_favorite( ro_repo->get_key( ) ).
+
     " Set default repo for user
-    zcl_abapgit_persistence_user=>get_instance( )->set_repo_show( lo_repo->get_key( ) ).
+    zcl_abapgit_persistence_user=>get_instance( )->set_repo_show( ro_repo->get_key( ) ).
 
     COMMIT WORK.
 

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -7,7 +7,7 @@ CLASS zcl_abapgit_services_repo DEFINITION
 
     CLASS-METHODS new_online
       IMPORTING
-        !iv_url        TYPE string
+        !is_repo_params TYPE zif_abapgit_services_repo=>ty_repo_params
       RETURNING
         VALUE(ro_repo) TYPE REF TO zcl_abapgit_repo_online
       RAISING

--- a/src/ui/zcl_abapgit_ui_injector.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_ui_injector.clas.testclasses.abap
@@ -96,6 +96,10 @@ CLASS ltcl_abapgit_popups_mock IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD zif_abapgit_popups~popup_search_help.
+
+  ENDMETHOD.
+
 ENDCLASS.
 
 CLASS ltcl_no_dependency_injection IMPLEMENTATION.

--- a/src/ui/zif_abapgit_popups.intf.abap
+++ b/src/ui/zif_abapgit_popups.intf.abap
@@ -3,7 +3,7 @@ INTERFACE zif_abapgit_popups
 
 
   TYPES:
-    BEGIN OF ty_popup,
+    BEGIN OF ty_popup, " TODO remove, use zif_abapgit_services_repo=>ty_repo_params instead
       url              TYPE string,
       package          TYPE devclass,
       branch_name      TYPE string,
@@ -16,6 +16,13 @@ INTERFACE zif_abapgit_popups
 
   CONSTANTS c_new_branch_label TYPE string VALUE '+ create new ...' ##NO_TEXT.
 
+  METHODS popup_search_help
+    IMPORTING
+      !iv_tab_field TYPE string
+    RETURNING
+      VALUE(rv_value) TYPE ddshretval-fieldval
+    RAISING
+      zcx_abapgit_exception .
   METHODS popup_package_export
     EXPORTING
       !ev_package                    TYPE devclass

--- a/src/ui/zif_abapgit_services_repo.intf.abap
+++ b/src/ui/zif_abapgit_services_repo.intf.abap
@@ -1,0 +1,15 @@
+INTERFACE zif_abapgit_services_repo
+  PUBLIC .
+
+  TYPES:
+    BEGIN OF ty_repo_params,
+      url              TYPE string,
+      package          TYPE devclass,
+      branch_name      TYPE string,
+      display_name     TYPE string,
+      folder_logic     TYPE string,
+      ignore_subpackages TYPE abap_bool,
+      master_lang_only TYPE abap_bool,
+    END OF ty_repo_params .
+
+ENDINTERFACE.

--- a/src/ui/zif_abapgit_services_repo.intf.xml
+++ b/src/ui/zif_abapgit_services_repo.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_ABAPGIT_SERVICES_REPO</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit repo service definitions</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/utils/zcl_abapgit_string_map.clas.abap
+++ b/src/utils/zcl_abapgit_string_map.clas.abap
@@ -38,9 +38,15 @@ CLASS zcl_abapgit_string_map DEFINITION
       RETURNING
         VALUE(rv_size) TYPE i.
 
+    METHODS is_empty
+      RETURNING
+        VALUE(rv_yes) TYPE abap_bool.
+
     METHODS delete
       IMPORTING
         iv_key TYPE string.
+
+    METHODS clear.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -51,6 +57,11 @@ ENDCLASS.
 
 
 CLASS ZCL_ABAPGIT_STRING_MAP IMPLEMENTATION.
+
+
+  METHOD clear.
+    clear mt_entries.
+  ENDMETHOD.
 
 
   METHOD create.
@@ -81,6 +92,11 @@ CLASS ZCL_ABAPGIT_STRING_MAP IMPLEMENTATION.
     READ TABLE mt_entries TRANSPORTING NO FIELDS WITH KEY k = iv_key.
     rv_has = boolc( sy-subrc IS INITIAL ).
 
+  ENDMETHOD.
+
+
+  METHOD is_empty.
+    rv_yes = boolc( lines( mt_entries ) = 0 ).
   ENDMETHOD.
 
 

--- a/src/utils/zcl_abapgit_string_map.clas.abap
+++ b/src/utils/zcl_abapgit_string_map.clas.abap
@@ -1,0 +1,109 @@
+CLASS zcl_abapgit_string_map DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    TYPES:
+      BEGIN OF ty_entry,
+        k TYPE string,
+        v TYPE string,
+      END OF ty_entry,
+      tty_entries TYPE STANDARD TABLE OF ty_entry WITH KEY k,
+      tts_entries TYPE SORTED TABLE OF ty_entry WITH UNIQUE KEY k.
+
+    CLASS-METHODS create
+      RETURNING
+        VALUE(ro_instance) TYPE REF TO zcl_abapgit_string_map.
+
+    METHODS get
+      IMPORTING
+        iv_key TYPE string
+      RETURNING
+        VALUE(rv_val) TYPE string.
+
+    METHODS has
+      IMPORTING
+        iv_key TYPE string
+      RETURNING
+        VALUE(rv_has) TYPE abap_bool.
+
+    METHODS set
+      IMPORTING
+        iv_key TYPE string
+        iv_val TYPE string.
+
+    METHODS size
+      RETURNING
+        VALUE(rv_size) TYPE i.
+
+    METHODS delete
+      IMPORTING
+        iv_key TYPE string.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    DATA mt_entries TYPE tts_entries.
+
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPGIT_STRING_MAP IMPLEMENTATION.
+
+
+  METHOD create.
+    CREATE OBJECT ro_instance.
+  ENDMETHOD.
+
+
+  METHOD delete.
+
+    DELETE mt_entries WHERE k = iv_key.
+
+  ENDMETHOD.
+
+
+  METHOD get.
+
+    FIELD-SYMBOLS <ls_entry> LIKE LINE OF mt_entries.
+    READ TABLE mt_entries ASSIGNING <ls_entry> WITH KEY k = iv_key.
+    IF sy-subrc IS INITIAL.
+      rv_val = <ls_entry>-v.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD has.
+
+    READ TABLE mt_entries TRANSPORTING NO FIELDS WITH KEY k = iv_key.
+    rv_has = boolc( sy-subrc IS INITIAL ).
+
+  ENDMETHOD.
+
+
+  METHOD set.
+
+    DATA ls_entry LIKE LINE OF mt_entries.
+    FIELD-SYMBOLS <ls_entry> LIKE LINE OF mt_entries.
+
+    READ TABLE mt_entries ASSIGNING <ls_entry> WITH KEY k = iv_key.
+    IF sy-subrc IS INITIAL.
+      <ls_entry>-v = iv_val.
+    ELSE.
+      ls_entry-k = iv_key.
+      ls_entry-v = iv_val.
+      INSERT ls_entry INTO TABLE mt_entries.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD size.
+
+    rv_size = lines( mt_entries ).
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/utils/zcl_abapgit_string_map.clas.abap
+++ b/src/utils/zcl_abapgit_string_map.clas.abap
@@ -135,8 +135,8 @@ CLASS ZCL_ABAPGIT_STRING_MAP IMPLEMENTATION.
     DATA lo_type TYPE REF TO cl_abap_typedescr.
     DATA lo_struc TYPE REF TO cl_abap_structdescr.
     DATA lv_field TYPE string.
-    FIELD-SYMBOLS <entry> LIKE LINE OF mt_entries.
-    FIELD-SYMBOLS <val> TYPE any.
+    FIELD-SYMBOLS <ls_entry> LIKE LINE OF mt_entries.
+    FIELD-SYMBOLS <lv_val> TYPE any.
 
     lo_type = cl_abap_typedescr=>describe_by_data( cs_container ).
     IF lo_type->type_kind <> cl_abap_typedescr=>typekind_struct1
@@ -145,12 +145,12 @@ CLASS ZCL_ABAPGIT_STRING_MAP IMPLEMENTATION.
     ENDIF.
 
     lo_struc ?= lo_type.
-    LOOP AT mt_entries ASSIGNING <entry>.
-      lv_field = to_upper( <entry>-k ).
-      ASSIGN COMPONENT lv_field OF STRUCTURE cs_container TO <val>.
+    LOOP AT mt_entries ASSIGNING <ls_entry>.
+      lv_field = to_upper( <ls_entry>-k ).
+      ASSIGN COMPONENT lv_field OF STRUCTURE cs_container TO <lv_val>.
       IF sy-subrc = 0.
         " TODO check target type ?
-        <val> = <entry>-v.
+        <lv_val> = <ls_entry>-v.
       ELSE.
         zcx_abapgit_exception=>raise( |Component { lv_field } not found in target| ).
       ENDIF.

--- a/src/utils/zcl_abapgit_string_map.clas.abap
+++ b/src/utils/zcl_abapgit_string_map.clas.abap
@@ -32,7 +32,7 @@ CLASS zcl_abapgit_string_map DEFINITION
     METHODS set
       IMPORTING
         iv_key TYPE string
-        iv_val TYPE string.
+        iv_val TYPE string OPTIONAL.
 
     METHODS size
       RETURNING

--- a/src/utils/zcl_abapgit_string_map.clas.abap
+++ b/src/utils/zcl_abapgit_string_map.clas.abap
@@ -60,7 +60,7 @@ CLASS ZCL_ABAPGIT_STRING_MAP IMPLEMENTATION.
 
 
   METHOD clear.
-    clear mt_entries.
+    CLEAR mt_entries.
   ENDMETHOD.
 
 

--- a/src/utils/zcl_abapgit_string_map.clas.xml
+++ b/src/utils/zcl_abapgit_string_map.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_STRING_MAP</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit string Map implementation</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -387,13 +387,21 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
   METHOD zif_abapgit_repo_srv~new_online.
 
     DATA: ls_repo        TYPE zif_abapgit_persistence=>ty_repo,
+          lv_branch_name LIKE iv_branch_name,
           lv_key         TYPE zif_abapgit_persistence=>ty_repo-key,
           ls_dot_abapgit TYPE zif_abapgit_dot_abapgit=>ty_dot_abapgit.
 
 
     ASSERT NOT iv_url IS INITIAL
-      AND NOT iv_branch_name IS INITIAL
       AND NOT iv_package IS INITIAL.
+
+    lv_branch_name = iv_branch_name.
+    IF lv_branch_name IS INITIAL.
+      lv_branch_name = 'refs/heads/master'.
+    ENDIF.
+    IF find( val = lv_branch_name sub = 'refs/heads/' ) = -1.
+      lv_branch_name = 'refs/heads/' && lv_branch_name. " Assume short branch name was received
+    ENDIF.
 
     IF zcl_abapgit_auth=>is_allowed( zif_abapgit_auth=>gc_authorization-create_repo ) = abap_false.
       zcx_abapgit_exception=>raise( 'Not authorized' ).
@@ -409,7 +417,7 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
 
     lv_key = zcl_abapgit_persist_factory=>get_repo( )->add(
       iv_url          = iv_url
-      iv_branch_name  = iv_branch_name
+      iv_branch_name  = lv_branch_name " local !
       iv_display_name = iv_display_name
       iv_package      = iv_package
       iv_offline      = abap_false

--- a/src/zcl_abapgit_repo_srv.clas.abap
+++ b/src/zcl_abapgit_repo_srv.clas.abap
@@ -399,7 +399,9 @@ CLASS ZCL_ABAPGIT_REPO_SRV IMPLEMENTATION.
     IF lv_branch_name IS INITIAL.
       lv_branch_name = 'refs/heads/master'.
     ENDIF.
-    IF find( val = lv_branch_name sub = 'refs/heads/' ) = -1.
+    IF -1 = find(
+        val = lv_branch_name
+        sub = 'refs/heads/' ).
       lv_branch_name = 'refs/heads/' && lv_branch_name. " Assume short branch name was received
     ENDIF.
 


### PR DESCRIPTION
OK, I think it can be tested and reviewed. Generally the code is ready. ~~I just want to try one tweak (string_map for form values below **DONE**)~~. The PR is rather large, apologies, but centered mostly in the new stuff. #3417

![image](https://user-images.githubusercontent.com/15635498/85231015-8b64f000-b3fc-11ea-935d-52cdf955e4ee.png)


## What's inside

- html form abstraction `zcl_abapgit_html_form` that should be reusable in other places and simplify the page code
  - I will probably write a doc on it later. But example can be seen `ZCL_ABAPGIT_GUI_PAGE_ADDONLINE->RENDER_CONTENT` - clean and readable 👌 
  - dblclick on text field = side actions button
  - the `render` method accepts root css class which should allow to render same form differently just with css (if needed)
  - look at the validation approach ! Separate method collects validation message into a string map (`zcl_abapgit_string_map`) which is then uniformly processed by the html_form.
  - what I want to tweak (above) is to use same approach for values, no need to pass them from a structure explicitly imho. So inputs will need just `iv_name` and the values will be passed to `render` as a string map. Thus the form is a schema which is then mixed with values and validation errors at render time. **UPD: DONE**
- `zcl_abapgit_string_map` a primitive for key-value map. I probably invented a bicycle ... but it's quite convenient (there probably should be something like that in standard abap ... but I don't know)
- `zcl_abapgit_services_basis` - for scripts not related to repos, git or abapgit ... create package for now, maybe something else in future ? Transports ? whatever...
- `zcl_abapgit_gui_page_addonline` - the hero of the occasion
- `zif_abapgit_popups~popup_search_help` quick util to show search helps
- *important !* `repo_services->new_online` does not call popups anymore
- *change !* `zif_abapgit_repo_srv~new_online` accepts branch names without `refs/heads` (maybe I broke something ?? but seems to work)

## Considerations
- the solution is JS free (except dblclick handling) ... and it was hard ... 
- issue is that certain **secondary** actions on abap side would need data from the form. Thus **all** actions must be submits. Agh !!! 🤦 OK, it is kind of solved. But e.g. side actions (buttons next to text fields) are also submits, and they behave strangely in HTML. I don't like the look but this is as far as I could get it without completely crippling the html (which is already crippled a bit by unnecessary divs). Well. Maybe someone knows CSS better and can improve. The initial version (including screenshots from #3417) used `anchors` and it was more controllable and better looking. But they could not submit the form without JS. life's hard. I need some beer today. 🍺 or 🍻 

## Not to forget someday
- remove `zif_abapgit_popups=>ty_popup` when (if) all dialogs move to html, use `zif_abapgit_services_repo=>ty_repo_params`

@larshp @FreHu @christianguenter2 @mbtools and other - welcome to review
