### PR TITLE
filename encoding of < and >

### DIFF
--- a/src/objects/zcl_abapgit_objects_files.clas.abap
+++ b/src/objects/zcl_abapgit_objects_files.clas.abap
@@ -239,6 +239,8 @@ CLASS ZCL_ABAPGIT_OBJECTS_FILES IMPLEMENTATION.
       REPLACE ALL OCCURRENCES OF `.` IN lv_obj_name WITH '%2e'.
       REPLACE ALL OCCURRENCES OF `=` IN lv_obj_name WITH '%3d'.
       REPLACE ALL OCCURRENCES OF `?` IN lv_obj_name WITH '%3f'.
+      REPLACE ALL OCCURRENCES OF `<` IN lv_obj_name WITH '%3c'.
+      REPLACE ALL OCCURRENCES OF `>` IN lv_obj_name WITH '%3e'.
     ENDIF.
 
     IF iv_extra IS INITIAL.


### PR DESCRIPTION
Windows cannot store filenames containing "<" and ">"

These two characters are now uri encoded, same approach as already deployed for some characters

#3817