### PR TITLE
Automatically repair ZCX_ABAPGIT_EXCEPTION

### DIFF
--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -563,6 +563,9 @@ CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
 
 
   METHOD zif_abapgit_object~deserialize.
+
+    DATA: ls_clskey TYPE seoclskey.
+
     deserialize_abap( io_xml     = io_xml
                       iv_package = iv_package ).
 
@@ -572,6 +575,23 @@ CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
                       iv_package = iv_package ).
 
     deserialize_docu( io_xml ).
+
+    " If a method was moved to an interface, abapGit does not remove the old
+    " method include and it's necessary to repair the class (#3833)
+    IF ms_item-obj_name = 'ZCX_ABAPGIT_EXCEPTION'.
+      ls_clskey-clsname = ms_item-obj_name.
+
+      CALL FUNCTION 'SEO_CLASS_REPAIR_CLASSPOOL'
+        EXPORTING
+          clskey       = ls_clskey
+        EXCEPTIONS
+          not_existing = 1
+          OTHERS       = 2.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise( |Error repairing class { ms_item-obj_name }| ).
+      ENDIF.
+    ENDIF.
+
   ENDMETHOD.
 
 

--- a/src/objects/zcl_abapgit_object_clas.clas.abap
+++ b/src/objects/zcl_abapgit_object_clas.clas.abap
@@ -578,6 +578,7 @@ CLASS ZCL_ABAPGIT_OBJECT_CLAS IMPLEMENTATION.
 
     " If a method was moved to an interface, abapGit does not remove the old
     " method include and it's necessary to repair the class (#3833)
+    " TODO: Remove 2020-11 or replace with general solution
     IF ms_item-obj_name = 'ZCX_ABAPGIT_EXCEPTION'.
       ls_clskey-clsname = ms_item-obj_name.
 


### PR DESCRIPTION
See #3833. This should prevent the diff updating to 1.99.1 when using the standalone prg.