### PR TITLE
XML Refactoring: zif_abapgit_object et al.

### DIFF
--- a/src/objects/zcl_abapgit_object_fugr.clas.abap
+++ b/src/objects/zcl_abapgit_object_fugr.clas.abap
@@ -75,12 +75,12 @@ CLASS zcl_abapgit_object_fugr DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
         zcx_abapgit_exception .
     METHODS serialize_xml
       IMPORTING
-        !io_xml TYPE REF TO zcl_abapgit_xml_output
+        !ii_xml TYPE REF TO zif_abapgit_xml_output
       RAISING
         zcx_abapgit_exception .
     METHODS deserialize_xml
       IMPORTING
-        !io_xml     TYPE REF TO zcl_abapgit_xml_input
+        !ii_xml     TYPE REF TO zif_abapgit_xml_input
         !iv_package TYPE devclass
       RAISING
         zcx_abapgit_exception .
@@ -89,7 +89,7 @@ CLASS zcl_abapgit_object_fugr DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
         zcx_abapgit_exception .
     METHODS deserialize_includes
       IMPORTING
-        !io_xml     TYPE REF TO zcl_abapgit_xml_input
+        !ii_xml     TYPE REF TO zif_abapgit_xml_input
         !iv_package TYPE devclass
         !ii_log     TYPE REF TO zif_abapgit_log
       RAISING
@@ -111,7 +111,7 @@ CLASS zcl_abapgit_object_fugr DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
         zcx_abapgit_exception .
     METHODS get_abap_version
       IMPORTING
-        !io_xml                TYPE REF TO zcl_abapgit_xml_input
+        !ii_xml                TYPE REF TO zif_abapgit_xml_input
       RETURNING
         VALUE(rv_abap_version) TYPE progdir-uccheck
       RAISING
@@ -123,20 +123,20 @@ CLASS zcl_abapgit_object_fugr DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
     METHODS serialize_texts
       IMPORTING
         !iv_prog_name TYPE programm
-        !io_xml       TYPE REF TO zif_abapgit_xml_output
+        !ii_xml       TYPE REF TO zif_abapgit_xml_output
       RAISING
         zcx_abapgit_exception .
     METHODS deserialize_texts
       IMPORTING
         !iv_prog_name TYPE programm
-        !io_xml       TYPE REF TO zif_abapgit_xml_input
+        !ii_xml       TYPE REF TO zif_abapgit_xml_input
       RAISING
         zcx_abapgit_exception .
 ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
+CLASS zcl_abapgit_object_fugr IMPLEMENTATION.
 
 
   METHOD check_rfc_parameters.
@@ -307,7 +307,7 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
 
   METHOD deserialize_includes.
 
-    DATA: lo_xml       TYPE REF TO zcl_abapgit_xml_input,
+    DATA: lo_xml       TYPE REF TO zif_abapgit_xml_input,
           ls_progdir   TYPE ty_progdir,
           lt_includes  TYPE ty_sobj_name_tt,
           lt_tpool     TYPE textpool_table,
@@ -320,7 +320,7 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
 
     tadir_insert( iv_package ).
 
