### PR TITLE
add success message box with commit hash

### DIFF
--- a/src/background/zcl_abapgit_background.clas.abap
+++ b/src/background/zcl_abapgit_background.clas.abap
@@ -110,7 +110,7 @@ CLASS ZCL_ABAPGIT_BACKGROUND IMPLEMENTATION.
         iv_username = <ls_list>-username
         iv_password = <ls_list>-password ).
 
-      CREATE OBJECT li_log TYPE zcl_abapgit_log.
+      li_log = lo_repo->get_log( ).
       CREATE OBJECT li_background TYPE (<ls_list>-method).
 
       li_background->run(

--- a/src/objects/zcl_abapgit_objects.clas.testclasses.abap
+++ b/src/objects/zcl_abapgit_objects.clas.testclasses.abap
@@ -51,8 +51,6 @@ CLASS ltcl_dangerous IMPLEMENTATION.
                    <ls_tadir>  LIKE LINE OF lt_tadir,
                    <lv_type>   LIKE LINE OF lt_types.
 
-    CREATE OBJECT li_log TYPE zcl_abapgit_log.
-
     zcl_abapgit_factory=>get_sap_package( c_package )->create_local( ).
 
     lt_types = zcl_abapgit_objects=>supported_list( ).
@@ -61,9 +59,10 @@ CLASS ltcl_dangerous IMPLEMENTATION.
       iv_url         = 'https://github.com/abapGit/Test-Objects.git'
       iv_branch_name = 'refs/heads/master'
       iv_package     = c_package ).
+
     lo_repo->status( ).
     lo_repo->deserialize( is_checks = ls_checks
-                          ii_log    = li_log ).
+                          ii_log    = lo_repo->get_log( ) ).
 
     lt_tadir = zcl_abapgit_factory=>get_tadir( )->read( c_package ).
     LOOP AT lt_types ASSIGNING <lv_type>.

--- a/src/objects/zcl_abapgit_objects_activation.clas.abap
+++ b/src/objects/zcl_abapgit_objects_activation.clas.abap
@@ -280,7 +280,7 @@ CLASS ZCL_ABAPGIT_OBJECTS_ACTIVATION IMPLEMENTATION.
 
     DELETE lt_lines WHERE severity <> 'E'.
 
-    CREATE OBJECT li_log TYPE zcl_abapgit_log.
+    li_log = zcl_abapgit_log=>get_log( ).
 
     LOOP AT lt_lines ASSIGNING <ls_line>.
       li_log->add( <ls_line>-line ).

--- a/src/ui/zabapgit_css_common.w3mi.data.css
+++ b/src/ui/zabapgit_css_common.w3mi.data.css
@@ -836,6 +836,12 @@ div.message-panel:hover .message-panel-commands {
   display: block
 }
 
