### PR TITLE
Add deleted objects to overwrite confirm popup

### DIFF
--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -90,143 +90,143 @@ CLASS zcl_abapgit_objects DEFINITION
         zcx_abapgit_exception .
   PROTECTED SECTION.
 
-private section.
+  PRIVATE SECTION.
 
-  types:
-    BEGIN OF ty_obj_serializer_map,
+    TYPES:
+      BEGIN OF ty_obj_serializer_map,
         item     TYPE zif_abapgit_definitions=>ty_item,
         metadata TYPE zif_abapgit_definitions=>ty_metadata,
       END OF ty_obj_serializer_map .
-  types:
-    tty_obj_serializer_map
-          TYPE SORTED TABLE OF ty_obj_serializer_map WITH UNIQUE KEY item .
+    TYPES:
+      tty_obj_serializer_map
+            TYPE SORTED TABLE OF ty_obj_serializer_map WITH UNIQUE KEY item .
 
-  class-data GT_OBJ_SERIALIZER_MAP type TTY_OBJ_SERIALIZER_MAP .
+    CLASS-DATA gt_obj_serializer_map TYPE tty_obj_serializer_map .
 
-  class-methods FILES_TO_DESERIALIZE
-    importing
-      !IO_REPO type ref to ZCL_ABAPGIT_REPO
-      !II_LOG type ref to ZIF_ABAPGIT_LOG optional
-    returning
-      value(RT_RESULTS) type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  class-methods CHECK_DUPLICATES
-    importing
-      !IT_FILES type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_TT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  class-methods PRIORITIZE_DESER
-    importing
-      !IT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
-    returning
-      value(RT_RESULTS) type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT .
-  class-methods CLASS_NAME
-    importing
-      !IS_ITEM type ZIF_ABAPGIT_DEFINITIONS=>TY_ITEM
-    returning
-      value(RV_CLASS_NAME) type STRING .
-  class-methods WARNING_OVERWRITE_ADJUST
-    importing
-      !IT_OVERWRITE type ZIF_ABAPGIT_DEFINITIONS=>TY_OVERWRITE_TT
-    changing
-      !CT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  class-methods CHECKS_ADJUST
-    importing
-      !IO_REPO type ref to ZCL_ABAPGIT_REPO
-      !IS_CHECKS type ZIF_ABAPGIT_DEFINITIONS=>TY_DESERIALIZE_CHECKS
-    changing
-      !CT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  class-methods WARNING_OVERWRITE_FIND
-    importing
-      !IT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
-    returning
-      value(RT_OVERWRITE) type ZIF_ABAPGIT_DEFINITIONS=>TY_OVERWRITE_TT .
-  class-methods WARNING_PACKAGE_ADJUST
-    importing
-      !IO_REPO type ref to ZCL_ABAPGIT_REPO
-      !IT_OVERWRITE type ZIF_ABAPGIT_DEFINITIONS=>TY_OVERWRITE_TT
-    changing
-      !CT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  class-methods WARNING_PACKAGE_FIND
-    importing
-      !IT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
-      !IO_REPO type ref to ZCL_ABAPGIT_REPO
-    returning
-      value(RT_OVERWRITE) type ZIF_ABAPGIT_DEFINITIONS=>TY_OVERWRITE_TT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  class-methods UPDATE_PACKAGE_TREE
-    importing
-      !IV_PACKAGE type DEVCLASS .
-  class-methods DELETE_OBJ
-    importing
-      !IV_PACKAGE type DEVCLASS
-      !IS_ITEM type ZIF_ABAPGIT_DEFINITIONS=>TY_ITEM
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  class-methods COMPARE_REMOTE_TO_LOCAL
-    importing
-      !II_OBJECT type ref to ZIF_ABAPGIT_OBJECT
-      !IT_REMOTE type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_TT
-      !IS_RESULT type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULT
-      !II_LOG type ref to ZIF_ABAPGIT_LOG
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  class-methods DESERIALIZE_OBJECTS
-    importing
-      !IS_STEP type ZIF_ABAPGIT_DEFINITIONS=>TY_STEP_DATA
-      !II_LOG type ref to ZIF_ABAPGIT_LOG
-    changing
-      !CT_FILES type ZIF_ABAPGIT_DEFINITIONS=>TY_FILE_SIGNATURES_TT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  class-methods CHECK_OBJECTS_LOCKED
-    importing
-      !IV_LANGUAGE type SPRAS
-      !IT_ITEMS type ZIF_ABAPGIT_DEFINITIONS=>TY_ITEMS_TT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  class-methods CREATE_OBJECT
-    importing
-      !IS_ITEM type ZIF_ABAPGIT_DEFINITIONS=>TY_ITEM
-      !IV_LANGUAGE type SPRAS
-      !IS_METADATA type ZIF_ABAPGIT_DEFINITIONS=>TY_METADATA optional
-      !IV_NATIVE_ONLY type ABAP_BOOL default ABAP_FALSE
-    returning
-      value(RI_OBJ) type ref to ZIF_ABAPGIT_OBJECT
-    raising
-      ZCX_ABAPGIT_EXCEPTION .
-  class-methods MAP_TADIR_TO_ITEMS
-    importing
-      !IT_TADIR type ZIF_ABAPGIT_DEFINITIONS=>TY_TADIR_TT
-    returning
-      value(RT_ITEMS) type ZIF_ABAPGIT_DEFINITIONS=>TY_ITEMS_TT .
-  class-methods MAP_RESULTS_TO_ITEMS
-    importing
-      !IT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
-    returning
-      value(RT_ITEMS) type ZIF_ABAPGIT_DEFINITIONS=>TY_ITEMS_TT .
-  class-methods FILTER_FILES_TO_DESERIALIZE
-    importing
-      !IT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
-      !II_LOG type ref to ZIF_ABAPGIT_LOG optional
-    returning
-      value(RT_RESULTS) type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT .
-  class-methods ADJUST_NAMESPACES
-    importing
-      !IT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
-    returning
-      value(RT_RESULTS) type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT .
-  class-methods GET_DESERIALIZE_STEPS
-    returning
-      value(RT_STEPS) type ZIF_ABAPGIT_DEFINITIONS=>TY_STEP_DATA_TT .
+    CLASS-METHODS files_to_deserialize
+      IMPORTING
+        !io_repo          TYPE REF TO zcl_abapgit_repo
+        !ii_log           TYPE REF TO zif_abapgit_log OPTIONAL
+      RETURNING
+        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS check_duplicates
+      IMPORTING
+        !it_files TYPE zif_abapgit_definitions=>ty_files_tt
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS prioritize_deser
+      IMPORTING
+        !it_results       TYPE zif_abapgit_definitions=>ty_results_tt
+      RETURNING
+        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt .
+    CLASS-METHODS class_name
+      IMPORTING
+        !is_item             TYPE zif_abapgit_definitions=>ty_item
+      RETURNING
+        VALUE(rv_class_name) TYPE string .
+    CLASS-METHODS warning_overwrite_adjust
+      IMPORTING
+        !it_overwrite TYPE zif_abapgit_definitions=>ty_overwrite_tt
+      CHANGING
+        !ct_results   TYPE zif_abapgit_definitions=>ty_results_tt
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS checks_adjust
+      IMPORTING
+        !io_repo    TYPE REF TO zcl_abapgit_repo
+        !is_checks  TYPE zif_abapgit_definitions=>ty_deserialize_checks
+      CHANGING
+        !ct_results TYPE zif_abapgit_definitions=>ty_results_tt
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS warning_overwrite_find
+      IMPORTING
+        !it_results         TYPE zif_abapgit_definitions=>ty_results_tt
+      RETURNING
+        VALUE(rt_overwrite) TYPE zif_abapgit_definitions=>ty_overwrite_tt .
+    CLASS-METHODS warning_package_adjust
+      IMPORTING
+        !io_repo      TYPE REF TO zcl_abapgit_repo
+        !it_overwrite TYPE zif_abapgit_definitions=>ty_overwrite_tt
+      CHANGING
+        !ct_results   TYPE zif_abapgit_definitions=>ty_results_tt
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS warning_package_find
+      IMPORTING
+        !it_results         TYPE zif_abapgit_definitions=>ty_results_tt
+        !io_repo            TYPE REF TO zcl_abapgit_repo
+      RETURNING
+        VALUE(rt_overwrite) TYPE zif_abapgit_definitions=>ty_overwrite_tt
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS update_package_tree
+      IMPORTING
+        !iv_package TYPE devclass .
+    CLASS-METHODS delete_obj
+      IMPORTING
+        !iv_package TYPE devclass
+        !is_item    TYPE zif_abapgit_definitions=>ty_item
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS compare_remote_to_local
+      IMPORTING
+        !ii_object TYPE REF TO zif_abapgit_object
+        !it_remote TYPE zif_abapgit_definitions=>ty_files_tt
+        !is_result TYPE zif_abapgit_definitions=>ty_result
+        !ii_log    TYPE REF TO zif_abapgit_log
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS deserialize_objects
+      IMPORTING
+        !is_step  TYPE zif_abapgit_definitions=>ty_step_data
+        !ii_log   TYPE REF TO zif_abapgit_log
+      CHANGING
+        !ct_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS check_objects_locked
+      IMPORTING
+        !iv_language TYPE spras
+        !it_items    TYPE zif_abapgit_definitions=>ty_items_tt
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS create_object
+      IMPORTING
+        !is_item        TYPE zif_abapgit_definitions=>ty_item
+        !iv_language    TYPE spras
+        !is_metadata    TYPE zif_abapgit_definitions=>ty_metadata OPTIONAL
+        !iv_native_only TYPE abap_bool DEFAULT abap_false
+      RETURNING
+        VALUE(ri_obj)   TYPE REF TO zif_abapgit_object
+      RAISING
+        zcx_abapgit_exception .
+    CLASS-METHODS map_tadir_to_items
+      IMPORTING
+        !it_tadir       TYPE zif_abapgit_definitions=>ty_tadir_tt
+      RETURNING
+        VALUE(rt_items) TYPE zif_abapgit_definitions=>ty_items_tt .
+    CLASS-METHODS map_results_to_items
+      IMPORTING
+        !it_results     TYPE zif_abapgit_definitions=>ty_results_tt
+      RETURNING
+        VALUE(rt_items) TYPE zif_abapgit_definitions=>ty_items_tt .
+    CLASS-METHODS filter_files_to_deserialize
+      IMPORTING
+        !it_results       TYPE zif_abapgit_definitions=>ty_results_tt
+        !ii_log           TYPE REF TO zif_abapgit_log OPTIONAL
+      RETURNING
+        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt .
+    CLASS-METHODS adjust_namespaces
+      IMPORTING
+        !it_results       TYPE zif_abapgit_definitions=>ty_results_tt
+      RETURNING
+        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt .
+    CLASS-METHODS get_deserialize_steps
+      RETURNING
+        VALUE(rt_steps) TYPE zif_abapgit_definitions=>ty_step_data_tt .
 ENDCLASS.
 
 

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -90,145 +90,143 @@ CLASS zcl_abapgit_objects DEFINITION
         zcx_abapgit_exception .
   PROTECTED SECTION.
 
