### PR TITLE
Improved staging robustness

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -1,5 +1,4 @@
 {
-  
   "global": {
     "files": "/src/**/*.*",
     "skipGeneratedGatewayClasses": true,

--- a/abaplint.json
+++ b/abaplint.json
@@ -1,4 +1,5 @@
 {
+  
   "global": {
     "files": "/src/**/*.*",
     "skipGeneratedGatewayClasses": true,

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -590,7 +590,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
     CREATE OBJECT ro_stage.
 
-    LOOP AT lt_fields ASSIGNING <ls_item>.
+    LOOP AT lt_fields ASSIGNING <ls_item>
+      WHERE value <> zif_abapgit_definitions=>c_method-skip. "Ignore Files that we don't want to stage, so any errors don't stop the staging process
 
       zcl_abapgit_path=>split_file_location(
         EXPORTING

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -592,7 +592,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
     LOOP AT lt_fields ASSIGNING <ls_item>
       "Ignore Files that we don't want to stage, so any errors don't stop the staging process
-      WHERE value <> zif_abapgit_definitions=>c_method-skip. 
+      WHERE value <> zif_abapgit_definitions=>c_method-skip.
 
       zcl_abapgit_path=>split_file_location(
         EXPORTING

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -591,7 +591,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
     CREATE OBJECT ro_stage.
 
     LOOP AT lt_fields ASSIGNING <ls_item>
-      WHERE value <> zif_abapgit_definitions=>c_method-skip. "Ignore Files that we don't want to stage, so any errors don't stop the staging process
+      "Ignore Files that we don't want to stage, so any errors don't stop the staging process
+      WHERE value <> zif_abapgit_definitions=>c_method-skip. 
 
       zcl_abapgit_path=>split_file_location(
         EXPORTING


### PR DESCRIPTION
Added code to skip any objects in the fields list, that are not marked for staging prior to processing them. 
This avoids that the user is stopped from staging some files if fiels that should not even be processed have an error and the expection is triggered.