+/* Success message Panel */
+div.success-panel {
+  border-color: hsl(148, 87%, 33%);
+  background-color: hsla(148, 67%, 92%, 1);
+}
+
 /* Tooltip text */
 .link-hint {
     line-height: 1em;

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -441,16 +441,6 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
 
     ro_html->add( |<div class="float-right message-panel-commands">| ).
 
-*    IF is_log_entry-obj_type = 'SHA1'.
-*      ro_html->add_a(
-*          iv_txt   = `Goto Repository`
-*          iv_act   = zif_abapgit_definitions=>c_action-goto_repo && |?SHA1={ is_log_entry-obj_name }|
-*          iv_typ   = zif_abapgit_html=>c_action_type-sapevent
-*          iv_title = lv_title
-*          iv_id    = `a_goto_repo`
-*           ).
-*    ENDIF.
-
     ro_html->add( |</div>| ).
     ro_html->add( |</div>| ).
 

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -14,11 +14,11 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
     CLASS-METHODS class_constructor.
     CLASS-METHODS render_error
       IMPORTING
-        !ix_error      TYPE REF TO zcx_abapgit_exception OPTIONAL
-        !iv_error      TYPE string OPTIONAL
+        !ix_error       TYPE REF TO zcx_abapgit_exception OPTIONAL
+        !iv_error       TYPE string OPTIONAL
         !iv_extra_style TYPE string OPTIONAL
       RETURNING
-        VALUE(ro_html) TYPE REF TO zcl_abapgit_html .
+        VALUE(ro_html)  TYPE REF TO zcl_abapgit_html .
     CLASS-METHODS render_repo_top
       IMPORTING
         !io_repo               TYPE REF TO zcl_abapgit_repo
@@ -62,6 +62,11 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
         ix_error       TYPE REF TO zcx_abapgit_exception
       RETURNING
         VALUE(ro_html) TYPE REF TO zcl_abapgit_html.
+    CLASS-METHODS render_success_message_box
+      IMPORTING
+        is_log_entry   TYPE zif_abapgit_log=>ty_log_out
+      RETURNING
+        VALUE(ro_html) TYPE REF TO zcl_abapgit_html.
     CLASS-METHODS parse_change_order_by
       IMPORTING
         iv_query_str       TYPE clike
@@ -103,7 +108,7 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
         VALUE(ro_html) TYPE REF TO zcl_abapgit_html.
     CLASS-METHODS render_repo_palette
       IMPORTING
-        iv_action TYPE string
+        iv_action      TYPE string
       RETURNING
         VALUE(ri_html) TYPE REF TO zif_abapgit_html
       RAISING
@@ -143,7 +148,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
+CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
 
 
   METHOD advanced_submenu.
@@ -409,6 +414,48 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
     ro_html->add( |</div>| ).
 
   ENDMETHOD.
+
+  METHOD render_success_message_box.
+
+    DATA:
+      lv_error_text   TYPE string,
+      lv_longtext     TYPE string,
+      lv_program_name TYPE sy-repid,
+      lv_title        TYPE string,
+      lv_text         TYPE string.
+
+
+    CREATE OBJECT ro_html.
+
+    ro_html->add( |<div id="message" class="message-panel success-panel">| ).
+    ro_html->add( |{ is_log_entry-text }| ).
+    ro_html->add( |<div class="float-right">| ).
+
+    ro_html->add_a(
+        iv_txt   = `&#x274c;`
+        iv_act   = `toggleDisplay('message')`
+        iv_class = `close-btn`
+        iv_typ   = zif_abapgit_html=>c_action_type-onclick ).
+
+    ro_html->add( |</div>| ).
+
+    ro_html->add( |<div class="float-right message-panel-commands">| ).
+
+*    IF is_log_entry-obj_type = 'SHA1'.
+*      ro_html->add_a(
+*          iv_txt   = `Goto Repository`
+*          iv_act   = zif_abapgit_definitions=>c_action-goto_repo && |?SHA1={ is_log_entry-obj_name }|
+*          iv_typ   = zif_abapgit_html=>c_action_type-sapevent
+*          iv_title = lv_title
+*          iv_id    = `a_goto_repo`
+*           ).
+*    ENDIF.
+
+    ro_html->add( |</div>| ).
+    ro_html->add( |</div>| ).
+
+  ENDMETHOD.
+
 
 
   METHOD render_event_as_form.

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -62,11 +62,6 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
         ix_error       TYPE REF TO zcx_abapgit_exception
       RETURNING
         VALUE(ro_html) TYPE REF TO zcl_abapgit_html.
-    CLASS-METHODS render_success_message_box
-      IMPORTING
-        is_log_entry   TYPE zif_abapgit_log=>ty_log_out
-      RETURNING
-        VALUE(ro_html) TYPE REF TO zcl_abapgit_html.
     CLASS-METHODS parse_change_order_by
       IMPORTING
         iv_query_str       TYPE clike
@@ -414,38 +409,6 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
     ro_html->add( |</div>| ).
 
   ENDMETHOD.
-
-  METHOD render_success_message_box.
-
-    DATA:
-      lv_error_text   TYPE string,
-      lv_longtext     TYPE string,
-      lv_program_name TYPE sy-repid,
-      lv_title        TYPE string,
-      lv_text         TYPE string.
-
-
-    CREATE OBJECT ro_html.
-
-    ro_html->add( |<div id="message" class="message-panel success-panel">| ).
-    ro_html->add( |{ is_log_entry-text }| ).
-    ro_html->add( |<div class="float-right">| ).
-
-    ro_html->add_a(
-        iv_txt   = `&#x274c;`
-        iv_act   = `toggleDisplay('message')`
-        iv_class = `close-btn`
-        iv_typ   = zif_abapgit_html=>c_action_type-onclick ).
-
-    ro_html->add( |</div>| ).
-
-    ro_html->add( |<div class="float-right message-panel-commands">| ).
-
-    ro_html->add( |</div>| ).
-    ro_html->add( |</div>| ).
-
-  ENDMETHOD.
-
 
 
   METHOD render_event_as_form.

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -818,13 +818,23 @@ CLASS zcl_abapgit_gui_chunk_lib IMPLEMENTATION.
 
   METHOD get_commit_display_url.
 
+    DATA ls_result TYPE match_result.
+    FIELD-SYMBOLS <ls_provider_match> TYPE submatch_result.
+
     rv_url = iv_url.
-    FIND REGEX '^https:\/\/(www\.)?github.com\/' IN rv_url.
+    FIND REGEX '^https:\/\/(?:www\.)?(github\.com|bitbucket\.org)\/' IN rv_url RESULTS ls_result.
     IF sy-subrc <> 0.
       zcx_abapgit_exception=>raise( |provider not yet supported| ).
     ENDIF.
-    REPLACE REGEX '\.git$' IN rv_url WITH space.
-    rv_url = rv_url && |/commit/| && iv_hash.
+    READ TABLE ls_result-submatches INDEX 1 ASSIGNING <ls_provider_match>.
+    CASE rv_url+<ls_provider_match>-offset(<ls_provider_match>-length).
+      WHEN 'github.com'.
+        REPLACE REGEX '\.git$' IN rv_url WITH space.
+        rv_url = rv_url && |/commit/| && iv_hash.
+      WHEN 'bitbucket.org'.
+        REPLACE REGEX '\.git$' IN rv_url WITH space.
+        rv_url = rv_url && |/commits/| && iv_hash.
+    ENDCASE.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -19,7 +19,7 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
         page_menu  TYPE REF TO zcl_abapgit_html_toolbar,
       END OF  ty_control .
 
-    CLASS-DATA ms_success_log_entry TYPE zif_abapgit_log=>ty_log_out.
+    CLASS-DATA gs_success_log_entry TYPE zif_abapgit_log=>ty_log_out.
 
     DATA ms_control TYPE ty_control.
 
@@ -219,11 +219,11 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
 
     CREATE OBJECT ro_html.
 
-    IF ms_success_log_entry IS NOT INITIAL.
+    IF gs_success_log_entry IS NOT INITIAL.
 
-      ro_html = zcl_abapgit_gui_chunk_lib=>render_success_message_box( is_log_entry = ms_success_log_entry ).
+      ro_html = zcl_abapgit_gui_chunk_lib=>render_success_message_box( is_log_entry = gs_success_log_entry ).
 
-      CLEAR ms_success_log_entry.
+      CLEAR gs_success_log_entry.
 
     ENDIF.
 
@@ -326,17 +326,6 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
           mo_exception_viewer->goto_message( ).
         ENDIF.
         ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
-
-*      WHEN zif_abapgit_definitions=>c_action-goto_repo.
-*        DATA: lt_fields TYPE tihttpnvp.
-*        lt_fields = zcl_abapgit_html_action_utils=>parse_fields_upper_case_name( iv_getdata ).
-*        DATA: lv_sha1 TYPE zif_abapgit_definitions=>ty_sha1.
-*
-*        zcl_abapgit_html_action_utils=>get_field( EXPORTING iv_name  = 'SHA1'
-*                                                            it_field = lt_fields
-*                                                  CHANGING  cg_field = lv_sha1 ).
-*
-*        ev_state = zcl_abapgit_gui=>c_event_state-no_more_act.
 
     ENDCASE.
 

--- a/src/ui/zcl_abapgit_gui_page.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page.clas.abap
@@ -17,9 +17,7 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
       BEGIN OF ty_control,
         page_title TYPE string,
         page_menu  TYPE REF TO zcl_abapgit_html_toolbar,
-      END OF  ty_control .
-
-    CLASS-DATA gs_success_log_entry TYPE zif_abapgit_log=>ty_log_out.
+      END OF  ty_control.
 
     DATA ms_control TYPE ty_control.
 
@@ -70,12 +68,6 @@ CLASS zcl_abapgit_gui_page DEFINITION PUBLIC ABSTRACT
         zcx_abapgit_exception.
 
     METHODS render_error_message_box
-      RETURNING
-        VALUE(ro_html) TYPE REF TO zcl_abapgit_html
-      RAISING
-        zcx_abapgit_exception.
-
-    METHODS render_commit_success_msg_box
       RETURNING
         VALUE(ro_html) TYPE REF TO zcl_abapgit_html
       RAISING
@@ -215,21 +207,6 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD render_commit_success_msg_box.
-
-    CREATE OBJECT ro_html.
-
-    IF gs_success_log_entry IS NOT INITIAL.
-
-      ro_html = zcl_abapgit_gui_chunk_lib=>render_success_message_box( is_log_entry = gs_success_log_entry ).
-
-      CLEAR gs_success_log_entry.
-
-    ENDIF.
-
-  ENDMETHOD.
-
-
   METHOD render_hotkey_overview.
 
     DATA lo_hotkeys_component TYPE REF TO zif_abapgit_gui_renderable.
@@ -351,7 +328,6 @@ CLASS zcl_abapgit_gui_page IMPLEMENTATION.
 
     ri_html->add( render_hotkey_overview( ) ).
     ri_html->add( render_error_message_box( ) ).
-    ri_html->add( render_commit_success_msg_box( ) ).
 
     render_deferred_parts(
       ii_html          = ri_html

--- a/src/ui/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_commit.clas.abap
@@ -487,7 +487,7 @@ CLASS zcl_abapgit_gui_page_commit IMPLEMENTATION.
         lt_log_messages = lv_repo_log->get_messages( ).
         READ TABLE lt_log_messages WITH KEY obj_type = 'SHA1' ASSIGNING <ls_message>.
         IF sy-subrc = 0.
-          me->ms_success_log_entry = <ls_message>.
+          gs_success_log_entry = <ls_message>.
         ELSE.
           MESSAGE 'Commit was successful' TYPE 'S' ##NO_TEXT.
         ENDIF.

--- a/src/ui/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_commit.clas.abap
@@ -487,7 +487,7 @@ CLASS zcl_abapgit_gui_page_commit IMPLEMENTATION.
         lt_log_messages = lv_repo_log->get_messages( ).
         READ TABLE lt_log_messages WITH KEY obj_type = 'SHA1' ASSIGNING <ls_message>.
         IF sy-subrc = 0.
-          gs_success_log_entry = <ls_message>.
+          MESSAGE <ls_message>-text TYPE 'S' ##NO_TEXT.
         ELSE.
           MESSAGE 'Commit was successful' TYPE 'S' ##NO_TEXT.
         ENDIF.

--- a/src/ui/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_commit.clas.abap
@@ -20,7 +20,7 @@ CLASS zcl_abapgit_gui_page_commit DEFINITION
         zcx_abapgit_exception.
 
     METHODS zif_abapgit_gui_event_handler~on_event
-        REDEFINITION .
+         REDEFINITION .
   PROTECTED SECTION.
 
     CLASS-METHODS parse_commit_request
@@ -82,7 +82,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_commit IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -465,6 +465,10 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
 
   METHOD zif_abapgit_gui_event_handler~on_event.
 
+    DATA lv_repo_log     TYPE REF TO zif_abapgit_log.
+    DATA lt_log_messages TYPE zif_abapgit_log=>tty_log_out.
+    FIELD-SYMBOLS <ls_message> TYPE zif_abapgit_log=>ty_log_out.
+
     CASE iv_action.
       WHEN c_action-commit_post.
 
@@ -479,7 +483,14 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
           io_repo   = mo_repo
           io_stage  = mo_stage ).
 
-        MESSAGE 'Commit was successful' TYPE 'S' ##NO_TEXT.
+        lv_repo_log = mo_repo->get_log( ).
+        lt_log_messages = lv_repo_log->get_messages( ).
+        READ TABLE lt_log_messages WITH KEY obj_type = 'SHA1' ASSIGNING <ls_message>.
+        IF sy-subrc = 0.
+          me->ms_success_log_entry = <ls_message>.
+        ELSE.
+          MESSAGE 'Commit was successful' TYPE 'S' ##NO_TEXT.
+        ENDIF.
 
         ev_state = zcl_abapgit_gui=>c_event_state-go_back_to_bookmark.
 

--- a/src/ui/zcl_abapgit_services_repo.clas.abap
+++ b/src/ui/zcl_abapgit_services_repo.clas.abap
@@ -122,7 +122,7 @@ CLASS ZCL_ABAPGIT_SERVICES_REPO IMPLEMENTATION.
 
 * and pass decisions to deserialize
     io_repo->deserialize( is_checks = ls_checks
-                          ii_log    = io_repo->create_new_log( 'Pull Log' ) ).
+                          ii_log    = io_repo->get_log( 'Pull Log' ) ).
 
   ENDMETHOD.
 

