### PR TITLE
popup_to_select_from_list can handle element-based tables

### DIFF
--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -153,8 +153,6 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
       WHEN cl_abap_elemdescr=>kind_elem.
         lo_elem_descr ?= mo_table_descr->get_table_line_type( ).
         INSERT INITIAL LINE INTO lt_components ASSIGNING <ls_component> INDEX 1.
-        ASSERT sy-subrc = 0.
-
         <ls_component>-name = c_default_column.
         <ls_component>-type = lo_elem_descr.
 
@@ -169,8 +167,6 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
     ENDIF.
 
     INSERT INITIAL LINE INTO lt_components ASSIGNING <ls_component> INDEX 1.
-    ASSERT sy-subrc = 0.
-
     <ls_component>-name = c_fieldname_selected.
     <ls_component>-type ?= cl_abap_datadescr=>describe_by_name( 'FLAG' ).
 

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -185,8 +185,9 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
       CLEAR <lg_line>.
       CASE lo_data_descr->kind.
         WHEN cl_abap_elemdescr=>kind_elem.
-          ASSIGN COMPONENT c_default_column OF STRUCTURE <lg_line> TO <lg_value>.
-          <lg_value> = <lg_data>.
+          ASSIGN COMPONENT c_default_column OF STRUCTURE <lg_data> TO <lg_value>.
+          ASSERT <lg_value> IS ASSIGNED.
+          <lg_line> = <lg_value>.
 
         WHEN OTHERS.
           MOVE-CORRESPONDING <lg_data> TO <lg_line>.
@@ -251,7 +252,7 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
     FIELD-SYMBOLS: <lg_exporting>    TYPE any,
                    <lt_table>        TYPE STANDARD TABLE,
                    <lg_line>         TYPE any,
-                   <lv_value>        TYPE any,
+                   <lg_value>        TYPE any,
                    <lv_selected>     TYPE abap_bool,
                    <lv_selected_row> TYPE LINE OF salv_t_row.
 
@@ -299,9 +300,9 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
       CASE lo_data_descr->kind.
         WHEN cl_abap_elemdescr=>kind_elem.
-          ASSIGN COMPONENT c_default_column OF STRUCTURE <lg_line> TO <lv_value>.
-          ASSERT <lv_value> IS ASSIGNED.
-          <lg_exporting> = <lv_value>.
+          ASSIGN COMPONENT c_default_column OF STRUCTURE <lg_line> TO <lg_value>.
+          ASSERT <lg_value> IS ASSIGNED.
+          <lg_exporting> = <lg_value>.
 
         WHEN OTHERS.
           MOVE-CORRESPONDING <lg_line> TO <lg_exporting>.

--- a/src/ui/zcl_abapgit_popups.clas.abap
+++ b/src/ui/zcl_abapgit_popups.clas.abap
@@ -5,6 +5,7 @@ CLASS zcl_abapgit_popups DEFINITION
   GLOBAL FRIENDS zcl_abapgit_ui_factory.
 
   PUBLIC SECTION.
+    CONSTANTS: c_default_column TYPE lvc_fname VALUE `DEFAULT_COLUMN` ##NO_TEXT.
 
     INTERFACES: zif_abapgit_popups.
     ALIASES:
@@ -134,17 +135,38 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
     DATA: lr_struct        TYPE REF TO data,
           lt_components    TYPE cl_abap_structdescr=>component_table,
+          lo_data_descr    TYPE REF TO cl_abap_datadescr,
+          lo_elem_descr    TYPE REF TO cl_abap_elemdescr,
           lo_struct_descr  TYPE REF TO cl_abap_structdescr,
           lo_struct_descr2 TYPE REF TO cl_abap_structdescr.
 
     FIELD-SYMBOLS: <lt_table>     TYPE STANDARD TABLE,
                    <ls_component> TYPE abap_componentdescr,
                    <lg_line>      TYPE data,
-                   <lg_data>      TYPE any.
+                   <lg_data>      TYPE any,
+                   <lg_value>     TYPE any.
 
     mo_table_descr ?= cl_abap_tabledescr=>describe_by_data( it_list ).
