### PR TITLE
Add recently used repo url to user persistence

### DIFF
--- a/src/persist/zcl_abapgit_persistence_user.clas.abap
+++ b/src/persist/zcl_abapgit_persistence_user.clas.abap
@@ -6,7 +6,8 @@ CLASS zcl_abapgit_persistence_user DEFINITION
 
     INTERFACES zif_abapgit_persist_user.
 
-    TYPES tt_favorites TYPE zif_abapgit_persistence=>tt_repo_keys .
+    TYPES: tt_favorites TYPE zif_abapgit_persistence=>tt_repo_keys,
+           tt_urls      TYPE zif_abapgit_persistence=>tt_repo_urls.
 
     CLASS-METHODS get_instance
       IMPORTING
@@ -36,6 +37,7 @@ CLASS zcl_abapgit_persistence_user DEFINITION
         changes_only     TYPE abap_bool,
         diff_unified     TYPE abap_bool,
         favorites        TYPE tt_favorites,
+        urls             TYPE tt_urls,
         repo_config      TYPE ty_repo_config_tt,
         settings         TYPE zif_abapgit_definitions=>ty_s_user_settings,
       END OF ty_user .
@@ -82,7 +84,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_PERSISTENCE_USER IMPLEMENTATION.
+CLASS zcl_abapgit_persistence_user IMPLEMENTATION.
 
 
   METHOD constructor.
@@ -228,6 +230,13 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_USER IMPLEMENTATION.
   METHOD zif_abapgit_persist_user~get_favorites.
 
     rt_favorites = read( )-favorites.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_persist_user~get_urls.
+
+    rt_urls = read( )-urls.
 
   ENDMETHOD.
 
@@ -453,6 +462,44 @@ CLASS ZCL_ABAPGIT_PERSISTENCE_USER IMPLEMENTATION.
     update( ls_user ).
 
     COMMIT WORK AND WAIT.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_persist_user~add_url.
+
+    DATA: ls_user TYPE ty_user.
+
+    ls_user = read( ).
+
+    READ TABLE ls_user-urls TRANSPORTING NO FIELDS
+      WITH KEY table_line = iv_repo_url.
+
+    IF sy-subrc <> 0.
+      APPEND iv_repo_url TO ls_user-urls.
+
+      update( ls_user ).
+      COMMIT WORK AND WAIT.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD zif_abapgit_persist_user~remove_url.
+
+    DATA: ls_user TYPE ty_user.
+
+    ls_user = read( ).
+
+    READ TABLE ls_user-urls TRANSPORTING NO FIELDS
+      WITH KEY table_line = iv_repo_url.
+
+    IF sy-subrc = 0.
+      DELETE ls_user-urls WHERE table_line = iv_repo_url.
+
+      update( ls_user ).
+      COMMIT WORK AND WAIT.
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/persist/zif_abapgit_persist_user.intf.abap
+++ b/src/persist/zif_abapgit_persist_user.intf.abap
@@ -1,7 +1,8 @@
 INTERFACE zif_abapgit_persist_user
   PUBLIC .
 
-  TYPES tt_favorites TYPE zif_abapgit_persistence=>tt_repo_keys .
+  TYPES: tt_favorites TYPE zif_abapgit_persistence=>tt_repo_keys,
+         tt_urls      TYPE zif_abapgit_persistence=>tt_repo_urls.
 
   METHODS get_changes_only
     RETURNING
@@ -26,6 +27,11 @@ INTERFACE zif_abapgit_persist_user
   METHODS get_favorites
     RETURNING
       VALUE(rt_favorites) TYPE tt_favorites
+    RAISING
+      zcx_abapgit_exception .
+  METHODS get_urls
+    RETURNING
+      VALUE(rt_urls) TYPE tt_urls
     RAISING
       zcx_abapgit_exception .
   METHODS get_hide_files
@@ -125,6 +131,16 @@ INTERFACE zif_abapgit_persist_user
   METHODS toggle_favorite
     IMPORTING
       !iv_repo_key TYPE zif_abapgit_persistence=>ty_repo-key
+    RAISING
+      zcx_abapgit_exception .
+  METHODS add_url
+    IMPORTING
+      !iv_repo_url TYPE zif_abapgit_persistence=>ty_repo-url
+    RAISING
+      zcx_abapgit_exception .
+  METHODS remove_url
+    IMPORTING
+      !iv_repo_url TYPE zif_abapgit_persistence=>ty_repo-url
     RAISING
       zcx_abapgit_exception .
   METHODS toggle_hide_files

--- a/src/persist/zif_abapgit_persistence.intf.abap
+++ b/src/persist/zif_abapgit_persistence.intf.abap
@@ -66,9 +66,10 @@ INTERFACE zif_abapgit_persistence PUBLIC.
 
   TYPES: BEGIN OF ty_repo,
            key TYPE ty_value.
-      INCLUDE TYPE ty_repo_xml.
+           INCLUDE TYPE ty_repo_xml.
   TYPES: END OF ty_repo.
   TYPES: tt_repo TYPE STANDARD TABLE OF ty_repo WITH DEFAULT KEY.
   TYPES: tt_repo_keys TYPE STANDARD TABLE OF ty_repo-key WITH DEFAULT KEY.
+  TYPES: tt_repo_urls TYPE STANDARD TABLE OF ty_repo-url WITH DEFAULT KEY.
 
 ENDINTERFACE.


### PR DESCRIPTION
Related to #3639

Recently used repo urls can be saved/removed via the user persistence layer.