--- a/src/utils/zcl_abapgit_log.clas.abap
+++ b/src/utils/zcl_abapgit_log.clas.abap
@@ -69,8 +69,8 @@ CLASS zcl_abapgit_log IMPLEMENTATION.
       ls_repo_log-repo_key = iv_repo_key.
       CREATE OBJECT ls_repo_log-instance TYPE zcl_abapgit_log EXPORTING iv_title = iv_log_title.
       INSERT ls_repo_log INTO TABLE gt_repo_logs ASSIGNING <ls_repo_log>.
-    ELSEif iv_log_title IS SUPPLIED.
-        <ls_repo_log>-instance->set_title( iv_log_title ).
+    ELSEIF iv_log_title IS SUPPLIED.
+      <ls_repo_log>-instance->set_title( iv_log_title ).
     ENDIF.
 
     rv_result = <ls_repo_log>-instance.

--- a/src/utils/zcl_abapgit_log.clas.abap
+++ b/src/utils/zcl_abapgit_log.clas.abap
@@ -1,4 +1,4 @@
-CLASS zcl_abapgit_log DEFINITION
+CLASS zcl_ABAPGIT_LOG DEFINITION
   PUBLIC
   CREATE PROTECTED.
 
@@ -240,8 +240,9 @@ CLASS zcl_abapgit_log IMPLEMENTATION.
 
   METHOD zif_abapgit_log~get_status.
     DATA lt_msg TYPE zif_abapgit_log=>tty_msg.