-  PRIVATE SECTION.
+private section.
 
-    TYPES:
-      BEGIN OF ty_obj_serializer_map,
+  types:
+    BEGIN OF ty_obj_serializer_map,
         item     TYPE zif_abapgit_definitions=>ty_item,
         metadata TYPE zif_abapgit_definitions=>ty_metadata,
       END OF ty_obj_serializer_map .
-    TYPES:
-      tty_obj_serializer_map
+  types:
+    tty_obj_serializer_map
           TYPE SORTED TABLE OF ty_obj_serializer_map WITH UNIQUE KEY item .
 
-    CLASS-DATA gt_obj_serializer_map TYPE tty_obj_serializer_map .
+  class-data GT_OBJ_SERIALIZER_MAP type TTY_OBJ_SERIALIZER_MAP .
 
-    CLASS-METHODS files_to_deserialize
-      IMPORTING
-        !io_repo          TYPE REF TO zcl_abapgit_repo
-        !ii_log           TYPE REF TO zif_abapgit_log OPTIONAL
-      RETURNING
-        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS check_duplicates
-      IMPORTING
-        !it_files TYPE zif_abapgit_definitions=>ty_files_tt
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS prioritize_deser
-      IMPORTING
-        !it_results       TYPE zif_abapgit_definitions=>ty_results_tt
-      RETURNING
-        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt .
-    CLASS-METHODS class_name
-      IMPORTING
-        !is_item             TYPE zif_abapgit_definitions=>ty_item
-      RETURNING
-        VALUE(rv_class_name) TYPE string .
-    CLASS-METHODS warning_overwrite_adjust
-      IMPORTING
-        !it_overwrite TYPE zif_abapgit_definitions=>ty_overwrite_tt
-      CHANGING
-        !ct_results   TYPE zif_abapgit_definitions=>ty_results_tt
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS checks_adjust
-      IMPORTING
-        !io_repo    TYPE REF TO zcl_abapgit_repo
-        !is_checks  TYPE zif_abapgit_definitions=>ty_deserialize_checks
-      CHANGING
-        !ct_results TYPE zif_abapgit_definitions=>ty_results_tt
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS warning_overwrite_find
-      IMPORTING
-        !it_results         TYPE zif_abapgit_definitions=>ty_results_tt
-      RETURNING
-        VALUE(rt_overwrite) TYPE zif_abapgit_definitions=>ty_overwrite_tt
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS warning_package_adjust
-      IMPORTING
-        !io_repo      TYPE REF TO zcl_abapgit_repo
-        !it_overwrite TYPE zif_abapgit_definitions=>ty_overwrite_tt
-      CHANGING
-        !ct_results   TYPE zif_abapgit_definitions=>ty_results_tt
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS warning_package_find
-      IMPORTING
-        !it_results         TYPE zif_abapgit_definitions=>ty_results_tt
-        !io_repo            TYPE REF TO zcl_abapgit_repo
-      RETURNING
-        VALUE(rt_overwrite) TYPE zif_abapgit_definitions=>ty_overwrite_tt
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS update_package_tree
-      IMPORTING
-        !iv_package TYPE devclass .
-    CLASS-METHODS delete_obj
-      IMPORTING
-        !iv_package TYPE devclass
-        !is_item    TYPE zif_abapgit_definitions=>ty_item
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS compare_remote_to_local
-      IMPORTING
-        !ii_object TYPE REF TO zif_abapgit_object
-        !it_remote TYPE zif_abapgit_definitions=>ty_files_tt
-        !is_result TYPE zif_abapgit_definitions=>ty_result
-        !ii_log    TYPE REF TO zif_abapgit_log
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS deserialize_objects
-      IMPORTING
-        !is_step  TYPE zif_abapgit_definitions=>ty_step_data
-        !ii_log   TYPE REF TO zif_abapgit_log
-      CHANGING
-        !ct_files TYPE zif_abapgit_definitions=>ty_file_signatures_tt
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS check_objects_locked
-      IMPORTING
-        !iv_language TYPE spras
-        !it_items    TYPE zif_abapgit_definitions=>ty_items_tt
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS create_object
-      IMPORTING
-        !is_item        TYPE zif_abapgit_definitions=>ty_item
-        !iv_language    TYPE spras
-        !is_metadata    TYPE zif_abapgit_definitions=>ty_metadata OPTIONAL
-        !iv_native_only TYPE abap_bool DEFAULT abap_false
-      RETURNING
-        VALUE(ri_obj)   TYPE REF TO zif_abapgit_object
-      RAISING
-        zcx_abapgit_exception .
-    CLASS-METHODS map_tadir_to_items
-      IMPORTING
-        !it_tadir       TYPE zif_abapgit_definitions=>ty_tadir_tt
-      RETURNING
-        VALUE(rt_items) TYPE zif_abapgit_definitions=>ty_items_tt .
-    CLASS-METHODS map_results_to_items
-      IMPORTING
-        !it_results     TYPE zif_abapgit_definitions=>ty_results_tt
-      RETURNING
-        VALUE(rt_items) TYPE zif_abapgit_definitions=>ty_items_tt .
-    CLASS-METHODS filter_files_to_deserialize
-      IMPORTING
-        !it_results       TYPE zif_abapgit_definitions=>ty_results_tt
-        !ii_log           TYPE REF TO zif_abapgit_log OPTIONAL
-      RETURNING
-        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt .
-    CLASS-METHODS adjust_namespaces
-      IMPORTING
-        !it_results       TYPE zif_abapgit_definitions=>ty_results_tt
-      RETURNING
-        VALUE(rt_results) TYPE zif_abapgit_definitions=>ty_results_tt .
-    CLASS-METHODS get_deserialize_steps
-      RETURNING
-        VALUE(rt_steps) TYPE zif_abapgit_definitions=>ty_step_data_tt .
+  class-methods FILES_TO_DESERIALIZE
+    importing
+      !IO_REPO type ref to ZCL_ABAPGIT_REPO
+      !II_LOG type ref to ZIF_ABAPGIT_LOG optional
+    returning
+      value(RT_RESULTS) type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  class-methods CHECK_DUPLICATES
+    importing
+      !IT_FILES type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_TT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  class-methods PRIORITIZE_DESER
+    importing
+      !IT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
+    returning
+      value(RT_RESULTS) type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT .
+  class-methods CLASS_NAME
+    importing
+      !IS_ITEM type ZIF_ABAPGIT_DEFINITIONS=>TY_ITEM
+    returning
+      value(RV_CLASS_NAME) type STRING .
+  class-methods WARNING_OVERWRITE_ADJUST
+    importing
+      !IT_OVERWRITE type ZIF_ABAPGIT_DEFINITIONS=>TY_OVERWRITE_TT
+    changing
+      !CT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  class-methods CHECKS_ADJUST
+    importing
+      !IO_REPO type ref to ZCL_ABAPGIT_REPO
+      !IS_CHECKS type ZIF_ABAPGIT_DEFINITIONS=>TY_DESERIALIZE_CHECKS
+    changing
+      !CT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  class-methods WARNING_OVERWRITE_FIND
+    importing
+      !IT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
+    returning
+      value(RT_OVERWRITE) type ZIF_ABAPGIT_DEFINITIONS=>TY_OVERWRITE_TT .
+  class-methods WARNING_PACKAGE_ADJUST
+    importing
+      !IO_REPO type ref to ZCL_ABAPGIT_REPO
+      !IT_OVERWRITE type ZIF_ABAPGIT_DEFINITIONS=>TY_OVERWRITE_TT
+    changing
+      !CT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  class-methods WARNING_PACKAGE_FIND
+    importing
+      !IT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
+      !IO_REPO type ref to ZCL_ABAPGIT_REPO
+    returning
+      value(RT_OVERWRITE) type ZIF_ABAPGIT_DEFINITIONS=>TY_OVERWRITE_TT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  class-methods UPDATE_PACKAGE_TREE
+    importing
+      !IV_PACKAGE type DEVCLASS .
+  class-methods DELETE_OBJ
+    importing
+      !IV_PACKAGE type DEVCLASS
+      !IS_ITEM type ZIF_ABAPGIT_DEFINITIONS=>TY_ITEM
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  class-methods COMPARE_REMOTE_TO_LOCAL
+    importing
+      !II_OBJECT type ref to ZIF_ABAPGIT_OBJECT
+      !IT_REMOTE type ZIF_ABAPGIT_DEFINITIONS=>TY_FILES_TT
+      !IS_RESULT type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULT
+      !II_LOG type ref to ZIF_ABAPGIT_LOG
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  class-methods DESERIALIZE_OBJECTS
+    importing
+      !IS_STEP type ZIF_ABAPGIT_DEFINITIONS=>TY_STEP_DATA
+      !II_LOG type ref to ZIF_ABAPGIT_LOG
+    changing
+      !CT_FILES type ZIF_ABAPGIT_DEFINITIONS=>TY_FILE_SIGNATURES_TT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  class-methods CHECK_OBJECTS_LOCKED
+    importing
+      !IV_LANGUAGE type SPRAS
+      !IT_ITEMS type ZIF_ABAPGIT_DEFINITIONS=>TY_ITEMS_TT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  class-methods CREATE_OBJECT
+    importing
+      !IS_ITEM type ZIF_ABAPGIT_DEFINITIONS=>TY_ITEM
+      !IV_LANGUAGE type SPRAS
+      !IS_METADATA type ZIF_ABAPGIT_DEFINITIONS=>TY_METADATA optional
+      !IV_NATIVE_ONLY type ABAP_BOOL default ABAP_FALSE
+    returning
+      value(RI_OBJ) type ref to ZIF_ABAPGIT_OBJECT
+    raising
+      ZCX_ABAPGIT_EXCEPTION .
+  class-methods MAP_TADIR_TO_ITEMS
+    importing
+      !IT_TADIR type ZIF_ABAPGIT_DEFINITIONS=>TY_TADIR_TT
+    returning
+      value(RT_ITEMS) type ZIF_ABAPGIT_DEFINITIONS=>TY_ITEMS_TT .
+  class-methods MAP_RESULTS_TO_ITEMS
+    importing
+      !IT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
+    returning
+      value(RT_ITEMS) type ZIF_ABAPGIT_DEFINITIONS=>TY_ITEMS_TT .
+  class-methods FILTER_FILES_TO_DESERIALIZE
+    importing
+      !IT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
+      !II_LOG type ref to ZIF_ABAPGIT_LOG optional
+    returning
+      value(RT_RESULTS) type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT .
+  class-methods ADJUST_NAMESPACES
+    importing
+      !IT_RESULTS type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT
+    returning
+      value(RT_RESULTS) type ZIF_ABAPGIT_DEFINITIONS=>TY_RESULTS_TT .
+  class-methods GET_DESERIALIZE_STEPS
+    returning
+      value(RT_STEPS) type ZIF_ABAPGIT_DEFINITIONS=>TY_STEP_DATA_TT .
 ENDCLASS.
 
 
