### PR TITLE
Fix "Cannot find .abapgit.xml" error 

### DIFF
--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -356,7 +356,8 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
       ro_dot = zcl_abapgit_dot_abapgit=>deserialize( <ls_remote>-data ).
       set_dot_abapgit( ro_dot ).
       COMMIT WORK AND WAIT. " to release lock
-    ELSE.
+    ELSEIF lines( mt_remote ) > 3.
+      " Less files means it's a new repo (with just readme and license, for example) which is ok
       zcx_abapgit_exception=>raise( |Cannot find .abapgit.xml - Is this an abapGit repo?| ).
     ENDIF.
 


### PR DESCRIPTION
An error will be raised only for repos with more than 3 files. New repos with for example readme, license, and changelog files will not cause the error anymore.

Follow-up to https://github.com/larshp/abapGit/issues/3512, closes https://github.com/larshp/abapGit/issues/3563