+    FIELD-SYMBOLS <ls_log> TYPE zcl_abapgit_log=>ty_log.
 
-    LOOP AT me->mt_log ASSIGNING FIELD-SYMBOL(<ls_log>).
+    LOOP AT me->mt_log ASSIGNING <ls_log>.
       APPEND <ls_log>-msg TO lt_msg.
     ENDLOOP.
 

--- a/src/utils/zcl_abapgit_log.clas.abap
+++ b/src/utils/zcl_abapgit_log.clas.abap
@@ -1,4 +1,4 @@
-CLASS zcl_ABAPGIT_LOG DEFINITION
+CLASS zcl_abapgit_log DEFINITION
   PUBLIC
   CREATE PROTECTED.
 
@@ -34,7 +34,7 @@ CLASS zcl_ABAPGIT_LOG DEFINITION
 
     DATA mt_log TYPE STANDARD TABLE OF ty_log WITH DEFAULT KEY .
     DATA mv_title TYPE string .
-    CLASS-DATA mt_repo_logs TYPE ty_repo_log_instances.
+    CLASS-DATA gt_repo_logs TYPE ty_repo_log_instances.
     METHODS get_messages_status
       IMPORTING
         !it_msg          TYPE zif_abapgit_log=>tty_msg
@@ -61,14 +61,14 @@ CLASS zcl_abapgit_log IMPLEMENTATION.
 
   METHOD get_repo_log.
 