@@ -1275,13 +1273,11 @@ CLASS ZCL_ABAPGIT_OBJECTS IMPLEMENTATION.
 
     FIELD-SYMBOLS: <ls_result> LIKE LINE OF it_results.
 
-    LOOP AT it_results ASSIGNING <ls_result>
-        WHERE NOT obj_type IS INITIAL.
+    LOOP AT it_results ASSIGNING <ls_result> WHERE NOT obj_type IS INITIAL.
       IF <ls_result>-lstate IS NOT INITIAL
-          AND <ls_result>-lstate <> zif_abapgit_definitions=>c_state-deleted
-          AND NOT ( <ls_result>-lstate = zif_abapgit_definitions=>c_state-added
-          AND <ls_result>-rstate IS INITIAL ).
-* current object has been modified locally, add to table
+        AND NOT ( <ls_result>-lstate = zif_abapgit_definitions=>c_state-added
+        AND <ls_result>-rstate IS INITIAL ).
+        " current object has been modified or deleted locally, add to table
         CLEAR ls_overwrite.
         MOVE-CORRESPONDING <ls_result> TO ls_overwrite.
         APPEND ls_overwrite TO rt_overwrite.

--- a/src/objects/zcl_abapgit_objects.clas.testclasses.abap
+++ b/src/objects/zcl_abapgit_objects.clas.testclasses.abap
@@ -873,3 +873,120 @@ CLASS ltcl_prio_deserialization IMPLEMENTATION.
   ENDMETHOD.
 
 ENDCLASS.
