### PR TITLE
Fix startup of repo view

### DIFF
--- a/src/git/zcl_abapgit_git_branch_list.clas.abap
+++ b/src/git/zcl_abapgit_git_branch_list.clas.abap
@@ -127,7 +127,8 @@ CLASS ZCL_ABAPGIT_GIT_BRANCH_LIST IMPLEMENTATION.
       READ TABLE mt_branches INTO rs_branch
         WITH KEY name = iv_branch_name.
       IF sy-subrc <> 0.
-        zcx_abapgit_exception=>raise( |Branch not found: { get_display_name( iv_branch_name ) }| ).
+        zcx_abapgit_exception=>raise( |Branch { get_display_name( iv_branch_name )
+          } not found. Use 'Branch' > 'Switch' to select a different branch| ).
       ENDIF.
 
     ENDIF.

--- a/src/http/zcl_abapgit_http.clas.abap
+++ b/src/http/zcl_abapgit_http.clas.abap
@@ -70,7 +70,7 @@ CLASS ZCL_ABAPGIT_HTTP IMPLEMENTATION.
         cv_pass         = lv_pass ).
 
     IF lv_user IS INITIAL.
-      zcx_abapgit_exception=>raise( 'HTTP 401, unauthorized' ).
+      zcx_abapgit_exception=>raise( 'Unauthorized access. Check your credentials' ).
     ENDIF.
 
     IF lv_user <> lv_default_user.

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -669,6 +669,7 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
 
     DATA: lo_repo_online       TYPE REF TO zcl_abapgit_repo_online,
           lo_pback             TYPE REF TO zcl_abapgit_persist_background,
+          lx_error             TYPE REF TO zcx_abapgit_exception,
           lv_hint              TYPE string,
           lv_icon              TYPE string,
           lv_package_jump_data TYPE string.
@@ -700,8 +701,15 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
                               && |{ lo_repo_online->get_url( ) }|
                       iv_class = |url| ).
 
-      render_repo_top_commit_hash( ii_html        = ri_html
-                                   iv_repo_online = lo_repo_online ).
+      TRY.
+          render_repo_top_commit_hash( ii_html        = ri_html
+                                       iv_repo_online = lo_repo_online ).
+        CATCH zcx_abapgit_exception INTO lx_error.
+          " In case of missing or wrong credentials, show message in status bar
+          IF lx_error->get_text( ) CS 'credentials'.
+            MESSAGE lx_error->get_text( ) TYPE 'S'.
+          ENDIF.
+      ENDTRY.
 
     ENDIF.
 

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -119,7 +119,7 @@ CLASS zcl_abapgit_gui_chunk_lib DEFINITION
     CLASS-METHODS render_repo_top_commit_hash
       IMPORTING
         !ii_html        TYPE REF TO zif_abapgit_html
-        !iv_repo_online TYPE REF TO zcl_abapgit_repo_online
+        !io_repo_online TYPE REF TO zcl_abapgit_repo_online
       RAISING
         zcx_abapgit_exception .
   PRIVATE SECTION.
@@ -703,7 +703,7 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
 
       TRY.
           render_repo_top_commit_hash( ii_html        = ri_html
-                                       iv_repo_online = lo_repo_online ).
+                                       io_repo_online = lo_repo_online ).
         CATCH zcx_abapgit_exception INTO lx_error.
           " In case of missing or wrong credentials, show message in status bar
           lv_hint = lx_error->get_text( ).
@@ -797,7 +797,7 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
           lv_display_url       TYPE zif_abapgit_persistence=>ty_repo-url,
           lv_icon_commit       TYPE string.
 
-    lv_commit_hash = iv_repo_online->get_sha1_remote( ).
+    lv_commit_hash = io_repo_online->get_sha1_remote( ).
     lv_commit_short_hash = lv_commit_hash(7).
 
 
@@ -806,7 +806,7 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
                                              iv_hint  = 'Commit' ).
 
     TRY.
-        lv_display_url = iv_repo_online->get_commit_display_url( lv_commit_hash ).
+        lv_display_url = io_repo_online->get_commit_display_url( lv_commit_hash ).
 
         ii_html->add_a( iv_txt   = |{ lv_icon_commit }{ lv_commit_short_hash }|
                         iv_act   = |{ zif_abapgit_definitions=>c_action-url }?|

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -708,7 +708,7 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
           " In case of missing or wrong credentials, show message in status bar
           lv_hint = lx_error->get_text( ).
           IF lv_hint CS 'credentials'.
-            MESSAGE lv_hint TYPE 'S'.
+            MESSAGE lv_hint TYPE 'S' DISPLAY LIKE 'E'.
           ENDIF.
       ENDTRY.
 

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -706,8 +706,9 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
                                        iv_repo_online = lo_repo_online ).
         CATCH zcx_abapgit_exception INTO lx_error.
           " In case of missing or wrong credentials, show message in status bar
-          IF lx_error->get_text( ) CS 'credentials'.
-            MESSAGE lx_error->get_text( ) TYPE 'S'.
+          lv_hint = lx_error->get_text( ).
+          IF lv_hint CS 'credentials'.
+            MESSAGE lv_hint TYPE 'S'.
           ENDIF.
       ENDTRY.
 