-    DATA: ls_repo_log TYPE zcl_abapgit_log=>ty_repo_log_instance.
-    FIELD-SYMBOLS: <ls_repo_log> TYPE zcl_abapgit_log=>ty_repo_log_instance.
+    DATA: ls_repo_log TYPE ty_repo_log_instance.
+    FIELD-SYMBOLS: <ls_repo_log> TYPE ty_repo_log_instance.
 
-    READ TABLE mt_repo_logs ASSIGNING <ls_repo_log> WITH KEY repo_key = iv_repo_key.
+    READ TABLE gt_repo_logs ASSIGNING <ls_repo_log> WITH KEY repo_key = iv_repo_key.
     IF sy-subrc <> 0.
       ls_repo_log-repo_key = iv_repo_key.
       CREATE OBJECT ls_repo_log-instance TYPE zcl_abapgit_log EXPORTING iv_title = iv_log_title.
-      INSERT ls_repo_log INTO TABLE mt_repo_logs ASSIGNING <ls_repo_log>.
+      INSERT ls_repo_log INTO TABLE gt_repo_logs ASSIGNING <ls_repo_log>.
     ELSE.
       IF iv_log_title IS SUPPLIED.
         rv_result->set_title( iv_log_title ).
@@ -240,7 +240,7 @@ CLASS zcl_abapgit_log IMPLEMENTATION.
 
   METHOD zif_abapgit_log~get_status.
     DATA lt_msg TYPE zif_abapgit_log=>tty_msg.
