### PR TITLE
Hide "Action" column when toggling "Details"

### DIFF
--- a/src/ui/zabapgit_js_common.w3mi.data.js
+++ b/src/ui/zabapgit_js_common.w3mi.data.js
@@ -232,6 +232,7 @@ function RepoOverViewHelper() {
   this.isDetailsDisplayed = false;
   this.isOnlyFavoritesDisplayed = false;
   this.detailCssClass = findStyleSheetByName(".ro-detail");
+  this.actionCssClass = findStyleSheetByName(".ro-action");
   var icon = document.getElementById("icon-filter-detail");
   this.toggleFilterIcon(icon, this.isDetailsDisplayed);
   icon = document.getElementById("icon-filter-favorite");
@@ -249,6 +250,7 @@ RepoOverViewHelper.prototype.toggleItemsDetail = function(forceDisplay){
   if (this.detailCssClass) {
     this.isDetailsDisplayed = forceDisplay || !this.isDetailsDisplayed;
     this.detailCssClass.style.display = this.isDetailsDisplayed ? "" : "none";
+    this.actionCssClass.style.display = this.isDetailsDisplayed ? "none" : "";
     var icon = document.getElementById("icon-filter-detail");
     this.toggleFilterIcon(icon, this.isDetailsDisplayed);
   }


### PR DESCRIPTION
Turning on "Details" in Repo Overview will now hide the "Action" column to improve display on smaller screens.