### PR TITLE
Fix user settings containing invalid repo key

### DIFF
--- a/src/persist/zcl_abapgit_persistence_user.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_user.clas.abap
@@ -270,7 +270,18 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_USER IMPLEMENTATION.
 
   METHOD zif_abapgit_persist_user~get_repo_show.
 
+    DATA lo_repo TYPE REF TO zcl_abapgit_repo.
+
     rv_key = read( )-repo_show.
+
+    " Check if repo exists
+    TRY.
+        lo_repo = zcl_abapgit_repo_srv=>get_instance( )->get( rv_key ).
+      CATCH zcx_abapgit_exception.
+        " remove invalid key
+        CLEAR rv_key.
+        zif_abapgit_persist_user~set_repo_show( rv_key ).
+    ENDTRY.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -126,7 +126,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_gui_router IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
 
 
   METHOD abapgit_services_actions.
@@ -207,13 +207,16 @@ CLASS zcl_abapgit_gui_router IMPLEMENTATION.
 
         IF zcl_abapgit_persist_settings=>get_instance( )->read( )->get_show_default_repo( ) = abap_true.
           lv_last_repo_key = zcl_abapgit_persistence_user=>get_instance( )->get_repo_show( ).
-          CREATE OBJECT ei_page TYPE zcl_abapgit_gui_page_view_repo
-          EXPORTING iv_key = lv_last_repo_key.
-          ev_state = zcl_abapgit_gui=>c_event_state-new_page.
-        ELSE.
-          CREATE OBJECT ei_page TYPE zcl_abapgit_gui_page_main.
-          ev_state = zcl_abapgit_gui=>c_event_state-new_page.
         ENDIF.
+
+        IF lv_last_repo_key IS INITIAL.
+          CREATE OBJECT ei_page TYPE zcl_abapgit_gui_page_main.
+        ELSE.
+          CREATE OBJECT ei_page TYPE zcl_abapgit_gui_page_view_repo
+            EXPORTING
+              iv_key = lv_last_repo_key.
+        ENDIF.
+        ev_state = zcl_abapgit_gui=>c_event_state-new_page.
 
       WHEN zif_abapgit_definitions=>c_action-go_repo_overview.               " Go Repository overview
         CREATE OBJECT ei_page TYPE zcl_abapgit_gui_repo_over.


### PR DESCRIPTION
If user settings are set to display last repo and the repo does not exist anymore, then abapgit fails to start with a dump:

Runtime Errors         OBJECTS_OBJREF_NOT_ASSIGNED_NO
Except.                CX_SY_REF_IS_INITIAL
ABAP Program           ZCL_ABAPGIT_GUI===============CP

A possible cause is an incomplete or failed uninstall.

This fix removes the invalid repo key from the user settings and displays the repo list instead.