### PR TITLE
DTEL and TABL EXISTS() performance

### DIFF
--- a/src/objects/zcl_abapgit_object_dtel.clas.abap
+++ b/src/objects/zcl_abapgit_object_dtel.clas.abap
@@ -218,11 +218,13 @@ CLASS ZCL_ABAPGIT_OBJECT_DTEL IMPLEMENTATION.
 
     DATA: lv_rollname TYPE dd04l-rollname.
 
-
-    SELECT SINGLE rollname FROM dd04l INTO lv_rollname
-      WHERE rollname = ms_item-obj_name
-      AND as4local = 'A'
-      AND as4vers = '0000'.
+    lv_rollname = ms_item-obj_name.
+    CALL FUNCTION 'DD_GET_NAMETAB_HEADER'
+      EXPORTING
+        tabname   = lv_rollname
+      EXCEPTIONS
+        not_found = 1
+        OTHERS    = 2.
     rv_bool = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.

--- a/src/objects/zcl_abapgit_object_tabl.clas.abap
+++ b/src/objects/zcl_abapgit_object_tabl.clas.abap
@@ -769,10 +769,13 @@ CLASS ZCL_ABAPGIT_OBJECT_TABL IMPLEMENTATION.
 
     DATA: lv_tabname TYPE dd02l-tabname.
 
-    SELECT SINGLE tabname FROM dd02l INTO lv_tabname
-      WHERE tabname = ms_item-obj_name
-      AND as4local = 'A'
-      AND as4vers = '0000'.
+    lv_tabname = ms_item-obj_name.
+    CALL FUNCTION 'DD_GET_NAMETAB_HEADER'
+      EXPORTING
+        tabname   = lv_tabname
+      EXCEPTIONS
+        not_found = 1
+        OTHERS    = 2.
     rv_bool = boolc( sy-subrc = 0 ).
 
   ENDMETHOD.


### PR DESCRIPTION
This changest the existence checks of DTEL and TABL to lookup in the nametab, this is faster than the non-buffered database accesses, under the assumption that the objects can fit into the ntab buffer(see transaction `ST02`). As the objects are undergoing development I think its okay to assume that the system settings can fit the objects into the buffer, as the developer will also run the programs triggering the buffering anyhow

Test with:
```abap
DATA(lt_results) = zcl_abapgit_factory=>get_tadir( )->read( 'YOUR_FAVORITE_PACKAGE' ).
WRITE lines( lt_results ).
```

In my example with a 200k object package, performance went from ~67sek to ~47sek, performance may vary depending on how the object type distribution is and machines/databases.