### PR TITLE
Allow naming of different test class types

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -215,9 +215,9 @@
       "ignoreExceptions": true
     },
     "local_class_naming": {
-      "exception": "^LCL_.*$",
+      "exception": "^LCX_.*$",
       "local": "^LCL_.*$",
-      "test": "^LTCL_.*$"
+      "test": "^LT(C|D|H|S|CL)_.*$"
     },
     "local_testclass_location": true,
     "local_variable_names": {

--- a/abaplint.json
+++ b/abaplint.json
@@ -217,7 +217,7 @@
     "local_class_naming": {
       "exception": "^LCX_.*$",
       "local": "^LCL_.*$",
-      "test": "^LT(C|D|H|S|CL)_.*$"
+      "test": "^LT.+$"
     },
     "local_testclass_location": true,
     "local_variable_names": {


### PR DESCRIPTION
Propose to use the more commonly used naming conventions for test classes rather than naming everything ltcl_. These are used by SAP and also referenced in the style guides e.g. the section on [Helper Methods](https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#put-help-methods-in-help-classes) and used in the ABAP unit testing book.

ltc_: test class
lth_: test helper
ltd_: test double
lts_: test suite

Oh, and also corrected bug in exception class name that I spotted when editing