### PR TITLE
1.99.1

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -72,6 +72,7 @@
     "globalMacros": []
   },
   "rules": {
+    "line_break_style": true,
     "forbidden_pseudo_and_pragma": {
       "ignoreGlobalClassDefinition": true,
       "ignoreGlobalInterface": true,

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,15 @@ Legend
 + : added
 - : removed
 
+2020-09-03 v1.99.1
+------------------
+! exception class updated, might require update via ZABAPGIT_STANDALONE
+! restart abapGit in case of self update
+* OTGR enable parentes again
+* fix filename encoding of < and >
+* class parsing, show line number causing error
+* refactoring
+
 2020-08-27 v1.99.0
 ------------------
 + New functionality for switching between PRs for github

--- a/src/zif_abapgit_version.intf.abap
+++ b/src/zif_abapgit_version.intf.abap
@@ -2,6 +2,6 @@ INTERFACE zif_abapgit_version
   PUBLIC .
 
   CONSTANTS gc_xml_version TYPE string VALUE 'v1.0.0' ##NO_TEXT.
-  CONSTANTS gc_abap_version TYPE string VALUE '1.99.0' ##NO_TEXT.
+  CONSTANTS gc_abap_version TYPE string VALUE '1.99.1' ##NO_TEXT.
 
 ENDINTERFACE.


### PR DESCRIPTION
- exception class updated, might require update via ZABAPGIT_STANDALONE
- restart abapGit in case of self update
- OTGR enable parentes again
- fix filename encoding of < and >
- class parsing, show line number causing error
- refactoring