### PR TITLE
SHI3: Fix "IMG structure ID still used"

### DIFF
--- a/src/objects/zcl_abapgit_object_shi3.clas.abap
+++ b/src/objects/zcl_abapgit_object_shi3.clas.abap
@@ -205,7 +205,7 @@ CLASS ZCL_ABAPGIT_OBJECT_SHI3 IMPLEMENTATION.
                   CHANGING  cg_data = lt_texts ).
 
     IF zif_abapgit_object~exists( ) = abap_true.
-      zif_abapgit_object~delete( iv_package ).
+      delete_tree_structure( mv_tree_id ).
     ENDIF.
 
     CALL FUNCTION 'STREE_HIERARCHY_SAVE'


### PR DESCRIPTION
Follow-up. Delete tree directly.