### PR TITLE
Faulty handling of post data

### DIFF
--- a/src/ui/db/zcl_abapgit_gui_page_db_edit.clas.abap
+++ b/src/ui/db/zcl_abapgit_gui_page_db_edit.clas.abap
@@ -56,7 +56,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DB_EDIT IMPLEMENTATION.
           lv_string TYPE string.
 
 
-    CONCATENATE LINES OF it_postdata INTO lv_string.
+    lv_string = zcl_abapgit_utils=>translate_postdata( it_postdata ).
 
     lv_string = cl_http_utility=>unescape_url( lv_string ).
 

--- a/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
@@ -233,7 +233,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_BOVERVIEW IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_field> LIKE LINE OF lt_fields.
 
 
-    CONCATENATE LINES OF it_postdata INTO lv_string.
+    lv_string = zcl_abapgit_utils=>translate_postdata( it_postdata ).
 
     lt_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_string ).
 

--- a/src/ui/zcl_abapgit_gui_page_patch.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_patch.clas.abap
@@ -345,7 +345,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_PATCH IMPLEMENTATION.
           lv_add    TYPE string,
           lv_remove TYPE string.
 
-    CONCATENATE LINES OF it_postdata INTO lv_string.
+    lv_string = zcl_abapgit_utils=>translate_postdata( it_postdata ).
     lt_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_string ).
 
     zcl_abapgit_html_action_utils=>get_field( EXPORTING iv_name  = c_patch_action-add

--- a/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
@@ -84,7 +84,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
 
     DATA lv_serialized_post_data TYPE string.
 
-    CONCATENATE LINES OF it_postdata INTO lv_serialized_post_data.
+    lv_serialized_post_data = zcl_abapgit_utils=>translate_postdata( it_postdata ).
     rt_post_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_serialized_post_data ).
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_settings.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_settings.clas.abap
@@ -128,7 +128,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETTINGS IMPLEMENTATION.
 
     DATA lv_serialized_post_data TYPE string.
 
-    CONCATENATE LINES OF it_postdata INTO lv_serialized_post_data.
+    lv_serialized_post_data = zcl_abapgit_utils=>translate_postdata( it_postdata ).
     rt_post_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_serialized_post_data ).
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -581,7 +581,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
                    <ls_status> LIKE LINE OF ms_files-status,
                    <ls_item>   LIKE LINE OF lt_fields.
 
-    CONCATENATE LINES OF it_postdata INTO lv_string.
+    lv_string = zcl_abapgit_utils=>translate_postdata( it_postdata ).
     lt_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_string ).
 
     IF lines( lt_fields ) = 0.

--- a/src/ui/zcl_abapgit_gui_page_tag.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_tag.clas.abap
@@ -159,7 +159,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_TAG IMPLEMENTATION.
 
     CLEAR eg_fields.
 
-    CONCATENATE LINES OF it_postdata INTO lv_string.
+    lv_string = zcl_abapgit_utils=>translate_postdata( it_postdata ).
     REPLACE ALL OCCURRENCES OF zif_abapgit_definitions=>c_crlf    IN lv_string WITH lc_replace.
     REPLACE ALL OCCURRENCES OF zif_abapgit_definitions=>c_newline IN lv_string WITH lc_replace.
     lt_fields = zcl_abapgit_html_action_utils=>parse_fields_upper_case_name( lv_string ).

--- a/src/utils/zcl_abapgit_utils.clas.abap
+++ b/src/utils/zcl_abapgit_utils.clas.abap
@@ -19,6 +19,11 @@ CLASS zcl_abapgit_utils DEFINITION
         !ev_time    TYPE zif_abapgit_definitions=>ty_commit-time
       RAISING
         zcx_abapgit_exception .
+    CLASS-METHODS TRANSLATE_POSTDATA
+      IMPORTING
+        !IT_POSTDATA TYPE CNHT_POST_DATA_TAB
+      RETURNING
+        value(R_STRING) TYPE STRING .
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
@@ -70,6 +75,32 @@ CLASS zcl_abapgit_utils IMPLEMENTATION.
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( |Error author regex value='{ iv_author }'| ).
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD translate_postdata.
+
+    DATA: lt_post_data       TYPE cnht_post_data_tab,
+          ls_last_line       TYPE cnht_post_data_line,
+          lv_last_line_index TYPE i.
+
+    IF it_postdata IS INITIAL.
+      "Nothing to do
+      RETURN.
+    ENDIF.
+
+    lt_post_data = it_postdata.
+    lv_last_line_index = lines( lt_post_data ).
+
+    "Save the last line for separate merge, because we don't need its trailing spaces
+    ls_last_line = it_postdata[ lv_last_line_index ].
+    DELETE lt_post_data INDEX lv_last_line_index.
+
+    CONCATENATE LINES OF lt_post_data INTO r_string
+      IN CHARACTER MODE RESPECTING BLANKS.
+    CONCATENATE r_string ls_last_line INTO r_string
+      IN CHARACTER MODE.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/utils/zcl_abapgit_utils.clas.abap
+++ b/src/utils/zcl_abapgit_utils.clas.abap
@@ -23,7 +23,7 @@ CLASS zcl_abapgit_utils DEFINITION
       IMPORTING
         !it_postdata TYPE cnht_post_data_tab
       RETURNING