-    io_xml->read( EXPORTING iv_name = 'INCLUDES'
+    ii_xml->read( EXPORTING iv_name = 'INCLUDES'
                   CHANGING cg_data = lt_includes ).
 
     LOOP AT lt_includes ASSIGNING <lv_include>.
@@ -372,7 +372,7 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
           lt_tpool      TYPE textpool_table.
 
     FIELD-SYMBOLS <ls_tpool> LIKE LINE OF lt_tpool_i18n.
-    io_xml->read( EXPORTING iv_name = 'I18N_TPOOL'
+    ii_xml->read( EXPORTING iv_name = 'I18N_TPOOL'
                   CHANGING  cg_data = lt_tpool_i18n ).
 
     LOOP AT lt_tpool_i18n ASSIGNING <ls_tpool>.
@@ -394,7 +394,7 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
           lv_abap_version TYPE trdir-uccheck,
           lv_corrnum      TYPE e070use-ordernum.
 
-    lv_abap_version = get_abap_version( io_xml ).
+    lv_abap_version = get_abap_version( ii_xml ).
     lv_complete = ms_item-obj_name.
 
     CALL FUNCTION 'FUNCTION_INCLUDE_SPLIT'
@@ -420,7 +420,7 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
       zcx_abapgit_exception=>raise( 'error from FUNCTION_INCLUDE_SPLIT' ).
     ENDIF.
 
-    io_xml->read( EXPORTING iv_name = 'AREAT'
+    ii_xml->read( EXPORTING iv_name = 'AREAT'
                   CHANGING cg_data = lv_areat ).
     lv_stext = lv_areat.
     lv_corrnum = zcl_abapgit_default_transport=>get_instance( )->get( )-ordernum.
@@ -497,11 +497,11 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
 
     DATA: lt_includes TYPE ty_sobj_name_tt,
           ls_progdir  TYPE ty_progdir,
-          lo_xml      TYPE REF TO zcl_abapgit_xml_input.
+          lo_xml      TYPE REF TO zif_abapgit_xml_input.
 
     FIELD-SYMBOLS: <lv_include> LIKE LINE OF lt_includes.
 
-    io_xml->read( EXPORTING iv_name = 'INCLUDES'
+    ii_xml->read( EXPORTING iv_name = 'INCLUDES'
                   CHANGING cg_data = lt_includes ).
 
     LOOP AT lt_includes ASSIGNING <lv_include>.
@@ -854,7 +854,7 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
 
     FIELD-SYMBOLS <ls_tpool> LIKE LINE OF lt_tpool_i18n.
 
-    IF io_xml->i18n_params( )-serialize_master_lang_only = abap_true.
+    IF ii_xml->i18n_params( )-serialize_master_lang_only = abap_true.
       RETURN.
     ENDIF.
 
@@ -877,7 +877,7 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
     ENDLOOP.
 
     IF lines( lt_tpool_i18n ) > 0.
-      io_xml->add( iv_name = 'I18N_TPOOL'
+      ii_xml->add( iv_name = 'I18N_TPOOL'
                    ig_data = lt_tpool_i18n ).
     ENDIF.
   ENDMETHOD.
@@ -896,9 +896,9 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
 
     lt_includes = includes( ).
 
-    io_xml->add( iv_name = 'AREAT'
+    ii_xml->add( iv_name = 'AREAT'
                  ig_data = lv_areat ).
-    io_xml->add( iv_name = 'INCLUDES'
+    ii_xml->add( iv_name = 'INCLUDES'
                  ig_data = lt_includes ).
 
   ENDMETHOD.
@@ -1055,7 +1055,7 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
           ls_cua          TYPE ty_cua.
 
     deserialize_xml(
-      io_xml     = io_xml
+      ii_xml     = io_xml
       iv_package = iv_package ).
 
     io_xml->read( EXPORTING iv_name = 'FUNCTIONS'
@@ -1065,14 +1065,14 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
       ii_log       = ii_log ).
 
     deserialize_includes(
-      io_xml     = io_xml
+      ii_xml     = io_xml
       iv_package = iv_package
       ii_log     = ii_log ).
 
     lv_program_name = main_name( ).
 
     deserialize_texts( iv_prog_name = lv_program_name
-                       io_xml       = io_xml ).
+                       ii_xml       = io_xml ).
 
     io_xml->read( EXPORTING iv_name = 'DYNPROS'
                   CHANGING cg_data = lt_dynpros ).
@@ -1182,7 +1182,7 @@ CLASS ZCL_ABAPGIT_OBJECT_FUGR IMPLEMENTATION.
     ls_progdir = read_progdir( lv_program_name ).
 
     serialize_texts( iv_prog_name = lv_program_name
-                     io_xml       = io_xml ).
+                     ii_xml       = io_xml ).
 
     IF ls_progdir-subc = 'F'.
       lt_dynpros = serialize_dynpros( lv_program_name ).

--- a/src/objects/zcl_abapgit_object_sprx.clas.abap
+++ b/src/objects/zcl_abapgit_object_sprx.clas.abap
@@ -32,7 +32,7 @@ CLASS zcl_abapgit_object_sprx DEFINITION PUBLIC INHERITING FROM zcl_abapgit_obje
         !ev_obj_name TYPE sproxhdr-obj_name .
     METHODS delta_handling
       IMPORTING
-        !io_xml          TYPE REF TO zcl_abapgit_xml_input
+        !ii_xml          TYPE REF TO zif_abapgit_xml_input
       EXPORTING
         !et_sproxhdr_new TYPE sprx_hdr_t
         !et_sproxdat_new TYPE sprx_dat_t
@@ -115,7 +115,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SPRX IMPLEMENTATION.
       CATCH cx_proxy_gen_error.
         "No delta for this object -> create
 
-        io_xml->read(
+        ii_xml->read(
           EXPORTING
             iv_name = c_proxy-header
           CHANGING
@@ -125,7 +125,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SPRX IMPLEMENTATION.
           zcx_abapgit_exception=>raise( |SPRX - error deserialize: { ms_item-obj_name }| ).
         ENDIF.
 
-        io_xml->read(
+        ii_xml->read(
           EXPORTING
             iv_name = c_proxy-data
           CHANGING
@@ -266,7 +266,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SPRX IMPLEMENTATION.
 
     delta_handling(
       EXPORTING
-        io_xml = io_xml
+        ii_xml = io_xml
       IMPORTING
         et_sproxhdr_new = lt_sproxhdr_new
         et_sproxdat_new = lt_sproxdat_new ).

--- a/src/objects/zcl_abapgit_objects.clas.abap
+++ b/src/objects/zcl_abapgit_objects.clas.abap
@@ -7,15 +7,6 @@ CLASS zcl_abapgit_objects DEFINITION
     TYPES:
       ty_types_tt TYPE SORTED TABLE OF tadir-object WITH UNIQUE KEY table_line.
     TYPES:
-      BEGIN OF ty_deserialization,
-        obj     TYPE REF TO zif_abapgit_object,
-        xml     TYPE REF TO zcl_abapgit_xml_input,
-        package TYPE devclass,
-        item    TYPE zif_abapgit_definitions=>ty_item,
-      END OF ty_deserialization .
-    TYPES:
-      ty_deserialization_tt TYPE STANDARD TABLE OF ty_deserialization WITH DEFAULT KEY .
-    TYPES:
       BEGIN OF ty_serialization,
         files TYPE zif_abapgit_definitions=>ty_files_tt,
         item  TYPE zif_abapgit_definitions=>ty_item,
@@ -572,7 +563,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
           lt_remote   TYPE zif_abapgit_definitions=>ty_files_tt,
           lv_package  TYPE devclass,
           lo_files    TYPE REF TO zcl_abapgit_objects_files,
-          lo_xml      TYPE REF TO zcl_abapgit_xml_input,
+          lo_xml      TYPE REF TO zif_abapgit_xml_input,
           lt_results  TYPE zif_abapgit_definitions=>ty_results_tt,
           li_progress TYPE REF TO zif_abapgit_progress,
           lv_path     TYPE string,
@@ -585,7 +576,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_result>  TYPE zif_abapgit_definitions=>ty_result,
                    <lv_step_id> TYPE LINE OF zif_abapgit_definitions=>ty_deserialization_step_tt,
                    <ls_step>    TYPE LINE OF zif_abapgit_definitions=>ty_step_data_tt,
-                   <ls_deser>   TYPE LINE OF ty_deserialization_tt.
+                   <ls_deser>   TYPE LINE OF zif_abapgit_definitions=>ty_deserialization_tt.
 
     lt_steps = get_deserialize_steps( ).
 
@@ -1169,7 +1160,7 @@ CLASS zcl_abapgit_objects IMPLEMENTATION.
     ENDIF.
 
     li_obj->serialize( lo_xml ).
-    lo_files->add_xml( io_xml      = lo_xml
+    lo_files->add_xml( ii_xml      = lo_xml
                        is_metadata = li_obj->get_metadata( ) ).
 
     rs_files_and_item-files = lo_files->get_files( ).

--- a/src/objects/zcl_abapgit_objects_files.clas.abap
+++ b/src/objects/zcl_abapgit_objects_files.clas.abap
@@ -26,7 +26,7 @@ CLASS zcl_abapgit_objects_files DEFINITION
     METHODS add_xml
       IMPORTING
         !iv_extra     TYPE clike OPTIONAL
-        !io_xml       TYPE REF TO zcl_abapgit_xml_output
+        !ii_xml       TYPE REF TO zif_abapgit_xml_output
         !iv_normalize TYPE abap_bool DEFAULT abap_true
         !is_metadata  TYPE zif_abapgit_definitions=>ty_metadata OPTIONAL
       RAISING
@@ -35,7 +35,7 @@ CLASS zcl_abapgit_objects_files DEFINITION
       IMPORTING
         !iv_extra     TYPE clike OPTIONAL
       RETURNING
-        VALUE(ro_xml) TYPE REF TO zcl_abapgit_xml_input
+        VALUE(ri_xml) TYPE REF TO zif_abapgit_xml_input
       RAISING
         zcx_abapgit_exception .
     METHODS read_abap
@@ -111,7 +111,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECTS_FILES IMPLEMENTATION.
+CLASS zcl_abapgit_objects_files IMPLEMENTATION.
 
 
   METHOD add.
@@ -173,7 +173,7 @@ CLASS ZCL_ABAPGIT_OBJECTS_FILES IMPLEMENTATION.
     DATA: lv_xml  TYPE string,
           ls_file TYPE zif_abapgit_definitions=>ty_file.
 
-    lv_xml = io_xml->render( iv_normalize = iv_normalize
+    lv_xml = ii_xml->render( iv_normalize = iv_normalize
                              is_metadata = is_metadata ).
     ls_file-path = '/'.
 
@@ -371,7 +371,8 @@ CLASS ZCL_ABAPGIT_OBJECTS_FILES IMPLEMENTATION.
 
     lv_xml = zcl_abapgit_convert=>xstring_to_string_utf8( lv_data ).
 
-    CREATE OBJECT ro_xml
+    CREATE OBJECT ri_xml
+      TYPE zcl_abapgit_xml_input
       EXPORTING
         iv_xml      = lv_xml
         iv_filename = lv_filename.

--- a/src/objects/zcl_abapgit_objects_program.clas.abap
+++ b/src/objects/zcl_abapgit_objects_program.clas.abap
@@ -35,7 +35,7 @@ CLASS zcl_abapgit_objects_program DEFINITION PUBLIC INHERITING FROM zcl_abapgit_
            END OF ty_progdir.
 
     METHODS serialize_program
-      IMPORTING io_xml     TYPE REF TO zcl_abapgit_xml_output OPTIONAL
+      IMPORTING io_xml     TYPE REF TO zif_abapgit_xml_output OPTIONAL
                 is_item    TYPE zif_abapgit_definitions=>ty_item
                 io_files   TYPE REF TO zcl_abapgit_objects_files
                 iv_program TYPE programm OPTIONAL
@@ -165,7 +165,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_OBJECTS_PROGRAM IMPLEMENTATION.
+CLASS zcl_abapgit_objects_program IMPLEMENTATION.
 
 
   METHOD add_tpool.
@@ -765,10 +765,10 @@ CLASS ZCL_ABAPGIT_OBJECTS_PROGRAM IMPLEMENTATION.
                    <ls_field_int>   LIKE LINE OF lt_fieldlist_int.
 
     "#2746: relevant flag values (taken from include MSEUSBIT)
-    CONSTANTS:    lc_flg1ddf TYPE x VALUE '20',
-                  lc_flg3fku TYPE x VALUE '08',
-                  lc_flg3for TYPE x VALUE '04',
-                  lc_flg3fdu TYPE x VALUE '02'.
+    CONSTANTS: lc_flg1ddf TYPE x VALUE '20',
+               lc_flg3fku TYPE x VALUE '08',
+               lc_flg3for TYPE x VALUE '04',
+               lc_flg3fdu TYPE x VALUE '02'.
 
 
     CALL FUNCTION 'RS_SCREEN_LIST'
@@ -875,7 +875,7 @@ CLASS ZCL_ABAPGIT_OBJECTS_PROGRAM IMPLEMENTATION.
           lt_source       TYPE TABLE OF abaptxt255,
           lt_tpool        TYPE textpool_table,
           ls_tpool        LIKE LINE OF lt_tpool,
-          lo_xml          TYPE REF TO zcl_abapgit_xml_output.
+          li_xml          TYPE REF TO zif_abapgit_xml_output.
 
     IF iv_program IS INITIAL.
       lv_program_name = is_item-obj_name.
@@ -912,21 +912,21 @@ CLASS ZCL_ABAPGIT_OBJECTS_PROGRAM IMPLEMENTATION.
     ls_progdir = read_progdir( lv_program_name ).
 
     IF io_xml IS BOUND.
-      lo_xml = io_xml.
+      li_xml = io_xml.
     ELSE.
-      CREATE OBJECT lo_xml.
+      CREATE OBJECT li_xml TYPE zcl_abapgit_xml_output.
     ENDIF.
 
-    lo_xml->add( iv_name = 'PROGDIR'
+    li_xml->add( iv_name = 'PROGDIR'
                  ig_data = ls_progdir ).
     IF ls_progdir-subc = '1' OR ls_progdir-subc = 'M'.
       lt_dynpros = serialize_dynpros( lv_program_name ).
-      lo_xml->add( iv_name = 'DYNPROS'
+      li_xml->add( iv_name = 'DYNPROS'
                    ig_data = lt_dynpros ).
 
       ls_cua = serialize_cua( lv_program_name ).
       IF NOT ls_cua IS INITIAL.
-        lo_xml->add( iv_name = 'CUA'
+        li_xml->add( iv_name = 'CUA'
                      ig_data = ls_cua ).
       ENDIF.
     ENDIF.
@@ -936,12 +936,12 @@ CLASS ZCL_ABAPGIT_OBJECTS_PROGRAM IMPLEMENTATION.
       DELETE lt_tpool INDEX sy-tabix.
     ENDIF.
 
-    lo_xml->add( iv_name = 'TPOOL'
+    li_xml->add( iv_name = 'TPOOL'
                  ig_data = add_tpool( lt_tpool ) ).
 
     IF NOT io_xml IS BOUND.
       io_files->add_xml( iv_extra = iv_extra
-                         io_xml   = lo_xml ).
+                         ii_xml   = li_xml ).
     ENDIF.
 
     io_files->add_abap( iv_extra = iv_extra

--- a/src/objects/zif_abapgit_object.intf.abap
+++ b/src/objects/zif_abapgit_object.intf.abap
@@ -15,13 +15,13 @@ INTERFACE zif_abapgit_object
 
   METHODS serialize
     IMPORTING
-      !io_xml TYPE REF TO zcl_abapgit_xml_output
+      !io_xml TYPE REF TO zif_abapgit_xml_output
     RAISING
       zcx_abapgit_exception .
   METHODS deserialize
     IMPORTING
       !iv_package TYPE devclass
-      !io_xml     TYPE REF TO zcl_abapgit_xml_input
+      !io_xml     TYPE REF TO zif_abapgit_xml_input
       !iv_step    TYPE zif_abapgit_definitions=>ty_deserialization_step
       !ii_log     TYPE REF TO zif_abapgit_log
     RAISING

--- a/src/zcl_abapgit_settings.clas.abap
+++ b/src/zcl_abapgit_settings.clas.abap
@@ -267,15 +267,15 @@ CLASS zcl_abapgit_settings IMPLEMENTATION.
 
   METHOD get_settings_xml.
 
-    DATA: lo_output TYPE REF TO zcl_abapgit_xml_output.
+    DATA: li_output TYPE REF TO zif_abapgit_xml_output.
 
 
-    CREATE OBJECT lo_output.
+    CREATE OBJECT li_output TYPE zcl_abapgit_xml_output.
 
-    lo_output->add( iv_name = zcl_abapgit_persistence_db=>c_type_settings
+    li_output->add( iv_name = zcl_abapgit_persistence_db=>c_type_settings
                     ig_data = ms_settings ).
 
-    rv_settings_xml = lo_output->render( ).
+    rv_settings_xml = li_output->render( ).
 
   ENDMETHOD.
 

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -217,7 +217,7 @@ INTERFACE zif_abapgit_definitions
   TYPES:
     BEGIN OF ty_tpool.
       INCLUDE TYPE textpool.
-      TYPES: split TYPE c LENGTH 8.
+  TYPES: split TYPE c LENGTH 8.
   TYPES: END OF ty_tpool .
   TYPES:
     ty_tpool_tt TYPE STANDARD TABLE OF ty_tpool WITH DEFAULT KEY .

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -25,8 +25,8 @@ INTERFACE zif_abapgit_definitions
   TYPES:
     BEGIN OF ty_file.
       INCLUDE TYPE ty_file_signature.
-  TYPES: data TYPE xstring,
-         END OF ty_file .
+      TYPES: data TYPE xstring,
+    END OF ty_file .
   TYPES:
     ty_files_tt TYPE STANDARD TABLE OF ty_file WITH DEFAULT KEY .
   TYPES:
@@ -104,8 +104,8 @@ INTERFACE zif_abapgit_definitions
   TYPES:
     BEGIN OF ty_overwrite.
       INCLUDE TYPE ty_item.
-  TYPES: decision TYPE ty_yes_no,
-         END OF ty_overwrite .
+      TYPES: decision TYPE ty_yes_no,
+    END OF ty_overwrite .
   TYPES:
     ty_overwrite_tt TYPE STANDARD TABLE OF ty_overwrite WITH DEFAULT KEY
                               WITH UNIQUE HASHED KEY object_type_and_name
@@ -217,7 +217,7 @@ INTERFACE zif_abapgit_definitions
   TYPES:
     BEGIN OF ty_tpool.
       INCLUDE TYPE textpool.
-  TYPES: split TYPE c LENGTH 8.
+      TYPES: split TYPE c LENGTH 8.
   TYPES: END OF ty_tpool .
   TYPES:
     ty_tpool_tt TYPE STANDARD TABLE OF ty_tpool WITH DEFAULT KEY .
@@ -390,7 +390,7 @@ INTERFACE zif_abapgit_definitions
   TYPES:
     BEGIN OF ty_deserialization,
       obj     TYPE REF TO zif_abapgit_object,
-      xml     TYPE REF TO zcl_abapgit_xml_input,
+      xml     TYPE REF TO zif_abapgit_xml_input,
       package TYPE devclass,
       item    TYPE ty_item,
     END OF ty_deserialization .

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -25,7 +25,7 @@ INTERFACE zif_abapgit_definitions
   TYPES:
     BEGIN OF ty_file.
       INCLUDE TYPE ty_file_signature.
-      TYPES: data TYPE xstring,
+  TYPES: data TYPE xstring,
     END OF ty_file .
   TYPES:
     ty_files_tt TYPE STANDARD TABLE OF ty_file WITH DEFAULT KEY .

--- a/src/zif_abapgit_definitions.intf.abap
+++ b/src/zif_abapgit_definitions.intf.abap
@@ -104,7 +104,7 @@ INTERFACE zif_abapgit_definitions
   TYPES:
     BEGIN OF ty_overwrite.
       INCLUDE TYPE ty_item.
-      TYPES: decision TYPE ty_yes_no,
+  TYPES: decision TYPE ty_yes_no,
     END OF ty_overwrite .
   TYPES:
     ty_overwrite_tt TYPE STANDARD TABLE OF ty_overwrite WITH DEFAULT KEY


### PR DESCRIPTION
Ref #3531 This should be the last one before we can start removing the aliases

Contains the "Big One": reference changed in `zif_abapgit_object`