### PR TITLE
PROG,FUGR,ENHO: Remove workaround for leading spaces

### DIFF
--- a/src/objects/zcl_abapgit_object_enho_hook.clas.abap
+++ b/src/objects/zcl_abapgit_object_enho_hook.clas.abap
@@ -23,11 +23,6 @@ CLASS zcl_abapgit_object_enho_hook DEFINITION PUBLIC.
       CHANGING  ct_impl   TYPE enh_hook_impl_it
       RAISING   zcx_abapgit_exception.
 
-    METHODS hook_impl_serialize
-      EXPORTING et_spaces TYPE ty_spaces_tt
-      CHANGING  ct_impl   TYPE enh_hook_impl_it
-      RAISING   zcx_abapgit_exception.
-
 ENDCLASS.
 
 CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
@@ -67,10 +62,6 @@ CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
              <ls_enhancement>-id.
     ENDLOOP.
 
-    hook_impl_serialize(
-      IMPORTING et_spaces = lt_spaces
-      CHANGING ct_impl = lt_enhancements ).
-
     io_xml->add( iv_name = 'TOOL'
                  ig_data = ii_enh_tool->get_tool( ) ).
     io_xml->add( ig_data = lv_shorttext
@@ -82,29 +73,6 @@ CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
     io_xml->add( iv_name = 'SPACES'
                  ig_data = lt_spaces ).
 
-  ENDMETHOD.
-
-  METHOD hook_impl_serialize.
-* handle normalization of XML values
-* i.e. remove leading spaces
-
-    FIELD-SYMBOLS: <ls_impl>  LIKE LINE OF ct_impl,
-                   <ls_space> LIKE LINE OF et_spaces,
-                   <lv_space> TYPE i,
-                   <lv_line>  TYPE string.
-
-
-    LOOP AT ct_impl ASSIGNING <ls_impl>.
-      APPEND INITIAL LINE TO et_spaces ASSIGNING <ls_space>.
-      <ls_space>-full_name = <ls_impl>-full_name.
-      LOOP AT <ls_impl>-source ASSIGNING <lv_line>.
-        APPEND INITIAL LINE TO <ls_space>-spaces ASSIGNING <lv_space>.
-        WHILE strlen( <lv_line> ) >= 1 AND <lv_line>(1) = ` `.
-          <lv_line> = <lv_line>+1.
-          <lv_space> = <lv_space> + 1.
-        ENDWHILE.
-      ENDLOOP.
-    ENDLOOP.
   ENDMETHOD.
 
   METHOD hook_impl_deserialize.
@@ -155,6 +123,7 @@ CLASS zcl_abapgit_object_enho_hook IMPLEMENTATION.
     io_xml->read( EXPORTING iv_name = 'SPACES'
                   CHANGING cg_data  = lt_spaces ).
 
+    " todo: kept for compatibility, remove after grace period #3680
     hook_impl_deserialize( EXPORTING it_spaces = lt_spaces
                            CHANGING ct_impl    = lt_enhancements ).
 

--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -149,9 +149,6 @@ CLASS zcl_abapgit_objects_program DEFINITION PUBLIC INHERITING FROM zcl_abapgit_
         VALUE(rt_tpool) TYPE zif_abapgit_definitions=>ty_tpool_tt .
   PRIVATE SECTION.
     METHODS:
-      condense_flow
-        EXPORTING et_spaces TYPE ty_spaces_tt
-        CHANGING  ct_flow   TYPE swydyflow,
       uncondense_flow
         IMPORTING it_flow        TYPE swydyflow
                   it_spaces      TYPE ty_spaces_tt
@@ -224,29 +221,6 @@ CLASS ZCL_ABAPGIT_OBJECTS_PROGRAM IMPLEMENTATION.
       IF <ls_pfk>-code+6(14) IS INITIAL AND <ls_pfk>-code(6) CO lc_num_only.
         cs_adm-pfkcode = <ls_pfk>-code.
       ENDIF.
-    ENDLOOP.
-
-  ENDMETHOD.
-
-
-  METHOD condense_flow.
-
-    DATA: lv_spaces LIKE LINE OF et_spaces.
-
-    FIELD-SYMBOLS: <ls_flow> LIKE LINE OF ct_flow.
-
-
-    CLEAR et_spaces.
-
-    LOOP AT ct_flow ASSIGNING <ls_flow>.
-      lv_spaces = 0.
-
-      WHILE NOT <ls_flow>-line IS INITIAL AND <ls_flow>-line(1) = space.
-        lv_spaces = lv_spaces + 1.
-        <ls_flow>-line = <ls_flow>-line+1.
-      ENDWHILE.
-
-      APPEND lv_spaces TO et_spaces.
     ENDLOOP.
 
   ENDMETHOD.
@@ -338,6 +312,7 @@ CLASS ZCL_ABAPGIT_OBJECTS_PROGRAM IMPLEMENTATION.
 * the program to dump since it_dynpros cannot be changed
     LOOP AT it_dynpros INTO ls_dynpro.
 
+      " todo: kept for compatibility, remove after grace period #3680
       ls_dynpro-flow_logic = uncondense_flow(
         it_flow = ls_dynpro-flow_logic
         it_spaces = ls_dynpro-spaces ).
@@ -883,8 +858,6 @@ CLASS ZCL_ABAPGIT_OBJECTS_PROGRAM IMPLEMENTATION.
       <ls_dynpro>-containers = lt_containers.
       <ls_dynpro>-fields     = lt_fields_to_containers.
 
-      condense_flow( IMPORTING et_spaces = <ls_dynpro>-spaces
-                     CHANGING ct_flow = lt_flow_logic ).
       <ls_dynpro>-flow_logic = lt_flow_logic.
 
     ENDLOOP.


### PR DESCRIPTION
Closes https://github.com/larshp/abapGit/issues/3680

Change is compatible with repos that contain the workaround:
- Deserialize will continue to respect <SPACES> section 
- Serialize will not contain the <SPACES> section anymore

Suggested grace period until complete removal of workaround: 6 months

PS: Test repos will be updated after merge of this PR