-        value(rv_string) TYPE string .
+        VALUE(rv_string) TYPE string .
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.

--- a/src/utils/zcl_abapgit_utils.clas.abap
+++ b/src/utils/zcl_abapgit_utils.clas.abap
@@ -94,7 +94,8 @@ CLASS zcl_abapgit_utils IMPLEMENTATION.
     lv_last_line_index = lines( lt_post_data ).
 
     "Save the last line for separate merge, because we don't need its trailing spaces
-    ls_last_line = it_postdata[ lv_last_line_index ].
+    
+    READ TABLE it_postdata INTO ls_last_line INDEX lv_last_line_index.
     DELETE lt_post_data INDEX lv_last_line_index.
 
     CONCATENATE LINES OF lt_post_data INTO r_string

--- a/src/utils/zcl_abapgit_utils.clas.abap
+++ b/src/utils/zcl_abapgit_utils.clas.abap
@@ -19,11 +19,11 @@ CLASS zcl_abapgit_utils DEFINITION
         !ev_time    TYPE zif_abapgit_definitions=>ty_commit-time
       RAISING
         zcx_abapgit_exception .
-    CLASS-METHODS TRANSLATE_POSTDATA
+    CLASS-METHODS translate_postdata
       IMPORTING
-        !IT_POSTDATA TYPE CNHT_POST_DATA_TAB
+        !it_postdata TYPE cnht_post_data_tab
       RETURNING
-        value(R_STRING) TYPE STRING .
+        value(rv_string) TYPE string .
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
@@ -94,13 +94,12 @@ CLASS zcl_abapgit_utils IMPLEMENTATION.
     lv_last_line_index = lines( lt_post_data ).
 
     "Save the last line for separate merge, because we don't need its trailing spaces
-    
     READ TABLE it_postdata INTO ls_last_line INDEX lv_last_line_index.
     DELETE lt_post_data INDEX lv_last_line_index.
 
-    CONCATENATE LINES OF lt_post_data INTO r_string
+    CONCATENATE LINES OF lt_post_data INTO rv_string
       IN CHARACTER MODE RESPECTING BLANKS.
-    CONCATENATE r_string ls_last_line INTO r_string
+    CONCATENATE rv_string ls_last_line INTO rv_string
       IN CHARACTER MODE.
 
   ENDMETHOD.

--- a/src/utils/zcl_abapgit_utils.clas.abap
+++ b/src/utils/zcl_abapgit_utils.clas.abap
@@ -91,11 +91,13 @@ CLASS zcl_abapgit_utils IMPLEMENTATION.
     ENDIF.
 
     lt_post_data = it_postdata.
-    lv_last_line_index = lines( lt_post_data ).
 
     "Save the last line for separate merge, because we don't need its trailing spaces
-    READ TABLE it_postdata INTO ls_last_line INDEX lv_last_line_index.
-    DELETE lt_post_data INDEX lv_last_line_index.
+    WHILE ls_last_line IS INITIAL.
+      lv_last_line_index = lines( lt_post_data ).
+      READ TABLE lt_post_data INTO ls_last_line INDEX lv_last_line_index.
+      DELETE lt_post_data INDEX lv_last_line_index.
+    ENDWHILE.
 
     CONCATENATE LINES OF lt_post_data INTO rv_string
       IN CHARACTER MODE RESPECTING BLANKS.


### PR DESCRIPTION
In various places of the UI handling the lines of the post data (IT_POSTDATA) was translated to a string by concatenating its parts into the string. This could cause various unspecified errors or crashes, depending on the content of the post data (e.g. #3073), because everytime a filename with spaces happened to be caught on a table line break, the trailing spaces would be lost.
The error would be hard to track and even vanish by itself if other changes were performed and the alignment of the fieldnames in the post data changed in such a way that the spaces no longer happened at the end of a table line.

I have added a utility method to correctly translate the post data into a string and replaced the CONCATENATE calls with the translation method. This should address any such issues and most likely fix #3073.