-    FIELD-SYMBOLS <ls_log> TYPE zcl_abapgit_log=>ty_log.
+    FIELD-SYMBOLS <ls_log> TYPE ty_log.
 
     LOOP AT me->mt_log ASSIGNING <ls_log>.
       APPEND <ls_log>-msg TO lt_msg.

--- a/src/utils/zcl_abapgit_log.clas.abap
+++ b/src/utils/zcl_abapgit_log.clas.abap
@@ -69,10 +69,8 @@ CLASS zcl_abapgit_log IMPLEMENTATION.
       ls_repo_log-repo_key = iv_repo_key.
       CREATE OBJECT ls_repo_log-instance TYPE zcl_abapgit_log EXPORTING iv_title = iv_log_title.
       INSERT ls_repo_log INTO TABLE gt_repo_logs ASSIGNING <ls_repo_log>.
-    ELSE.
-      IF iv_log_title IS SUPPLIED.
-        rv_result->set_title( iv_log_title ).
-      ENDIF.
+    ELSEif iv_log_title IS SUPPLIED.
+        <ls_repo_log>-instance->set_title( iv_log_title ).
     ENDIF.
 
     rv_result = <ls_repo_log>-instance.

--- a/src/zcl_abapgit_file_status.clas.testclasses.abap
+++ b/src/zcl_abapgit_file_status.clas.testclasses.abap
@@ -53,7 +53,7 @@ CLASS ltcl_run_checks IMPLEMENTATION.
 
   METHOD setup.
 
-    CREATE OBJECT mi_log TYPE zcl_abapgit_log.
+    mi_log = zcl_abapgit_log=>get_log( 'File State' ).
 
     mo_dot = zcl_abapgit_dot_abapgit=>build_default( ).
     mo_dot->set_starting_folder( '/' ).

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -128,6 +128,11 @@ CLASS zcl_abapgit_repo DEFINITION
     METHODS get_log
       RETURNING
         VALUE(ri_log) TYPE REF TO zif_abapgit_log .
+    METHODS get_or_create_log
+      IMPORTING
+        !iv_title     TYPE string OPTIONAL
+      RETURNING
+        VALUE(ri_log) TYPE REF TO zif_abapgit_log .
     METHODS reset_log .
     METHODS refresh_local_object
       IMPORTING
@@ -198,7 +203,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
+CLASS zcl_abapgit_repo IMPLEMENTATION.
 
 
   METHOD bind_listener.
@@ -497,6 +502,16 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
 
   METHOD get_log.
     ri_log = mi_log.
+  ENDMETHOD.
+
+
+  METHOD get_or_create_log.
+
+    ri_log = me->get_log( ).
+    IF ri_log IS NOT BOUND.
+      ri_log = me->create_new_log( iv_title ).
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -120,20 +120,11 @@ CLASS zcl_abapgit_repo DEFINITION
         !iv_offline TYPE abap_bool
       RAISING
         zcx_abapgit_exception .
-    METHODS create_new_log
-      IMPORTING
-        !iv_title     TYPE string OPTIONAL
-      RETURNING
-        VALUE(ri_log) TYPE REF TO zif_abapgit_log .
     METHODS get_log
-      RETURNING
-        VALUE(ri_log) TYPE REF TO zif_abapgit_log .
-    METHODS get_or_create_log
       IMPORTING
         !iv_title     TYPE string OPTIONAL
       RETURNING
         VALUE(ri_log) TYPE REF TO zif_abapgit_log .
-    METHODS reset_log .
     METHODS refresh_local_object
       IMPORTING
         !iv_obj_type TYPE tadir-object
@@ -246,16 +237,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
 
     ms_data = is_data.
     mv_request_remote_refresh = abap_true.
-
-  ENDMETHOD.
-
-
-  METHOD create_new_log.
-
-    CREATE OBJECT mi_log TYPE zcl_abapgit_log.
-    mi_log->set_title( iv_title ).
-
-    ri_log = mi_log.
 
   ENDMETHOD.
 
@@ -501,16 +482,16 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
 
 
   METHOD get_log.
-    ri_log = mi_log.
-  ENDMETHOD.
 
-
-  METHOD get_or_create_log.
-
-    ri_log = me->get_log( ).
-    IF ri_log IS NOT BOUND.
-      ri_log = me->create_new_log( iv_title ).
+    IF mi_log IS NOT BOUND.
+      mi_log = zcl_abapgit_log=>get_repo_log( me->get_key( ) ).
     ENDIF.
