### PR TITLE
html event abstraction, phase 2 (action utils usage unification)

### DIFF
--- a/src/ui/db/zcl_abapgit_gui_page_db_edit.clas.abap
+++ b/src/ui/db/zcl_abapgit_gui_page_db_edit.clas.abap
@@ -52,18 +52,24 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_DB_EDIT IMPLEMENTATION.
 
   METHOD dbcontent_decode.
 
-    DATA: lt_fields TYPE tihttpnvp,
-          lv_string TYPE string.
+    DATA lt_fields TYPE tihttpnvp.
 
+    lt_fields = zcl_abapgit_html_action_utils=>parse_post_form_data(
+      it_post_data = it_postdata
+      iv_upper_cased = abap_true ).
 
-    lv_string = zcl_abapgit_utils=>translate_postdata( it_postdata ).
-
-    lv_string = cl_http_utility=>unescape_url( lv_string ).
-
-    rs_content = zcl_abapgit_html_action_utils=>dbkey_decode( lv_string ).
-
-    lt_fields = zcl_abapgit_html_action_utils=>parse_fields_upper_case_name( lv_string ).
-
+    zcl_abapgit_html_action_utils=>get_field(
+      EXPORTING
+        iv_name = 'TYPE'
+        it_field = lt_fields
+      CHANGING
+        cg_field = rs_content-type ).
+    zcl_abapgit_html_action_utils=>get_field(
+      EXPORTING
+        iv_name = 'VALUE'
+        it_field = lt_fields
+      CHANGING
+        cg_field = rs_content-value ).
     zcl_abapgit_html_action_utils=>get_field(
       EXPORTING
         iv_name = 'XMLDATA'

--- a/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_addonline.clas.abap
@@ -93,7 +93,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_ADDONLINE IMPLEMENTATION.
     DATA lt_form TYPE tihttpnvp.
     DATA ls_field LIKE LINE OF lt_form.
 
-    lt_form = zcl_abapgit_html_action_utils=>parse_post_data( it_post_data ).
+    lt_form = zcl_abapgit_html_action_utils=>parse_post_form_data( it_post_data ).
     CREATE OBJECT ro_form_data.
 
     LOOP AT lt_form INTO ls_field.

--- a/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_boverview.clas.abap
@@ -245,15 +245,11 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_BOVERVIEW IMPLEMENTATION.
 
   METHOD decode_merge.
 
-    DATA: lv_string TYPE string,
-          lt_fields TYPE tihttpnvp.
-
+    DATA lt_fields TYPE tihttpnvp.
     FIELD-SYMBOLS: <ls_field> LIKE LINE OF lt_fields.
 
 
-    lv_string = zcl_abapgit_utils=>translate_postdata( it_postdata ).
-
-    lt_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_string ).
+    lt_fields = zcl_abapgit_html_action_utils=>parse_post_form_data( it_postdata ).
 
     READ TABLE lt_fields ASSIGNING <ls_field> WITH KEY name = 'source'.
     ASSERT sy-subrc = 0.

--- a/src/ui/zcl_abapgit_gui_page_commit.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_commit.clas.abap
@@ -177,19 +177,15 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
 
   METHOD parse_commit_request.
 
-    CONSTANTS: lc_replace TYPE string VALUE '<<new>>'.
-
-    DATA: lv_string TYPE string,
-          lt_fields TYPE tihttpnvp.
+    DATA lt_fields TYPE tihttpnvp.
 
     FIELD-SYMBOLS <lv_body> TYPE string.
 
     CLEAR eg_fields.
 
