### PR TITLE
WDCC, fix syntax error in compiled report

### DIFF
--- a/src/objects/zcl_abapgit_object_wdcc.clas.abap
+++ b/src/objects/zcl_abapgit_object_wdcc.clas.abap
@@ -1,6 +1,5 @@
-CLASS zcl_abapgit_object_wdcc DEFINITION
-  INHERITING FROM zcl_abapgit_objects_super
-  PUBLIC.
+CLASS zcl_abapgit_object_wdcc DEFINITION PUBLIC
+  INHERITING FROM zcl_abapgit_objects_super.
 
   PUBLIC SECTION.
     INTERFACES zif_abapgit_object.


### PR DESCRIPTION
the PUBLIC keyword was placed in such a way it was not recognized by abapmerge, this should fix the compiled report

follow up tasks
https://github.com/larshp/abapmerge/issues/130
https://github.com/abaplint/abaplint/issues/1215
created