### PR TITLE
Handle "invalid committer" error

### DIFF
--- a/src/git/zcl_abapgit_git_transport.clas.abap
+++ b/src/git/zcl_abapgit_git_transport.clas.abap
@@ -82,7 +82,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GIT_TRANSPORT IMPLEMENTATION.
+CLASS zcl_abapgit_git_transport IMPLEMENTATION.
 
 
   METHOD branches.
@@ -247,6 +247,8 @@ CLASS ZCL_ABAPGIT_GIT_TRANSPORT IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'branch delete not allowed' ).
     ELSEIF lv_string CP '*cannot lock ref*reference already exists*'.
       zcx_abapgit_exception=>raise( 'branch already exists' ).
+    ELSEIF lv_string CP '*invalid committer*'.
+      zcx_abapgit_exception=>raise( 'invalid committer' ).
     ENDIF.
 
   ENDMETHOD.


### PR DESCRIPTION
This error is produced when committer email is not allowed for logged in user. Encountered it with an SCP git repo.
Failing to catch this error leads to an erroneous "Commit was successful" message.