### PR TITLE
Use title case for page titles

### DIFF
--- a/src/ui/db/zcl_abapgit_gui_page_db.clas.abap
+++ b/src/ui/db/zcl_abapgit_gui_page_db.clas.abap
@@ -43,7 +43,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DB IMPLEMENTATION.
 
   METHOD constructor.
     super->constructor( ).
-    ms_control-page_title = 'DATABASE PERSISTENCY'.
+    ms_control-page_title = 'Database Persistency'.
   ENDMETHOD.
 
 

--- a/src/ui/db/zcl_abapgit_gui_page_db_dis.clas.abap
+++ b/src/ui/db/zcl_abapgit_gui_page_db_dis.clas.abap
@@ -29,7 +29,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DB_DIS IMPLEMENTATION.
   METHOD constructor.
     super->constructor( ).
     ms_key = is_key.
-    ms_control-page_title = 'CONFIG DISPLAY'.
+    ms_control-page_title = 'Config display'.
   ENDMETHOD.
 
 

--- a/src/ui/db/zcl_abapgit_gui_page_db_edit.clas.abap
+++ b/src/ui/db/zcl_abapgit_gui_page_db_edit.clas.abap
@@ -46,7 +46,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DB_EDIT IMPLEMENTATION.
   METHOD constructor.
     super->constructor( ).
     ms_key = is_key.
-    ms_control-page_title = 'CONFIG EDIT'.
+    ms_control-page_title = 'Config Edit'.
   ENDMETHOD.
 
 

--- a/src/ui/zcl_abapgit_gui_buttons.clas.abap
+++ b/src/ui/zcl_abapgit_gui_buttons.clas.abap
@@ -44,7 +44,7 @@ CLASS zcl_abapgit_gui_buttons IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD repo_list.
-    rv_html_string = `<i class="icon icon-bars"></i> Repository list`.
+    rv_html_string = `<i class="icon icon-bars"></i> Repository List`.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_page_bkg.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_bkg.clas.abap
@@ -78,7 +78,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_BKG IMPLEMENTATION.
     super->constructor( ).
 
     mv_key = iv_key.
-    ms_control-page_title = 'BACKGROUND'.
+    ms_control-page_title = 'Backround'.
     ms_control-page_menu  = build_menu( ).
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_bkg_run.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_bkg_run.clas.abap
@@ -28,7 +28,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_BKG_RUN IMPLEMENTATION.
 
   METHOD constructor.
     super->constructor( ).
-    ms_control-page_title = 'BACKGROUND_RUN'.
+    ms_control-page_title = 'Backgorund Run'.
   ENDMETHOD.
 
 

--- a/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
@@ -219,7 +219,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_BOVERVIEW IMPLEMENTATION.
 
   METHOD constructor.
     super->constructor( ).
-    ms_control-page_title = 'BRANCH_OVERVIEW'.
+    ms_control-page_title = 'Branch Overview'.
     mo_repo = io_repo.
     refresh( ).
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_commit.clas.abap
@@ -91,7 +91,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
     mo_repo   = io_repo.
     mo_stage  = io_stage.
 
-    ms_control-page_title = 'COMMIT'.
+    ms_control-page_title = 'Commit'.
   ENDMETHOD.
 
 

--- a/src/ui/zcl_abapgit_gui_page_debuginfo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_debuginfo.clas.abap
@@ -37,7 +37,7 @@ CLASS zcl_abapgit_gui_page_debuginfo IMPLEMENTATION.
 
   METHOD constructor.
     super->constructor( ).
-    ms_control-page_title = 'DEBUG INFO'.
+    ms_control-page_title = 'Debug Info'.
   ENDMETHOD.
 
 

--- a/src/ui/zcl_abapgit_gui_page_diff.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_diff.clas.abap
@@ -459,7 +459,7 @@ CLASS zcl_abapgit_gui_page_diff IMPLEMENTATION.
     DATA: lv_ts TYPE timestamp.
 
     super->constructor( ).
-    ms_control-page_title = 'DIFF'.
+    ms_control-page_title = 'Diff'.
     mv_unified            = zcl_abapgit_persistence_user=>get_instance( )->get_diff_unified( ).
     mv_repo_key           = iv_key.
     mo_repo              ?= zcl_abapgit_repo_srv=>get_instance( )->get( iv_key ).

