### PR TITLE
Fix dump in Code Insp. Display for exception class

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_codi_base.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_codi_base.clas.abap
@@ -224,8 +224,21 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_CODI_BASE IMPLEMENTATION.
             WHEN seop_incextapp_testclasses.
               lv_obj_txt = |{ is_result-objname } : Test Classes|.
             WHEN OTHERS.
-              ls_mtdkey = cl_oo_classname_service=>get_method_by_include( is_result-sobjname ).
-              lv_obj_txt = |{ ls_mtdkey-clsname }->{ ls_mtdkey-cpdname }|.
+              cl_oo_classname_service=>get_method_by_include(
+                EXPORTING
+                  incname             = is_result-sobjname
+                RECEIVING
+                  mtdkey              = ls_mtdkey
+                EXCEPTIONS
+                  class_not_existing  = 1
+                  method_not_existing = 2
+                  OTHERS              = 3 ).
+              IF sy-subrc = 0.
+                lv_obj_txt = |{ ls_mtdkey-clsname }->{ ls_mtdkey-cpdname }|.
+              ELSE.
+                lv_obj_txt = is_result-sobjname.
+              ENDIF.
+
           ENDCASE.
         CATCH cx_root.
           lv_obj_txt = ''. "use default below


### PR DESCRIPTION
Fixes this dump for exception classes in code inspector display
![image](https://user-images.githubusercontent.com/17437789/89793743-841db100-db26-11ea-9a64-0c9a3d6d9300.png)

![image](https://user-images.githubusercontent.com/17437789/89793750-85e77480-db26-11ea-834d-eb4222bf868a.png)

![image](https://user-images.githubusercontent.com/17437789/89793759-8718a180-db26-11ea-9cce-97d78514f654.png)