--- a/src/zcl_abapgit_repo.clas.abap
+++ b/src/zcl_abapgit_repo.clas.abap
@@ -139,14 +139,6 @@ CLASS zcl_abapgit_repo DEFINITION
       RAISING
         zcx_abapgit_exception .
     METHODS reset_status .
-    METHODS validate
-        ABSTRACT
-      RAISING
-        zcx_abapgit_exception .
-    METHODS reset
-        ABSTRACT
-      RAISING
-        zcx_abapgit_exception .
   PROTECTED SECTION.
 
     DATA mt_local TYPE zif_abapgit_definitions=>ty_files_item_tt .

--- a/src/zcl_abapgit_repo_offline.clas.abap
+++ b/src/zcl_abapgit_repo_offline.clas.abap
@@ -10,10 +10,6 @@ CLASS zcl_abapgit_repo_offline DEFINITION
         REDEFINITION .
     METHODS has_remote_source
         REDEFINITION .
-    METHODS validate
-        REDEFINITION .
-    METHODS reset
-        REDEFINITION .
   PROTECTED SECTION.
 
     METHODS reset_remote
@@ -40,11 +36,6 @@ CLASS ZCL_ABAPGIT_REPO_OFFLINE IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD reset.
-    " Nothing to do so far
-  ENDMETHOD.
-
-
   METHOD reset_remote.
 
     DATA lt_backup LIKE mt_remote.
@@ -60,10 +51,5 @@ CLASS ZCL_ABAPGIT_REPO_OFFLINE IMPLEMENTATION.
     super->reset_remote( ).
     set_files_remote( lt_backup ).
 
-  ENDMETHOD.
-
-
-  METHOD validate.
-    " Nothing to do so far
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_abapgit_repo_online.clas.abap
+++ b/src/zcl_abapgit_repo_online.clas.abap
@@ -51,11 +51,10 @@ CLASS zcl_abapgit_repo_online DEFINITION
         VALUE(rv_url) TYPE zif_abapgit_persistence=>ty_repo-switched_origin .
     METHODS switch_origin
       IMPORTING
-        !iv_url TYPE zif_abapgit_persistence=>ty_repo-url
+        !iv_url       TYPE zif_abapgit_persistence=>ty_repo-url
         !iv_overwrite TYPE abap_bool DEFAULT abap_false
       RAISING
         zcx_abapgit_exception .
-
 
     METHODS get_files_remote
         REDEFINITION .
@@ -64,10 +63,6 @@ CLASS zcl_abapgit_repo_online DEFINITION
     METHODS has_remote_source
         REDEFINITION .
     METHODS rebuild_local_checksums
-        REDEFINITION .
-    METHODS validate
-        REDEFINITION .
-    METHODS reset
         REDEFINITION .
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -287,16 +282,6 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD reset.
-
-    " Reset repo to master branch
-    set_branch_name( 'refs/heads/master' ).
-
-    COMMIT WORK AND WAIT.
-
-  ENDMETHOD.
-
-
   METHOD set_branch_name.
 
     reset_remote( ).
@@ -314,21 +299,6 @@ CLASS ZCL_ABAPGIT_REPO_ONLINE IMPLEMENTATION.
 
     reset_remote( ).
     set( iv_url = iv_url ).
-
-  ENDMETHOD.
-
-
-  METHOD validate.
-
-    DATA:
-      lo_branches TYPE REF TO zcl_abapgit_git_branch_list,
-      ls_branch   TYPE zif_abapgit_definitions=>ty_git_branch.
-
-    " Check if branch still exists since it might have been deleted in remote repo
-    " This will raise exception if not
-    lo_branches = zcl_abapgit_git_transport=>branches( ms_data-url ).
-
-    ls_branch = lo_branches->find_by_name( ms_data-branch_name ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
This PR fixes and harmonizes several issues that can occur during the startup of the repo view:
1. Check if current branch still exists 
1. Messages in case of login errors like incorrect password and cancelation of login popup
1. URL that does not refer to a Git repo
1. Continuous errors when "last used repo" setting to turned on but errors prevent start of repo view
 
Replaces #3749, Closes #3826 

Solutions for above:
1. Missing branch -> Error with a hint what to do (no more automated switch to master)
![image](https://user-images.githubusercontent.com/59966492/92020012-7de5b380-ed25-11ea-9d60-fd5675631b02.png)

1. First failed or canceled login attempt -> Error in status bar, remain in popup
![image](https://user-images.githubusercontent.com/59966492/92020376-049a9080-ed26-11ea-8ae5-f5dfa7a89d30.png)
Second failed or canceled login attempt -> Error in repo view
![image](https://user-images.githubusercontent.com/59966492/92020495-36135c00-ed26-11ea-8ec9-f7e0164acd75.png)

1. Error, URL can be fixed with Advanced > Change Remote
![image](https://user-images.githubusercontent.com/59966492/92020730-999d8980-ed26-11ea-89cc-42f756251351.png)

1. Any error preventing a repo to be displayed correctly, will now reset the "last used repo" setting. A subsequent restart of abapGit, therefore, will go to the repo overview (instead of being stuck in the erroneous repo)