+
+    IF iv_title IS SUPPLIED.
+      mi_log->set_title( iv_title ).
+    ENDIF.
+
+    ri_log = mi_log.
 
   ENDMETHOD.
 
@@ -590,7 +571,7 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
     mv_request_local_refresh = abap_true.
     reset_remote( ).
 
-    CLEAR mi_log.
+    me->get_log( )->clear( ).
 
     IF iv_drop_cache = abap_true.
       CLEAR: mt_local.
@@ -638,11 +619,6 @@ CLASS zcl_abapgit_repo IMPLEMENTATION.
     mv_request_local_refresh = abap_true.
     get_files_local( ).
 
-  ENDMETHOD.
-
-
-  METHOD reset_log.
-    CLEAR mi_log.
   ENDMETHOD.
 
 

--- a/src/zcl_abapgit_repo.clas.testclasses.abap
+++ b/src/zcl_abapgit_repo.clas.testclasses.abap
@@ -56,7 +56,7 @@ CLASS ltcl_find_remote_dot_abapgit IMPLEMENTATION.
   METHOD given_any_repo.
 
     DATA: ls_data TYPE zif_abapgit_persistence=>ty_repo.
-break-POINT.
+
     ls_data-key = c_dummy_repo_key.
 
     " online/offline doesn't matter...

--- a/src/zcl_abapgit_repo.clas.testclasses.abap
+++ b/src/zcl_abapgit_repo.clas.testclasses.abap
@@ -56,7 +56,7 @@ CLASS ltcl_find_remote_dot_abapgit IMPLEMENTATION.
   METHOD given_any_repo.
 
     DATA: ls_data TYPE zif_abapgit_persistence=>ty_repo.
-
+break-POINT.
     ls_data-key = c_dummy_repo_key.
 
     " online/offline doesn't matter...

--- a/src/zcl_abapgit_repo_content_list.clas.abap
+++ b/src/zcl_abapgit_repo_content_list.clas.abap
@@ -192,7 +192,7 @@ CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
 
   METHOD constructor.
     mo_repo = io_repo.
-    mi_log = zcl_abapgit_log=>get_repo_log( io_repo->get_key( ) ).
+    mi_log = zcl_abapgit_log=>get_log( ).
   ENDMETHOD.
 
 

--- a/src/zcl_abapgit_repo_content_list.clas.abap
+++ b/src/zcl_abapgit_repo_content_list.clas.abap
@@ -49,7 +49,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
+CLASS zcl_abapgit_repo_content_list IMPLEMENTATION.
 
 
   METHOD build_folders.
@@ -192,7 +192,7 @@ CLASS ZCL_ABAPGIT_REPO_CONTENT_LIST IMPLEMENTATION.
 
   METHOD constructor.
     mo_repo = io_repo.
-    CREATE OBJECT mi_log TYPE zcl_abapgit_log.
+    mi_log = zcl_abapgit_log=>get_repo_log( io_repo->get_key( ) ).
   ENDMETHOD.
 
 

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -319,7 +319,7 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
 
     reset_status( ).
 
