### PR TITLE
Exclude test class with XML from line length check

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -208,7 +208,7 @@
       "ignoreFunctionModuleName": false
     },
     "line_length": {
-      "length": 121,
+      "length": 120,
       "exclude": ["zcl_abapgit_object_pdts.clas.testclasses.abap"]
     },
     "line_only_punc": {

--- a/abaplint.json
+++ b/abaplint.json
@@ -209,6 +209,7 @@
     },
     "line_length": {
       "length": 120
+      "exclude": ["zcl_abapgit_object_pdts.clas.testclasses.abap"]
     },
     "line_only_punc": {
       "ignoreExceptions": true

--- a/abaplint.json
+++ b/abaplint.json
@@ -208,7 +208,7 @@
       "ignoreFunctionModuleName": false
     },
     "line_length": {
-      "length": 120,
+      "length": 121,
       "exclude": ["zcl_abapgit_object_pdts.clas.testclasses.abap"]
     },
     "line_only_punc": {

--- a/abaplint.json
+++ b/abaplint.json
@@ -208,7 +208,7 @@
       "ignoreFunctionModuleName": false
     },
     "line_length": {
-      "length": 120
+      "length": 120,
       "exclude": ["zcl_abapgit_object_pdts.clas.testclasses.abap"]
     },
     "line_only_punc": {


### PR DESCRIPTION
We could also exclude all zcl_abapgit_object*testclasses or even test classes in general.
#3752 