### PR TITLE
Show repo list button in tutorial

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_tutorial.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_tutorial.clas.abap
@@ -33,6 +33,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_TUTORIAL IMPLEMENTATION.
     CREATE OBJECT ro_menu EXPORTING iv_id = 'toolbar-main'.
 
     ro_menu->add(
+      iv_txt = zcl_abapgit_gui_buttons=>repo_list( )
+      iv_act = zif_abapgit_definitions=>c_action-abapgit_home
+    )->add(
       iv_txt = zcl_abapgit_gui_buttons=>new_online( )
       iv_act = zif_abapgit_definitions=>c_action-repo_newonline
     )->add(


### PR DESCRIPTION
Currently the button is only visible in the tutorial text while the others (new offline, new online) are also included in the main menu.