### PR TITLE
objects: remove superfluous RSTAT from some class XMLs

### DIFF
--- a/src/objects/zcl_abapgit_object_scvi.clas.xml
+++ b/src/objects/zcl_abapgit_object_scvi.clas.xml
@@ -10,7 +10,6 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
-    <RSTAT>K</RSTAT>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>

--- a/src/objects/zcl_abapgit_object_stvi.clas.xml
+++ b/src/objects/zcl_abapgit_object_stvi.clas.xml
@@ -10,7 +10,6 @@
     <CLSCCINCL>X</CLSCCINCL>
     <FIXPT>X</FIXPT>
     <UNICODE>X</UNICODE>
-    <RSTAT>K</RSTAT>
    </VSEOCLASS>
   </asx:values>
  </asx:abap>


### PR DESCRIPTION
The removed fields have no real use as no other CLAS object contains
that field.

It was added in the commit:
https://github.com/larshp/abapGit/commit/b0d54f97e3a8fcf015f196d95af8d323e8b80610

Besides, it causes me troubles in sapcli when I do checkin.