### PR TITLE
clear ICFSERVICE-ICFBITMAP

### DIFF
--- a/src/objects/zcl_abapgit_object_sicf.clas.abap
+++ b/src/objects/zcl_abapgit_object_sicf.clas.abap
@@ -589,6 +589,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SICF IMPLEMENTATION.
     CLEAR ls_icfservice-icf_cclnt.
     CLEAR ls_icfservice-icf_mclnt.
     CLEAR ls_icfservice-icfaltnme_orig.
+    CLEAR ls_icfservice-icfbitmap.
 
     io_xml->add( iv_name = 'URL'
                  ig_data = lv_url ).


### PR DESCRIPTION
clear ICFBITMAP field, it sometimes becomes "0000000", but typically empty

looking at the values in the database table, everything is always empty or "0000000", at least in the systems I have access to