### PR TITLE
background pull: always overwrite all objects

### DIFF
--- a/src/background/zcl_abapgit_background_pull.clas.abap
+++ b/src/background/zcl_abapgit_background_pull.clas.abap
@@ -30,8 +30,15 @@ CLASS ZCL_ABAPGIT_BACKGROUND_PULL IMPLEMENTATION.
 
     DATA: ls_checks TYPE zif_abapgit_definitions=>ty_deserialize_checks.
 
+    FIELD-SYMBOLS: <ls_overwrite> LIKE LINE OF ls_checks-overwrite.
 
-* todo, set defaults in ls_checks
+
+    ls_checks = io_repo->deserialize_checks( ).
+
+    LOOP AT ls_checks-overwrite ASSIGNING <ls_overwrite>.
+      <ls_overwrite>-decision = zif_abapgit_definitions=>gc_yes.
+    ENDLOOP.
+
     io_repo->deserialize( is_checks = ls_checks
                           ii_log    = ii_log ).
 

--- a/src/ui/zcl_abapgit_gui_page_bkg.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_bkg.clas.abap
@@ -78,7 +78,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_BKG IMPLEMENTATION.
     super->constructor( ).
 
     mv_key = iv_key.
-    ms_control-page_title = 'Backround'.
+    ms_control-page_title = 'Background'.
     ms_control-page_menu  = build_menu( ).
 
   ENDMETHOD.


### PR DESCRIPTION
always choose to overwrite all objects when using the pull in background feature. If the decision is not set the job will fail with a "undecided" error

#3800