### PR TITLE
fix ci for autotag (fetch depth 2) #3808

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
this should probably fix #3808. On next version

Explanation: `git diff-tree` does not see the difference because there is just one commit in hitory depth