-    lv_repo_log = me->get_or_create_log( |Push| ).
+    lv_repo_log = me->get_log( |Push| ).
     ls_item-obj_name = ls_push-branch.
     ls_item-obj_type = 'SHA1'.
     lv_repo_log->add_success( iv_msg  = |Commit { ls_push-branch } pushed to { get_url( ) }|

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -284,7 +284,8 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
 
     DATA: ls_push     TYPE zcl_abapgit_git_porcelain=>ty_push_result,
           lv_text     TYPE string,
-          lv_repo_log TYPE REF TO zif_abapgit_log.
+          lv_repo_log TYPE REF TO zif_abapgit_log,
+          ls_item     TYPE zif_abapgit_definitions=>ty_item.
 
 
     IF ms_data-branch_name CP 'refs/tags*'.
@@ -319,10 +320,10 @@ CLASS zcl_abapgit_repo_online IMPLEMENTATION.
     reset_status( ).
 
     lv_repo_log = me->get_or_create_log( |Push| ).
-    DATA: ls_item TYPE zif_abapgit_definitions=>ty_item.
     ls_item-obj_name = ls_push-branch.
     ls_item-obj_type = 'SHA1'.
-    lv_repo_log->add_success( iv_msg = |Commit { ls_push-branch } pushed to { get_url( ) }| is_item = ls_item ).
+    lv_repo_log->add_success( iv_msg  = |Commit { ls_push-branch } pushed to { get_url( ) }|
+                              is_item = ls_item ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -41,13 +41,13 @@ CLASS zcl_abapgit_repo_online DEFINITION
         zcx_abapgit_exception .
 
     METHODS get_files_remote
-        REDEFINITION .
+         REDEFINITION .
     METHODS get_name
-        REDEFINITION .
+         REDEFINITION .
     METHODS has_remote_source
-        REDEFINITION .
+         REDEFINITION .
     METHODS rebuild_local_checksums
-        REDEFINITION .
+         REDEFINITION .
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -71,7 +71,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
+CLASS zcl_abapgit_repo_online IMPLEMENTATION.
 
 
   METHOD fetch_remote.
@@ -282,8 +282,9 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
 
 * assumption: PUSH is done on top of the currently selected branch
 
-    DATA: ls_push TYPE zcl_abapgit_git_porcelain=>ty_push_result,
-          lv_text TYPE string.
+    DATA: ls_push     TYPE zcl_abapgit_git_porcelain=>ty_push_result,
+          lv_text     TYPE string,
+          lv_repo_log TYPE REF TO zif_abapgit_log.
 
 
     IF ms_data-branch_name CP 'refs/tags*'.
@@ -316,6 +317,12 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
     update_local_checksums( ls_push-updated_files ).
 
     reset_status( ).
+
+    lv_repo_log = me->get_or_create_log( |Push| ).
+    DATA: ls_item TYPE zif_abapgit_definitions=>ty_item.
+    ls_item-obj_name = ls_push-branch.
+    ls_item-obj_type = 'SHA1'.
+    lv_repo_log->add_success( iv_msg = |Commit { ls_push-branch } pushed to { get_url( ) }| is_item = ls_item ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_abapgit_serialize.clas.testclasses.abap
+++ b/src/zcl_abapgit_serialize.clas.testclasses.abap
@@ -109,13 +109,14 @@ CLASS ltcl_serialize IMPLEMENTATION.
     <ls_tadir>-object   = 'ABCD'.
     <ls_tadir>-obj_name = 'OBJECT'.
 
-    CREATE OBJECT li_log1 TYPE zcl_abapgit_log.
+    li_log1 = zcl_abapgit_log=>get_log( 'LOG1' ).
+
     mo_cut->serialize(
       it_tadir            = lt_tadir
       ii_log              = li_log1
       iv_force_sequential = abap_true ).
 
-    CREATE OBJECT li_log2 TYPE zcl_abapgit_log.
+    li_log2  = zcl_abapgit_log=>get_log( 'LOG2' ).
     mo_cut->serialize(
       it_tadir            = lt_tadir
       ii_log              = li_log2

--- a/src/zcl_abapgit_zip.clas.abap
+++ b/src/zcl_abapgit_zip.clas.abap
@@ -70,7 +70,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_ZIP IMPLEMENTATION.
+CLASS zcl_abapgit_zip IMPLEMENTATION.
 
 
   METHOD encode_files.
@@ -101,7 +101,7 @@ CLASS ZCL_ABAPGIT_ZIP IMPLEMENTATION.
           lv_package TYPE devclass.
 
 
-    CREATE OBJECT li_log TYPE zcl_abapgit_log.
+    li_log = zcl_abapgit_log=>get_log( ).
 
     lv_package = io_repo->get_package( ).
 

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -518,6 +518,7 @@ INTERFACE zif_abapgit_definitions
       changed_by                    TYPE string VALUE 'changed_by',
       documentation                 TYPE string VALUE 'documentation',
       changelog                     TYPE string VALUE 'changelog',
+      goto_repo                     TYPE string VALUE 'goto_repo',
     END OF c_action.
   CONSTANTS c_tag_prefix TYPE string VALUE 'refs/tags/' ##NO_TEXT.
   CONSTANTS c_spagpa_param_repo_key TYPE c LENGTH 20 VALUE 'REPO_KEY' ##NO_TEXT.


### PR DESCRIPTION
fixes #3560 

The commit hash is shown in a message box. Link to the commit is prepared but not yet implemented
![image](https://user-images.githubusercontent.com/4643389/87883964-489e3400-ca0b-11ea-9370-39d3020811a5.png)