### PR TITLE
DDIC with reference to class/interface, Search Help with Exit Function

### DIFF
--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -190,6 +190,12 @@ CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'DD04V'
                   CHANGING cg_data = ls_dd04v ).
 
+    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd04v-datatype = 'REF'.
+      ls_dd04v-rollname = 'OBJECT'.
+    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd04v-datatype <> 'REF'.
+      RETURN. " already active
+    ENDIF.
+
     corr_insert( iv_package = iv_package
                  ig_object_class = 'DICT' ).
 
@@ -241,6 +247,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_deserialize_steps.
     APPEND zif_abapgit_object=>gc_step_id-ddic TO rt_steps.
+    APPEND zif_abapgit_object=>gc_step_id-late TO rt_steps.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -190,6 +190,7 @@ CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'DD04V'
                   CHANGING cg_data = ls_dd04v ).
 
+    " DDIC Step: Replace REF TO class/interface with generic reference to avoid cyclic dependency
     IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd04v-datatype = 'REF'.
       ls_dd04v-rollname = 'OBJECT'.
     ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd04v-datatype <> 'REF'.

--- a/src/objects/zcl_abapgit_object_shlp.clas.abap
+++ b/src/objects/zcl_abapgit_object_shlp.clas.abap
@@ -60,6 +60,13 @@ CLASS ZCL_ABAPGIT_OBJECT_SHLP IMPLEMENTATION.
 
     io_xml->read( EXPORTING iv_name = 'DD30V'
                   CHANGING cg_data = ls_dd30v ).
+
+    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND NOT ls_dd30v-selmexit IS INITIAL.
+      ls_dd30v-selmexit = 'RS_DD_SELMEXIT'.
+    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd30v-selmexit IS INITIAL.
+      RETURN. " already active
+    ENDIF.
+
     io_xml->read( EXPORTING iv_name = 'DD31V_TABLE'
                   CHANGING cg_data = lt_dd31v ).
     io_xml->read( EXPORTING iv_name = 'DD32P_TABLE'
@@ -116,6 +123,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SHLP IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_deserialize_steps.
     APPEND zif_abapgit_object=>gc_step_id-ddic TO rt_steps.
+    APPEND zif_abapgit_object=>gc_step_id-late TO rt_steps.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -486,6 +486,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
       io_xml->read( EXPORTING iv_name  = 'DD03P_TABLE'
                     CHANGING cg_data = lt_dd03p ).
 
+      " DDIC Step: Replace REF TO class/interface with generic reference to avoid cyclic dependency
       LOOP AT lt_dd03p ASSIGNING <ls_dd03p> WHERE datatype = 'REF'.
         IF iv_step = zif_abapgit_object=>gc_step_id-ddic.
           <ls_dd03p>-rollname = 'OBJECT'.
@@ -493,10 +494,6 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
           lv_refs = abap_true.
         ENDIF.
       ENDLOOP.
-
-      IF iv_step = zif_abapgit_object=>gc_step_id-late AND lv_refs = abap_false.
-        RETURN. " already active
-      ENDIF.
 
       io_xml->read( EXPORTING iv_name = 'DD05M_TABLE'
                     CHANGING cg_data = lt_dd05m ).
@@ -510,6 +507,15 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
                     CHANGING cg_data = lt_dd35v ).
       io_xml->read( EXPORTING iv_name = 'DD36M'
                     CHANGING cg_data = lt_dd36m ).
+
+      " DDIC Step: Remove referenced to search helps
+      IF iv_step = zif_abapgit_object=>gc_step_id-ddic.
+        CLEAR: lt_dd35v, lt_dd36m.
+      ENDIF.
+
+      IF iv_step = zif_abapgit_object=>gc_step_id-late AND lv_refs = abap_false AND lines( lt_dd35v ) = 0.
+        RETURN. " already active
+      ENDIF.
 
       corr_insert( iv_package = iv_package
                    ig_object_class = 'DICT' ).

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -471,7 +471,10 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
           lt_secondary LIKE lt_dd17v,
           lt_dd35v     TYPE TABLE OF dd35v,
           lt_dd36m     TYPE dd36mttyp,
-          ls_dd12v     LIKE LINE OF lt_dd12v.
+          ls_dd12v     LIKE LINE OF lt_dd12v,
+          lv_refs      TYPE abap_bool.
+
+    FIELD-SYMBOLS: <ls_dd03p> TYPE dd03p.
 
     IF deserialize_idoc_segment( io_xml     = io_xml
                                  iv_package = iv_package ) = abap_false.
@@ -482,6 +485,19 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
                     CHANGING cg_data = ls_dd09l ).
       io_xml->read( EXPORTING iv_name  = 'DD03P_TABLE'
                     CHANGING cg_data = lt_dd03p ).