-    CONCATENATE LINES OF it_postdata INTO lv_string.
-    REPLACE ALL OCCURRENCES OF zif_abapgit_definitions=>c_crlf    IN lv_string WITH lc_replace.
-    REPLACE ALL OCCURRENCES OF zif_abapgit_definitions=>c_newline IN lv_string WITH lc_replace.
-    lt_fields = zcl_abapgit_html_action_utils=>parse_fields_upper_case_name( lv_string ).
+    lt_fields = zcl_abapgit_html_action_utils=>parse_post_form_data(
+      it_post_data = it_postdata
+      iv_upper_cased = abap_true ).
 
     zcl_abapgit_html_action_utils=>get_field(
       EXPORTING
@@ -230,7 +226,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_COMMIT IMPLEMENTATION.
 
     ASSIGN COMPONENT 'BODY' OF STRUCTURE eg_fields TO <lv_body>.
     ASSERT <lv_body> IS ASSIGNED.
-    REPLACE ALL OCCURRENCES OF lc_replace IN <lv_body> WITH zif_abapgit_definitions=>c_newline.
+    REPLACE ALL OCCURRENCES OF zif_abapgit_definitions=>c_crlf IN <lv_body> WITH zif_abapgit_definitions=>c_newline.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_merge_res.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_merge_res.clas.abap
@@ -112,37 +112,36 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MERGE_RES IMPLEMENTATION.
 
   METHOD apply_merged_content.
 
-    CONSTANTS: lc_replace TYPE string VALUE '<<new>>'.
+    DATA:
+      BEGIN OF ls_filedata,
+        merge_content TYPE string,
+      END OF ls_filedata,
+      lt_fields           TYPE tihttpnvp,
+      lv_new_file_content TYPE xstring.
 
-    DATA: BEGIN OF ls_filedata,
-            merge_content TYPE string,
-          END OF ls_filedata.
+    FIELD-SYMBOLS:
+      <ls_conflict>      TYPE zif_abapgit_definitions=>ty_merge_conflict.
 
-    DATA: lv_string           TYPE string,
-          lt_fields           TYPE tihttpnvp,
-          lv_new_file_content TYPE xstring.
+    lt_fields = zcl_abapgit_html_action_utils=>parse_post_form_data(
+      it_post_data = it_postdata
+      iv_upper_cased = abap_true ).
 
-    FIELD-SYMBOLS: <lv_postdata_line> LIKE LINE OF it_postdata,
-                   <ls_conflict>      TYPE zif_abapgit_definitions=>ty_merge_conflict.
+    zcl_abapgit_html_action_utils=>get_field(
+      EXPORTING
+        iv_name = 'MERGE_CONTENT'
+        it_field = lt_fields
+      CHANGING
+        cg_field = ls_filedata ).
 
-    LOOP AT it_postdata ASSIGNING <lv_postdata_line>.
-      lv_string = |{ lv_string }{ <lv_postdata_line> }|.
-    ENDLOOP.
-    REPLACE ALL OCCURRENCES OF zif_abapgit_definitions=>c_crlf    IN lv_string WITH lc_replace.
-    REPLACE ALL OCCURRENCES OF zif_abapgit_definitions=>c_newline IN lv_string WITH lc_replace.
-
-    lt_fields = zcl_abapgit_html_action_utils=>parse_fields_upper_case_name( lv_string ).
-    zcl_abapgit_html_action_utils=>get_field( EXPORTING iv_name = 'MERGE_CONTENT'
-                                                        it_field = lt_fields
-                                              CHANGING cg_field = ls_filedata ).
-    ls_filedata-merge_content = cl_http_utility=>unescape_url( escaped = ls_filedata-merge_content ).
-    REPLACE ALL OCCURRENCES OF lc_replace IN ls_filedata-merge_content WITH zif_abapgit_definitions=>c_newline.
+    REPLACE ALL OCCURRENCES
+      OF zif_abapgit_definitions=>c_crlf IN ls_filedata-merge_content WITH zif_abapgit_definitions=>c_newline.
 
     lv_new_file_content = zcl_abapgit_convert=>string_to_xstring_utf8( ls_filedata-merge_content ).
 
     READ TABLE mt_conflicts ASSIGNING <ls_conflict> INDEX mv_current_conflict_index.
-    <ls_conflict>-result_sha1 = zcl_abapgit_hash=>sha1( iv_type = zif_abapgit_definitions=>c_type-blob
-                                                        iv_data = lv_new_file_content ).
+    <ls_conflict>-result_sha1 = zcl_abapgit_hash=>sha1(
+      iv_type = zif_abapgit_definitions=>c_type-blob
+      iv_data = lv_new_file_content ).
     <ls_conflict>-result_data = lv_new_file_content.
     mo_merge->resolve_conflict( <ls_conflict> ).
 

--- a/src/ui/zcl_abapgit_gui_page_patch.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_patch.clas.abap
@@ -318,13 +318,12 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_PATCH IMPLEMENTATION.
 
   METHOD apply_patch_from_form_fields.
 
-    DATA: lv_string TYPE string,
-          lt_fields TYPE tihttpnvp,
-          lv_add    TYPE string,
-          lv_remove TYPE string.
+    DATA:
+      lt_fields TYPE tihttpnvp,
+      lv_add    TYPE string,
+      lv_remove TYPE string.
 
-    lv_string = zcl_abapgit_utils=>translate_postdata( it_postdata ).
-    lt_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_string ).
+    lt_fields = zcl_abapgit_html_action_utils=>parse_post_form_data( it_postdata ).
 
     zcl_abapgit_html_action_utils=>get_field( EXPORTING iv_name  = c_patch_action-add
                                                         it_field = lt_fields

--- a/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_repo_sett.clas.abap
@@ -54,11 +54,6 @@ CLASS zcl_abapgit_gui_page_repo_sett DEFINITION
         !it_post_fields TYPE tihttpnvp
       RAISING
         zcx_abapgit_exception .
-    METHODS parse_post
-      IMPORTING
-        !it_postdata          TYPE cnht_post_data_tab
-      RETURNING
-        VALUE(rt_post_fields) TYPE tihttpnvp .
     METHODS render_dot_abapgit_reqs
       IMPORTING
         ii_html         TYPE REF TO zif_abapgit_html
@@ -87,16 +82,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
     super->constructor( ).
     ms_control-page_title = 'Repository Settings'.
     mo_repo = io_repo.
-  ENDMETHOD.
-
-
-  METHOD parse_post.
-
-    DATA lv_serialized_post_data TYPE string.
-
-    lv_serialized_post_data = zcl_abapgit_utils=>translate_postdata( it_postdata ).
-    rt_post_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_serialized_post_data ).
-
   ENDMETHOD.
 
 
