### PR TITLE
Fix: Open repo in master lang opens repo

### DIFF
--- a/src/ui/zcl_abapgit_gui_router.clas.abap
+++ b/src/ui/zcl_abapgit_gui_router.clas.abap
@@ -244,9 +244,7 @@ CLASS ZCL_ABAPGIT_GUI_ROUTER IMPLEMENTATION.
         " General PAGE routing
       WHEN zcl_abapgit_gui=>c_action-go_home.
 
-        IF zcl_abapgit_persist_settings=>get_instance( )->read( )->get_show_default_repo( ) = abap_true.
-          lv_last_repo_key = zcl_abapgit_persistence_user=>get_instance( )->get_repo_show( ).
-        ENDIF.
+        lv_last_repo_key = zcl_abapgit_persistence_user=>get_instance( )->get_repo_show( ).
 
         IF lv_last_repo_key IS INITIAL.
           CREATE OBJECT ei_page TYPE zcl_abapgit_gui_page_main.


### PR DESCRIPTION
fixes #3702 

After this fix is applied the menu "advanced > open in master language" opens the repo directly and doesn't navigate to the repo list anymore.

The show_default_repo setting is already properly handled here, so that shouldn't be a problem.
https://github.com/larshp/abapGit/blob/59e36c47bde5233b3342dad057f24838b53dfa8a/src/ui/zcl_abapgit_services_abapgit.clas.abap#L289-L292
