### PR TITLE
html_form chaining

### DIFF
--- a/src/ui/zcl_abapgit_html_form.clas.abap
+++ b/src/ui/zcl_abapgit_html_form.clas.abap
@@ -24,7 +24,9 @@ CLASS zcl_abapgit_html_form DEFINITION
         iv_label   TYPE string
         iv_action  TYPE string
         iv_is_main TYPE abap_bool DEFAULT abap_false
-        iv_as_a    TYPE abap_bool DEFAULT abap_false.
+        iv_as_a    TYPE abap_bool DEFAULT abap_false
+      RETURNING
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
 
     METHODS text
       IMPORTING
@@ -34,31 +36,41 @@ CLASS zcl_abapgit_html_form DEFINITION
         iv_required    TYPE abap_bool DEFAULT abap_false
         iv_upper_case  TYPE abap_bool DEFAULT abap_false
         iv_placeholder TYPE string OPTIONAL
-        iv_side_action TYPE string OPTIONAL.
+        iv_side_action TYPE string OPTIONAL
+      RETURNING
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
 
     METHODS checkbox
       IMPORTING
         iv_label TYPE string
         iv_name  TYPE string
-        iv_hint  TYPE string OPTIONAL.
+        iv_hint  TYPE string OPTIONAL
+      RETURNING
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
 
     METHODS radio
       IMPORTING
         iv_label         TYPE string
         iv_name          TYPE string
         iv_default_value TYPE string OPTIONAL
-        iv_hint          TYPE string OPTIONAL.
+        iv_hint          TYPE string OPTIONAL
+      RETURNING
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
 
     METHODS option
       IMPORTING
         iv_label TYPE string
-        iv_value TYPE string.
+        iv_value TYPE string
+      RETURNING
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
 
     METHODS start_group
       IMPORTING
         iv_label TYPE string
         iv_name  TYPE string
-        iv_hint  TYPE string OPTIONAL.
+        iv_hint  TYPE string OPTIONAL
+      RETURNING
+        VALUE(ro_self) TYPE REF TO zcl_abapgit_html_form.
 
     METHODS validate_normalize_form_data
       IMPORTING
@@ -149,6 +161,8 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
 
     APPEND ls_field TO mt_fields.
 
+    ro_self = me.
+
   ENDMETHOD.
 
 
@@ -164,6 +178,8 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
     ls_cmd-as_a = iv_as_a.
 
     APPEND ls_cmd TO mt_commands.
+
+    ro_self = me.
 
   ENDMETHOD.
 
@@ -201,6 +217,8 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
 
     APPEND ls_option TO <ls_last>-subitems.
 
+    ro_self = me.
+
   ENDMETHOD.
 
 
@@ -218,6 +236,8 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
     ENDIF.
 
     APPEND ls_field TO mt_fields.
+
+    ro_self = me.
 
   ENDMETHOD.
 
@@ -409,6 +429,8 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
 
     APPEND ls_field TO mt_fields.
 
+    ro_self = me.
+
   ENDMETHOD.
 
 
@@ -443,6 +465,8 @@ CLASS ZCL_ABAPGIT_HTML_FORM IMPLEMENTATION.
     ENDIF.
 
     APPEND ls_field TO mt_fields.
+
+    ro_self = me.
 
   ENDMETHOD.
 


### PR DESCRIPTION
> Let's add return self to `text`, `checkbox`, etc for `zcl_abapgit_html_form` so we can chain the definition (like html_toolbar->add, https://github.com/larshp/abapGit/blob/master/src/ui/zcl_abapgit_gui_page_view_repo.clas.abap#L424).

by @mbtools #3904
