### PR TITLE
Page HOC concept (refactoring)

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_hoc.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_hoc.clas.abap
@@ -1,0 +1,51 @@
+CLASS zcl_abapgit_gui_page_hoc DEFINITION
+  PUBLIC
+  FINAL
+  INHERITING FROM zcl_abapgit_gui_page
+  CREATE PRIVATE .
+
+  PUBLIC SECTION.
+
+    CLASS-METHODS create
+      IMPORTING
+        ii_child_component TYPE REF TO zif_abapgit_gui_renderable
+        iv_page_title TYPE string
+        io_page_menu TYPE REF TO zcl_abapgit_html_toolbar OPTIONAL
+      RETURNING
+        VALUE(ri_page_wrap) TYPE REF TO zif_abapgit_gui_renderable
+      RAISING
+        zcx_abapgit_exception.
+
+  PROTECTED SECTION.
+    METHODS render_content REDEFINITION.
+  PRIVATE SECTION.
+    DATA mi_child TYPE REF TO zif_abapgit_gui_renderable.
+ENDCLASS.
+
+
+
+CLASS ZCL_ABAPGIT_GUI_PAGE_HOC IMPLEMENTATION.
+
+
+  METHOD create.
+
+    DATA lo_page TYPE REF TO zcl_abapgit_gui_page_hoc.
+
+    CREATE OBJECT lo_page.
+    lo_page->ms_control-page_title = iv_page_title.
+    lo_page->ms_control-page_menu  = io_page_menu.
+    lo_page->mi_child = ii_child_component.
+
+    ri_page_wrap = lo_page.
+
+  ENDMETHOD.
+
+
+  METHOD render_content.
+
+    IF mi_child IS BOUND.
+      ri_html = mi_child->render( ).
+    ENDIF.
+
+  ENDMETHOD.
+ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_hoc.clas.xml
+++ b/src/ui/zcl_abapgit_gui_page_hoc.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_ABAPGIT_GUI_PAGE_HOC</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>abapGit GUI page HOC component</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
ref #3286

OK, here is one refactoring I wanted to come to for some time and mentioned in #3286. Currently just for one page as a demo. Eventually I'd suggest to migrate all pages to this approach.

Now all pages subclass `gui_page` which is cluttered: trickier to maintain, necessity to call `super`, confusion between `renderable~render` and `render_content`, redefinitions.

Idea: all generic page stuff - html head, footer, scripts - has to be a HOC (high order component). Which accepts a child component to render inside itself.

Consider changes to `zcl_abapgit_gui_page_addonline` - no redefinitions, no `super->on_event`,  proper reuse of interfaces,  completely independent and clean. Well, `create` knows about the gui_page but it is more for convenience sake.

`zcl_abapgit_gui_page_hoc` is a temporary piece - as soon as all pages will follow the proposed pattern it can be merged with `gui_page` (which will become non-abstract final class)