-    lo_struct_descr ?= mo_table_descr->get_table_line_type( ).
-    lt_components = lo_struct_descr->get_components( ).
+    lo_data_descr = mo_table_descr->get_table_line_type( ).
+
+    CASE lo_data_descr->kind.
+      WHEN cl_abap_elemdescr=>kind_elem.
+        lo_elem_descr ?= mo_table_descr->get_table_line_type( ).
+        INSERT INITIAL LINE INTO lt_components ASSIGNING <ls_component> INDEX 1.
+        ASSERT sy-subrc = 0.
+
+        <ls_component>-name = c_default_column.
+        <ls_component>-type = lo_elem_descr.
+
+      WHEN cl_abap_elemdescr=>kind_struct.
+        lo_struct_descr ?= mo_table_descr->get_table_line_type( ).
+        lt_components = lo_struct_descr->get_components( ).
+
+    ENDCASE.
+
+    IF lt_components IS INITIAL.
+      RETURN.
+    ENDIF.
 
     INSERT INITIAL LINE INTO lt_components ASSIGNING <ls_component> INDEX 1.
     ASSERT sy-subrc = 0.
@@ -165,7 +187,15 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
 
     LOOP AT it_list ASSIGNING <lg_data>.
       CLEAR <lg_line>.
-      MOVE-CORRESPONDING <lg_data> TO <lg_line>.
+      CASE lo_data_descr->kind.
+        WHEN cl_abap_elemdescr=>kind_elem.
+          ASSIGN COMPONENT c_default_column OF STRUCTURE <lg_line> TO <lg_value>.
+          <lg_value> = <lg_data>.
+
+        WHEN OTHERS.
+          MOVE-CORRESPONDING <lg_data> TO <lg_line>.
+
+      ENDCASE.
       INSERT <lg_line> INTO TABLE <lt_table>.
     ENDLOOP.
 
@@ -225,10 +255,12 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
     FIELD-SYMBOLS: <lg_exporting>    TYPE any,
                    <lt_table>        TYPE STANDARD TABLE,
                    <lg_line>         TYPE any,
+                   <lv_value>        TYPE any,
                    <lv_selected>     TYPE abap_bool,
                    <lv_selected_row> TYPE LINE OF salv_t_row.
 
-    DATA: lo_selections    TYPE REF TO cl_salv_selections,
+    DATA: lo_data_descr    TYPE REF TO cl_abap_datadescr,
+          lo_selections    TYPE REF TO cl_salv_selections,
           lt_selected_rows TYPE salv_t_row.
 
     ASSIGN mr_table->* TO <lt_table>.
@@ -245,7 +277,7 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
         READ TABLE <lt_table>
           ASSIGNING <lg_line>
           INDEX <lv_selected_row>.
-        CHECK <lv_selected_row> IS ASSIGNED.
+        CHECK <lg_line> IS ASSIGNED.
 
         ASSIGN COMPONENT c_fieldname_selected
            OF STRUCTURE <lg_line>
@@ -263,9 +295,22 @@ CLASS zcl_abapgit_popups IMPLEMENTATION.
     CREATE DATA lr_exporting LIKE LINE OF et_list.
     ASSIGN lr_exporting->* TO <lg_exporting>.
 
+    mo_table_descr ?= cl_abap_tabledescr=>describe_by_data( et_list ).
+    lo_data_descr = mo_table_descr->get_table_line_type( ).
+
     LOOP AT <lt_table> ASSIGNING <lg_line> WHERE (lv_condition).
       CLEAR <lg_exporting>.
-      MOVE-CORRESPONDING <lg_line> TO <lg_exporting>.
+
+      CASE lo_data_descr->kind.
+        WHEN cl_abap_elemdescr=>kind_elem.
+          ASSIGN COMPONENT c_default_column OF STRUCTURE <lg_line> TO <lv_value>.
+          ASSERT <lv_value> IS ASSIGNED.
+          <lg_exporting> = <lv_value>.
+
+        WHEN OTHERS.
+          MOVE-CORRESPONDING <lg_line> TO <lg_exporting>.
+
+      ENDCASE.
       APPEND <lg_exporting> TO et_list.
     ENDLOOP.
 


### PR DESCRIPTION
popup_to_select_from_list can now handle element-based non-structured tables like a table of url strings. Before it was only compatible with structured tables.

Therefore related to #3639