### PR TITLE
abapGit Emergency Mode

### DIFF
--- a/src/ui/core/zcl_abapgit_gui.clas.abap
+++ b/src/ui/core/zcl_abapgit_gui.clas.abap
@@ -18,6 +18,7 @@ CLASS zcl_abapgit_gui DEFINITION
     CONSTANTS:
       BEGIN OF c_action,
         go_home TYPE string VALUE 'go_home',
+        go_db   TYPE string VALUE 'go_db',
       END OF c_action.
 
     INTERFACES zif_abapgit_gui_services.
@@ -214,12 +215,20 @@ CLASS ZCL_ABAPGIT_GUI IMPLEMENTATION.
 
   METHOD go_home.
 
-    DATA ls_stack LIKE LINE OF mt_stack.
+    DATA: ls_stack LIKE LINE OF mt_stack,
+          lv_mode  TYPE tabname.
 
     IF mi_router IS BOUND.
       CLEAR: mt_stack, mt_event_handlers.
       APPEND mi_router TO mt_event_handlers.
-      on_event( action = |{ c_action-go_home }| ). " doesn't accept strings directly
+      " on_event doesn't accept strings directly
+      GET PARAMETER ID 'DBT' FIELD lv_mode.
+      CASE lv_mode.
+        WHEN 'ZABAPGIT'.
+          on_event( action = |{ c_action-go_db }| ).
+        WHEN OTHERS.
+          on_event( action = |{ c_action-go_home }| ).
+      ENDCASE.
     ELSE.
       IF lines( mt_stack ) > 0.
         READ TABLE mt_stack INTO ls_stack INDEX 1.


### PR DESCRIPTION
On rare occasions, it is necessary to edit the abapGit settings to overcome an issue (example: https://github.com/larshp/abapGit/issues/3701). 

This enhancement allows you to start abapGit in "emergency mode", which directly shows the "Database Utility" for you to view or edit any setting. 

How to start abapGit in "Emergency Mode":

1. Go to transaction SU3 to maintain your user profile
2. Maintain parameter DBT with value "ZABAPGIT" (all-caps).
3. Start abapGit
4. After exiting abapGit, go back to SU3 and remove parameter DBT