@@ -352,7 +337,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_REPO_SETT IMPLEMENTATION.
     DATA: lt_post_fields TYPE tihttpnvp,
           lv_msg         TYPE string.
 
-    lt_post_fields = parse_post( it_postdata ).
+    lt_post_fields = zcl_abapgit_html_action_utils=>parse_post_form_data( it_postdata ).
 
     save_dot_abap( lt_post_fields ).
     save_remotes( lt_post_fields ).

--- a/src/ui/zcl_abapgit_gui_page_settings.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_settings.clas.abap
@@ -61,11 +61,6 @@ CLASS zcl_abapgit_gui_page_settings DEFINITION
       IMPORTING
         !it_post_fields TYPE tihttpnvp .
     METHODS validate_settings .
-    METHODS parse_post
-      IMPORTING
-        !it_postdata          TYPE cnht_post_data_tab
-      RETURNING
-        VALUE(rt_post_fields) TYPE tihttpnvp .
     METHODS persist_settings
       RAISING
         zcx_abapgit_exception .
@@ -121,16 +116,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETTINGS IMPLEMENTATION.
         OR <ls_post_field>-value = 'on' ).     "HTML value when using Netweaver Java GUI
       rv_return = abap_true.
     ENDIF.
-  ENDMETHOD.
-
-
-  METHOD parse_post.
-
-    DATA lv_serialized_post_data TYPE string.
-
-    lv_serialized_post_data = zcl_abapgit_utils=>translate_postdata( it_postdata ).
-    rt_post_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_serialized_post_data ).
-
   ENDMETHOD.
 
 
@@ -719,7 +704,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETTINGS IMPLEMENTATION.
 
     CASE ii_event->mv_action.
       WHEN c_action-save_settings.
-        lt_post_fields = parse_post( ii_event->mt_postdata ).
+        lt_post_fields = zcl_abapgit_html_action_utils=>parse_post_form_data( ii_event->mt_postdata ).
 
         post( lt_post_fields ).
         validate_settings( ).

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -587,16 +587,16 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
   METHOD stage_selected.
 
-    DATA: lv_string TYPE string,
-          lt_fields TYPE tihttpnvp,
-          ls_file   TYPE zif_abapgit_definitions=>ty_file.
+    DATA:
+      lt_fields TYPE tihttpnvp,
+      ls_file   TYPE zif_abapgit_definitions=>ty_file.
 
-    FIELD-SYMBOLS: <ls_file>   LIKE LINE OF ms_files-local,
-                   <ls_status> LIKE LINE OF ms_files-status,
-                   <ls_item>   LIKE LINE OF lt_fields.
+    FIELD-SYMBOLS:
+      <ls_file>   LIKE LINE OF ms_files-local,
+      <ls_status> LIKE LINE OF ms_files-status,
+      <ls_item>   LIKE LINE OF lt_fields.
 
-    lv_string = zcl_abapgit_utils=>translate_postdata( it_postdata ).
-    lt_fields = zcl_abapgit_html_action_utils=>parse_fields( lv_string ).
+    lt_fields = zcl_abapgit_html_action_utils=>parse_post_form_data( it_postdata ).
 
     IF lines( lt_fields ) = 0.
       zcx_abapgit_exception=>raise( 'process_stage_list: empty list' ).
