### PR TITLE
Fix status calculation

### DIFF
--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -482,7 +482,12 @@ CLASS ZCL_ABAPGIT_REPO IMPLEMENTATION.
     FIELD-SYMBOLS <ls_object> LIKE LINE OF ms_data-local_checksums.
 
     LOOP AT ms_data-local_checksums ASSIGNING <ls_object>.
-      APPEND LINES OF <ls_object>-files TO rt_checksums.
+      " Check if item exists
+      READ TABLE mt_local TRANSPORTING NO FIELDS
+        WITH KEY item = <ls_object>-item.
+      IF sy-subrc = 0.
+        APPEND LINES OF <ls_object>-files TO rt_checksums.
+      ENDIF.
     ENDLOOP.
 
   ENDMETHOD.


### PR DESCRIPTION
Return checksum only if local item exists

During investigation of "Reset package name" https://github.com/larshp/abapGit/issues/2264, I found that the status calculation doesn't work correctly if 
- object existed before, was deleted, and then should be recreated (via pull or reset local for example)
- object existed in another branch but not in the current branch
- object had been deleted in another session

Root cause was that the local checksum still existed which made the status calculation incorrectly 'believe' the object was still there (due to the same checksum as remote). 

I created a new test case https://github.com/abapGit-tests/DEVC_main_sub with two branches. Master contains MAIN and 1 sub-package. Branch "feature" contains 2 sub-packages. 

This PR not only fixes #2264 but potentially several other open issues related to checksums and switching branches:

Branch created with no changes identified
https://github.com/larshp/abapGit/issues/3258

REFRESH_LOCAL_CHECKSUMS regression?
https://github.com/larshp/abapGit/issues/2086

Branching can cause changes to be flipped
https://github.com/larshp/abapGit/issues/2869

@christianguenter2, @7qiang, @sbcgua, @flaiker, @FreHu  please test. 