+
+      LOOP AT lt_dd03p ASSIGNING <ls_dd03p> WHERE datatype = 'REF'.
+        IF iv_step = zif_abapgit_object=>gc_step_id-ddic.
+          <ls_dd03p>-rollname = 'OBJECT'.
+        ELSE.
+          lv_refs = abap_true.
+        ENDIF.
+      ENDLOOP.
+
+      IF iv_step = zif_abapgit_object=>gc_step_id-late AND lv_refs = abap_false.
+        RETURN. " already active
+      ENDIF.
+
       io_xml->read( EXPORTING iv_name = 'DD05M_TABLE'
                     CHANGING cg_data = lt_dd05m ).
       io_xml->read( EXPORTING iv_name = 'DD08V_TABLE'
@@ -608,6 +624,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_deserialize_steps.
     APPEND zif_abapgit_object=>gc_step_id-ddic TO rt_steps.
+    APPEND zif_abapgit_object=>gc_step_id-late TO rt_steps.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_ttyp.clas.abap
+++ b/src/objects/zcl_abapgit_object_ttyp.clas.abap
@@ -63,6 +63,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TTYP IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'DD40V'
                   CHANGING cg_data = ls_dd40v ).
 
+    " DDIC Step: Replace REF TO class/interface with generic reference to avoid cyclic dependency
     IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd40v-datatype = 'REF'.
       ls_dd40v-rowtype = 'OBJECT'.
     ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd40v-datatype <> 'REF'.

--- a/src/objects/zcl_abapgit_object_ttyp.clas.abap
+++ b/src/objects/zcl_abapgit_object_ttyp.clas.abap
@@ -62,6 +62,13 @@ CLASS ZCL_ABAPGIT_OBJECT_TTYP IMPLEMENTATION.
 
     io_xml->read( EXPORTING iv_name = 'DD40V'
                   CHANGING cg_data = ls_dd40v ).
+
+    IF iv_step = zif_abapgit_object=>gc_step_id-ddic AND ls_dd40v-datatype = 'REF'.
+      ls_dd40v-rowtype = 'OBJECT'.
+    ELSEIF iv_step = zif_abapgit_object=>gc_step_id-late AND ls_dd40v-datatype <> 'REF'.
+      RETURN. " already active
+    ENDIF.
+
     io_xml->read( EXPORTING iv_name = 'DD42V'
                   CHANGING cg_data = lt_dd42v ).
     io_xml->read( EXPORTING iv_name = 'DD43V'
@@ -132,6 +139,7 @@ CLASS ZCL_ABAPGIT_OBJECT_TTYP IMPLEMENTATION.
 
   METHOD zif_abapgit_object~get_deserialize_steps.
     APPEND zif_abapgit_object=>gc_step_id-ddic TO rt_steps.
+    APPEND zif_abapgit_object=>gc_step_id-late TO rt_steps.
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -771,7 +771,16 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
     ENDLOOP.
 
-    zcl_abapgit_objects_activation=>activate( is_step-is_ddic ).
+   CASE is_step-step_id.
+      WHEN zif_abapgit_object=>gc_step_id-ddic.
+        zcl_abapgit_objects_activation=>activate( is_step-is_ddic ).
+      WHEN zif_abapgit_object=>gc_step_id-abap.
+        zcl_abapgit_objects_activation=>activate( is_step-is_ddic ).
+      WHEN zif_abapgit_object=>gc_step_id-late.
+        " late can have both DDIC (like TABL with REF TO) and non-DDIC objects
+        zcl_abapgit_objects_activation=>activate( abap_true ).
+        zcl_abapgit_objects_activation=>activate( abap_false ).
+    ENDCASE.
 
 *   Call postprocessing
     li_exit = zcl_abapgit_exit=>get_instance( ).

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -771,7 +771,7 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
     ENDLOOP.
 
-   CASE is_step-step_id.
+    CASE is_step-step_id.
       WHEN zif_abapgit_object=>gc_step_id-ddic.
         zcl_abapgit_objects_activation=>activate( is_step-is_ddic ).
       WHEN zif_abapgit_object=>gc_step_id-abap.


### PR DESCRIPTION
Fix for issue with cyclic dependencies between DDIC (data element, table, structure, table type) and classes or interfaces.
https://github.com/larshp/abapGit/issues/2015, https://github.com/larshp/abapGit/issues/2338
 
Inspired by https://launchpad.support.sap.com/#/notes/409671, the change replaces references to specific classes or interfaces with a generic OBJECT reference during DDIC step. This allows for successful activation. 

The DDIC objects are then updated during LATE step with the original references and activated again. At this time, the referenced classes/interfaces exist and the activation is successful. 

In a similar way, search helps with exit functions are pointed to existing exit function RS_DD_SELMEXIT during DDIC step. And then activated with the correct function during LATE step.

Successful tests:
https://github.com/abapGit-tests/TTYP_with_CLAS_reference 
https://github.com/abapGit-tests/SHLP_with_exit 
https://github.com/christianguenter2/test_TABL_SHLP.git

(just diffs related to language or old release, which should be fixed by updating these test cases)