@@ -687,7 +687,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
 
       WHEN c_action-stage_filter.
 
-        lt_fields = zcl_abapgit_html_action_utils=>parse_fields( concat_lines_of( table = ii_event->mt_postdata ) ).
+        lt_fields = zcl_abapgit_html_action_utils=>parse_post_form_data( ii_event->mt_postdata ).
 
         zcl_abapgit_html_action_utils=>get_field(
           EXPORTING

--- a/src/ui/zcl_abapgit_gui_page_tag.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_tag.clas.abap
@@ -153,19 +153,15 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_TAG IMPLEMENTATION.
 
   METHOD parse_tag_request.
 
-    CONSTANTS: lc_replace TYPE string VALUE '<<new>>'.
-
-    DATA: lv_string TYPE string,
-          lt_fields TYPE tihttpnvp.
+    DATA lt_fields TYPE tihttpnvp.
 
     FIELD-SYMBOLS <lv_body> TYPE string.
 
     CLEAR eg_fields.
 
-    lv_string = zcl_abapgit_utils=>translate_postdata( it_postdata ).
-    REPLACE ALL OCCURRENCES OF zif_abapgit_definitions=>c_crlf    IN lv_string WITH lc_replace.
-    REPLACE ALL OCCURRENCES OF zif_abapgit_definitions=>c_newline IN lv_string WITH lc_replace.
-    lt_fields = zcl_abapgit_html_action_utils=>parse_fields_upper_case_name( lv_string ).
+    lt_fields = zcl_abapgit_html_action_utils=>parse_post_form_data(
+      it_post_data = it_postdata
+      iv_upper_cased = abap_true ).
 
     zcl_abapgit_html_action_utils=>get_field( EXPORTING iv_name = 'SHA1'
                                                         it_field = lt_fields
@@ -188,7 +184,7 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_TAG IMPLEMENTATION.
 
     ASSIGN COMPONENT 'BODY' OF STRUCTURE eg_fields TO <lv_body>.
     ASSERT <lv_body> IS ASSIGNED.
-    REPLACE ALL OCCURRENCES OF lc_replace IN <lv_body> WITH zif_abapgit_definitions=>c_newline.
+    REPLACE ALL OCCURRENCES OF zif_abapgit_definitions=>c_crlf IN <lv_body> WITH zif_abapgit_definitions=>c_newline.
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_html_action_utils.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_html_action_utils.clas.testclasses.abap
@@ -279,7 +279,9 @@ CLASS ltcl_html_action_utils IMPLEMENTATION.
     DATA lv_size TYPE i.
 
     DESCRIBE FIELD lv_line LENGTH lv_size IN CHARACTER MODE.
-    lv_long_name = repeat( val = 'x' occ = lv_size - 4 ).
+    lv_long_name = repeat(
+      val = 'x'
+      occ = lv_size - 4 ).
     lv_line = 'a=b&' && lv_long_name.
 
     APPEND lv_line TO lt_post_data.

--- a/src/ui/zcl_abapgit_html_action_utils.clas.testclasses.abap
+++ b/src/ui/zcl_abapgit_html_action_utils.clas.testclasses.abap
@@ -9,6 +9,8 @@ CLASS ltcl_html_action_utils DEFINITION FOR TESTING RISK LEVEL HARMLESS
     METHODS parse_fields_advanced_case FOR TESTING.
     METHODS parse_fields_unescape FOR TESTING.
     METHODS parse_fields_german_umlauts FOR TESTING.
+    METHODS parse_fields_wrong_format FOR TESTING.
+    METHODS parse_post_form_data FOR TESTING.
 
   PRIVATE SECTION.
 
@@ -36,6 +38,9 @@ CLASS ltcl_html_action_utils DEFINITION FOR TESTING RISK LEVEL HARMLESS
         iv_index TYPE i
         iv_name  TYPE string
         iv_value TYPE string.
+    METHODS _then_field_count_should_be
+      IMPORTING
+        iv_count TYPE i.
 
     CLASS-METHODS _hex_to_char
       IMPORTING
@@ -65,12 +70,18 @@ CLASS ltcl_html_action_utils IMPLEMENTATION.
     ls_answer-value = 'TEST'.
     APPEND ls_answer TO lt_fields.
 
-    zcl_abapgit_html_action_utils=>get_field( EXPORTING iv_name = 'NAME'
-                                                        it_field = lt_fields
-                                      CHANGING  cg_field   = ls_field-value ).
-    zcl_abapgit_html_action_utils=>get_field( EXPORTING iv_name = 'NAME'
-                                                        it_field = lt_fields
-                                      CHANGING  cg_field   = ls_field ).
+    zcl_abapgit_html_action_utils=>get_field(
+      EXPORTING
+        iv_name = 'NAME'
+        it_field = lt_fields
+      CHANGING
+        cg_field   = ls_field-value ).
+    zcl_abapgit_html_action_utils=>get_field(
+      EXPORTING
+        iv_name = 'NAME'
+        it_field = lt_fields
+      CHANGING
+        cg_field   = ls_field ).
 
     ls_answer-name  = 'TEST'.
     ls_answer-value = 'TEST'.
@@ -208,19 +219,30 @@ CLASS ltcl_html_action_utils IMPLEMENTATION.
 
     FIELD-SYMBOLS: <ls_parsed_field> LIKE LINE OF mt_parsed_fields.
 
-    READ TABLE mt_parsed_fields ASSIGNING <ls_parsed_field>
-                                INDEX iv_index.
+    READ TABLE mt_parsed_fields ASSIGNING <ls_parsed_field> INDEX iv_index.
 
-    cl_abap_unit_assert=>assert_subrc( exp = 0
-                                       msg = |No parsed field found at index { iv_index }| ).
+    cl_abap_unit_assert=>assert_subrc(
+      exp = 0
+      msg = |No parsed field found at index { iv_index }| ).
 
-    cl_abap_unit_assert=>assert_equals( act = <ls_parsed_field>-name
-                                        exp = iv_name
-                                        msg = |Name at index { iv_index } should be { iv_name }| ).
+    cl_abap_unit_assert=>assert_equals(
+      act = <ls_parsed_field>-name
+      exp = iv_name
+      msg = |Name at index { iv_index } should be { iv_name }| ).
 
-    cl_abap_unit_assert=>assert_equals( act = <ls_parsed_field>-value
-                                        exp = iv_value
-                                        msg = |Value at index { iv_index } should be { iv_value }| ).
+    cl_abap_unit_assert=>assert_equals(
+      act = <ls_parsed_field>-value
+      exp = iv_value
+      msg = |Value at index { iv_index } should be { iv_value }| ).
+
+  ENDMETHOD.
+
+  METHOD _then_field_count_should_be.
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lines( mt_parsed_fields )
+      exp = iv_count
+      msg = |Field count { lines( mt_parsed_fields ) } should be { iv_count }| ).
 
   ENDMETHOD.
 
@@ -230,6 +252,62 @@ CLASS ltcl_html_action_utils IMPLEMENTATION.
 
     lo_conv = cl_abap_conv_in_ce=>create( ).
     lo_conv->convert( EXPORTING input = iv_x IMPORTING data = rv_s ).
+
+  ENDMETHOD.
+
+  METHOD parse_fields_wrong_format.
+
+    _given_string_is( `some_query_string_without_param_structure` ).
+    _when_fields_are_parsed( ).
+    _then_field_count_should_be( 0 ).
+
+    _given_string_is( `some_query_string_without_param_structure&a=b` ).
+    _when_fields_are_parsed( ).
+    _then_field_count_should_be( 1 ).
+    _then_fields_should_be(
+      iv_index = 1
+      iv_name  = 'A'
+      iv_value = 'b' ).
+
+  ENDMETHOD.
+
+  METHOD parse_post_form_data.
+
+    DATA lt_post_data TYPE cnht_post_data_tab.
+    DATA lv_line LIKE LINE OF lt_post_data.
+    DATA lv_long_name LIKE LINE OF lt_post_data.
+    DATA lv_size TYPE i.
+
+    DESCRIBE FIELD lv_line LENGTH lv_size IN CHARACTER MODE.
+    lv_long_name = repeat( val = 'x' occ = lv_size - 4 ).
+    lv_line = 'a=b&' && lv_long_name.
+
+    APPEND lv_line TO lt_post_data.
+    APPEND '=y' TO lt_post_data.
+
+    mt_parsed_fields = zcl_abapgit_html_action_utils=>parse_post_form_data( lt_post_data ).
+    _then_field_count_should_be( 2 ).
+    _then_fields_should_be(
+      iv_index = 1
+      iv_name  = 'a'
+      iv_value = 'b' ).
+    _then_fields_should_be(
+      iv_index = 2
+      iv_name  = |{ lv_long_name }|
+      iv_value = 'y' ).
+
+    mt_parsed_fields = zcl_abapgit_html_action_utils=>parse_post_form_data(
+      it_post_data = lt_post_data
+      iv_upper_cased = abap_true ).
+    _then_field_count_should_be( 2 ).
+    _then_fields_should_be(
+      iv_index = 1
+      iv_name  = 'A'
+      iv_value = 'b' ).
+    _then_fields_should_be(
+      iv_index = 2
+      iv_name  = |{ to_upper( lv_long_name ) }|
+      iv_value = 'y' ).
 
   ENDMETHOD.
 

--- a/src/utils/zcl_abapgit_utils.clas.abap
+++ b/src/utils/zcl_abapgit_utils.clas.abap
@@ -19,18 +19,29 @@ CLASS zcl_abapgit_utils DEFINITION
         !ev_time    TYPE zif_abapgit_definitions=>ty_commit-time
       RAISING
         zcx_abapgit_exception .
-    CLASS-METHODS translate_postdata
-      IMPORTING
-        !it_postdata TYPE cnht_post_data_tab
-      RETURNING
-        VALUE(rv_string) TYPE string .
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS zcl_abapgit_utils IMPLEMENTATION.
+CLASS ZCL_ABAPGIT_UTILS IMPLEMENTATION.
+
+
+  METHOD extract_author_data.
+
+    " unix time stamps are in same time zone, so ignore the zone
+    FIND REGEX zif_abapgit_definitions=>c_author_regex IN iv_author
+      SUBMATCHES
+      ev_author
+      ev_email
+      ev_time.
+
+    IF sy-subrc <> 0.
+      zcx_abapgit_exception=>raise( |Error author regex value='{ iv_author }'| ).
+    ENDIF.
+
+  ENDMETHOD.
 
 
   METHOD is_binary.
@@ -59,50 +70,6 @@ CLASS zcl_abapgit_utils IMPLEMENTATION.
         EXIT.
       ENDIF.
     ENDDO.
-
-  ENDMETHOD.
-
-
-  METHOD extract_author_data.
-
-    " unix time stamps are in same time zone, so ignore the zone
-    FIND REGEX zif_abapgit_definitions=>c_author_regex IN iv_author
-      SUBMATCHES
-      ev_author
-      ev_email
-      ev_time.
-
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( |Error author regex value='{ iv_author }'| ).
-    ENDIF.
-
-  ENDMETHOD.
-
-
-  METHOD translate_postdata.
-
-    DATA: lt_post_data       TYPE cnht_post_data_tab,
-          ls_last_line       TYPE cnht_post_data_line,
-          lv_last_line_index TYPE i.
-
-    IF it_postdata IS INITIAL.
-      "Nothing to do
-      RETURN.
-    ENDIF.
-
-    lt_post_data = it_postdata.
-
-    "Save the last line for separate merge, because we don't need its trailing spaces
-    WHILE ls_last_line IS INITIAL.
-      lv_last_line_index = lines( lt_post_data ).
-      READ TABLE lt_post_data INTO ls_last_line INDEX lv_last_line_index.
-      DELETE lt_post_data INDEX lv_last_line_index.
-    ENDWHILE.
-
-    CONCATENATE LINES OF lt_post_data INTO rv_string
-      IN CHARACTER MODE RESPECTING BLANKS.
-    CONCATENATE rv_string ls_last_line INTO rv_string
-      IN CHARACTER MODE.
 
   ENDMETHOD.
 ENDCLASS.


### PR DESCRIPTION
to: #3602
... appears to be more phases than I expected ...

So this is more a cleanup PR for the action utils
1) `translate_postdata` moved to `zcl_abapgit_html_action_utils` (commit 1)
2) minor tweaks and addtional UTs in `zcl_abapgit_html_action_utils` (commit 1)
3) the rest is refactoring of pages to use action utils more uniformely (mainly `parse_post_form_data`) - this required some logic changes - I didn't test all really thoroughly but stage, commit (including multiline comment), dbedit, settings work

Next steps (**Question**): I initially was thinking to remove action utils at all. So to merge it completely with event class. But now I think it should stay. event class will reuse action utils internally and provide nice wrappers to reuse in the handlers code (_probably 100% of them I see now will use event_). But parsing logic is an utility ! So might be useful to keep it _public_ for some special cases or quick prototypes in future. Any opinions on this ?

Besides action utils contain a lot of typical patterns (`*_decode`) which may need more time to refactor