+
+CLASS ltcl_warning_overwrite_find DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+    DATA:
+      mo_objects   TYPE REF TO zcl_abapgit_objects,
+      mt_result    TYPE zif_abapgit_definitions=>ty_results_tt,
+      mt_overwrite TYPE zif_abapgit_definitions=>ty_overwrite_tt.
+
+    METHODS:
+      setup,
+      warning_overwrite_find_01 FOR TESTING RAISING cx_static_check,
+      warning_overwrite_find_02 FOR TESTING RAISING cx_static_check,
+      warning_overwrite_find_03 FOR TESTING RAISING cx_static_check,
+      warning_overwrite_find_04 FOR TESTING RAISING cx_static_check,
+
+      given_result
+        IMPORTING
+          iv_result_line TYPE string,
+
+      when_warning_overwrite_find.
+
+ENDCLASS.
+
+CLASS zcl_abapgit_objects DEFINITION LOCAL FRIENDS ltcl_warning_overwrite_find.
+
+CLASS ltcl_warning_overwrite_find IMPLEMENTATION.
+
+  METHOD setup.
+
+    CREATE OBJECT mo_objects.
+
+  ENDMETHOD.
+
+  METHOD warning_overwrite_find_01.
+
+    " change remote but not local -> no overwrite
+    given_result( |CLAS;ZAG_UNIT_TEST;;/src/;zag_unit_test.clas.abap;;;;M| ).
+
+    when_warning_overwrite_find( ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 0
+      act = lines( mt_overwrite ) ).
+
+  ENDMETHOD.
+
+  METHOD warning_overwrite_find_02.
+
+    " change remote and local -> overwrite
+    given_result( |CLAS;ZAG_UNIT_TEST;;/src/;zag_unit_test.clas.abap;;;M;M| ).
+
+    when_warning_overwrite_find( ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 1
+      act = lines( mt_overwrite ) ).
+
+  ENDMETHOD.
+
+  METHOD warning_overwrite_find_03.
+
+    " delete local -> overwrite (since object will be created again from remote)
+    given_result( |CLAS;ZAG_UNIT_TEST;;/src/;zag_unit_test.clas.abap;;;D;| ).
+
+    when_warning_overwrite_find( ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 1
+      act = lines( mt_overwrite ) ).
+
+  ENDMETHOD.
+
+  METHOD warning_overwrite_find_04.
+
+    " exists local but not remote -> no overwrite
+    " (object will be in delete confirmation popup: see ZCL_ABAPGIT_SERVICES_GIT->GET_UNNECESSARY_LOCAL_OBJS)
+    given_result( |CLAS;ZAG_UNIT_TEST;;/src/;zag_unit_test.clas.abap;;;A;| ).
+
+    when_warning_overwrite_find( ).
+
+    cl_abap_unit_assert=>assert_equals(
+      exp = 0
+      act = lines( mt_overwrite ) ).
+
+  ENDMETHOD.
+
+  METHOD given_result.
+
+    DATA: ls_result LIKE LINE OF mt_result.
+
+    SPLIT iv_result_line
+      AT ';'
+      INTO ls_result-obj_type
+           ls_result-obj_name
+           ls_result-inactive
+           ls_result-path
+           ls_result-filename
+           ls_result-package
+           ls_result-match
+           ls_result-lstate
+           ls_result-rstate.
+
+    INSERT ls_result INTO TABLE mt_result.
+
+  ENDMETHOD.
+
+
+  METHOD when_warning_overwrite_find.
+
+    mt_overwrite = mo_objects->warning_overwrite_find( mt_result ).
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -82,7 +82,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_abapgit_services_repo IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
 
 
   METHOD gui_deserialize.
@@ -238,8 +238,8 @@ CLASS zcl_abapgit_services_repo IMPLEMENTATION.
     li_popups->popup_to_select_from_list(
       EXPORTING
         it_list               = ct_overwrite
-        iv_header_text        = |The following objects have been modified locally.|
-                             && | Select the objects which should be overwritten.|
+        iv_header_text        = |The following objects have been modified (or deleted) locally.|
+                             && | Select the objects which should be overwritten (or recreated).|
         iv_select_column_text = 'Overwrite?'
         it_columns_to_display = lt_columns
       IMPORTING


### PR DESCRIPTION
Previously, "reset local" would automatically recreate objects that had been deleted locally. Now user has to confirm these cases on the overwrite popup. 
Includes new unit tests for overwrite popup and closes https://github.com/larshp/abapGit/issues/2845