--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -66,7 +66,7 @@ CLASS zcl_abapgit_gui_page_main IMPLEMENTATION.
   METHOD constructor.
     super->constructor( ).
     ms_control-page_menu  = build_main_menu( ).
-    ms_control-page_title = 'REPOSITORY LIST'.
+    ms_control-page_title = 'Repository List'.
   ENDMETHOD.
 
 

--- a/src/ui/zcl_abapgit_gui_page_merge.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_merge.clas.abap
@@ -77,7 +77,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MERGE IMPLEMENTATION.
         iv_source_branch = iv_source.
     mo_merge->run( ).
 
-    ms_control-page_title = 'MERGE'.
+    ms_control-page_title = 'Merge'.
     ms_control-page_menu  = build_menu( mo_merge->has_conflicts( ) ).
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_patch.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_patch.clas.abap
@@ -398,6 +398,7 @@ CLASS zcl_abapgit_gui_page_patch IMPLEMENTATION.
     CLEAR: mv_unified.
     CREATE OBJECT mo_stage.
 
+    ms_control-page_title = 'Patch'.
     ms_control-page_menu = build_menu( ).
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
@@ -70,7 +70,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_repo_sett IMPLEMENTATION.
 
 
   METHOD constructor.

--- a/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
@@ -75,7 +75,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
 
   METHOD constructor.
     super->constructor( ).
-    ms_control-page_title = 'REPO SETTINGS'.
+    ms_control-page_title = 'Repository settings'.
     mo_repo = io_repo.
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_settings.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_settings.clas.abap
@@ -109,7 +109,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETTINGS IMPLEMENTATION.
 
   METHOD constructor.
     super->constructor( ).
-    ms_control-page_title = 'SETTINGS'.
+    ms_control-page_title = 'Settings'.
   ENDMETHOD.
 
 

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -134,7 +134,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
     super->constructor( ).
 
-    ms_control-page_title = 'STAGE'.
+    ms_control-page_title = 'Stage'.
     mo_repo               = io_repo.
     ms_files              = zcl_abapgit_factory=>get_stage_logic( )->get( mo_repo ).
     mv_seed               = iv_seed.

--- a/src/ui/zcl_abapgit_gui_page_syntax.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_syntax.clas.abap
@@ -48,7 +48,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SYNTAX IMPLEMENTATION.
 
   METHOD constructor.
     super->constructor( ).
-    ms_control-page_title = 'SYNTAX CHECK'.
+    ms_control-page_title = 'Syntax Check'.
     mo_repo = io_repo.
     run_syntax_check( ).
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_tag.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_tag.clas.abap
@@ -73,7 +73,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_TAG IMPLEMENTATION.
 
     mo_repo_online ?= io_repo.
 
-    ms_control-page_title = 'TAG'.
+    ms_control-page_title = 'Tag'.
     mv_selected_type = c_tag_type-lightweight.
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_view_repo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_view_repo.clas.abap
@@ -515,7 +515,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_VIEW_REPO IMPLEMENTATION.
     mv_show_order_by = zcl_abapgit_persistence_user=>get_instance( )->get_show_order_by( ).
     mv_diff_first    = abap_true.
 
-    ms_control-page_title = 'REPOSITORY'.
+    ms_control-page_title = 'Repository'.
     ms_control-page_menu = build_main_menu( ).
 
     " Read global settings to get max # of objects to be listed

--- a/src/ui/zcl_abapgit_gui_repo_over.clas.abap
+++ b/src/ui/zcl_abapgit_gui_repo_over.clas.abap
@@ -388,7 +388,7 @@ CLASS zcl_abapgit_gui_repo_over IMPLEMENTATION.
         iv_act = |{ zif_abapgit_definitions=>c_action-go_patch }?{ <ls_overview>-key } | ).
 
       lv_code_inspector_link = ii_html->a(
-        iv_txt = |Code inspector|
+        iv_txt = |Check|
         iv_act = |{ zif_abapgit_definitions=>c_action-repo_code_inspector }?{ <ls_overview>-key } | ).
 
       lv_repo_settings_link = ii_html->a(


### PR DESCRIPTION
Other minor changes:

- patch page is no longer called diff
- "code inspector" in main page action menu renamed to "check"
