### PR TITLE
Split up global settings button and utility menu

### DIFF
--- a/src/ui/zcl_abapgit_gui_buttons.clas.abap
+++ b/src/ui/zcl_abapgit_gui_buttons.clas.abap
@@ -19,6 +19,9 @@ CLASS zcl_abapgit_gui_buttons DEFINITION
     CLASS-METHODS repo_list
       RETURNING VALUE(rv_html_string) TYPE string.
 
+    CLASS-METHODS settings
+      RETURNING VALUE(rv_html_string) TYPE string.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
@@ -45,6 +48,10 @@ CLASS zcl_abapgit_gui_buttons IMPLEMENTATION.
 
   METHOD repo_list.
     rv_html_string = `<i class="icon icon-bars"></i> Repository List`.
+  ENDMETHOD.
+
+  METHOD settings.
+    rv_html_string = `<i class="icon icon-cog"></i> Settings`.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
+++ b/src/ui/zcl_abapgit_gui_chunk_lib.clas.abap
@@ -177,10 +177,7 @@ CLASS ZCL_ABAPGIT_GUI_CHUNK_LIB IMPLEMENTATION.
       iv_act = zif_abapgit_definitions=>c_action-go_debuginfo
     )->add(
       iv_txt = 'Performance Test'
-      iv_act = zif_abapgit_definitions=>c_action-performance_test
-    )->add(
-      iv_txt = 'Settings'
-      iv_act = zif_abapgit_definitions=>c_action-go_settings ).
+      iv_act = zif_abapgit_definitions=>c_action-performance_test ).
 
   ENDMETHOD.
 

--- a/src/ui/zcl_abapgit_gui_page_main.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_main.clas.abap
@@ -54,10 +54,13 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_MAIN IMPLEMENTATION.
       iv_txt = zcl_abapgit_gui_buttons=>new_offline( )
       iv_act = zif_abapgit_definitions=>c_action-repo_newoffline
     )->add(
-      iv_txt = '<i class="icon icon-tools-solid"></i>'
+      iv_txt = zcl_abapgit_gui_buttons=>settings( )
+      iv_act = zif_abapgit_definitions=>c_action-go_settings
+    )->add(
+      iv_txt = zcl_abapgit_gui_buttons=>advanced( )
       io_sub = zcl_abapgit_gui_chunk_lib=>advanced_submenu( )
     )->add(
-      iv_txt = '<i class="icon icon-question-circle-solid"></i>'
+      iv_txt = zcl_abapgit_gui_buttons=>help( )
       io_sub = zcl_abapgit_gui_chunk_lib=>help_submenu( ) ).
 
   ENDMETHOD.

--- a/src/ui/zcl_abapgit_gui_page_tutorial.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_tutorial.clas.abap
@@ -42,6 +42,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_TUTORIAL IMPLEMENTATION.
       iv_txt = zcl_abapgit_gui_buttons=>new_offline( )
       iv_act = zif_abapgit_definitions=>c_action-repo_newoffline
     )->add(
+      iv_txt = zcl_abapgit_gui_buttons=>settings( )
+      iv_act = zif_abapgit_definitions=>c_action-go_settings
+    )->add(
       iv_txt = zcl_abapgit_gui_buttons=>advanced( )
       io_sub = zcl_abapgit_gui_chunk_lib=>advanced_submenu( )
     )->add(

--- a/src/ui/zcl_abapgit_gui_page_view_repo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_view_repo.clas.abap
@@ -1232,6 +1232,14 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_VIEW_REPO IMPLEMENTATION.
   METHOD zif_abapgit_gui_hotkeys~get_hotkey_actions.
 
     DATA: ls_hotkey_action LIKE LINE OF rt_hotkey_actions.
+
+    ls_hotkey_action-ui_component = 'Main'.
+
+    ls_hotkey_action-description   = |abapGit settings|.
+    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-go_settings.
+    ls_hotkey_action-hotkey = |x|.
+    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
+
     ls_hotkey_action-ui_component = 'Repo'.
 
     ls_hotkey_action-description   = |Stage changes|.

--- a/src/ui/zcl_abapgit_gui_page_view_repo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_view_repo.clas.abap
@@ -425,6 +425,9 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_VIEW_REPO IMPLEMENTATION.
       iv_txt = zcl_abapgit_gui_buttons=>repo_list( )
       iv_act = zif_abapgit_definitions=>c_action-abapgit_home
     )->add(
+      iv_txt = zcl_abapgit_gui_buttons=>settings( )
+      iv_act = zif_abapgit_definitions=>c_action-go_settings
+    )->add(
       iv_txt = zcl_abapgit_gui_buttons=>advanced( )
       io_sub = zcl_abapgit_gui_chunk_lib=>advanced_submenu( )
     )->add(

--- a/src/ui/zcl_abapgit_gui_page_view_repo.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_view_repo.clas.abap
@@ -1232,14 +1232,6 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_VIEW_REPO IMPLEMENTATION.
   METHOD zif_abapgit_gui_hotkeys~get_hotkey_actions.
 
     DATA: ls_hotkey_action LIKE LINE OF rt_hotkey_actions.
-
-    ls_hotkey_action-ui_component = 'Main'.
-
-    ls_hotkey_action-description   = |abapGit settings|.
-    ls_hotkey_action-action = zif_abapgit_definitions=>c_action-go_settings.
-    ls_hotkey_action-hotkey = |x|.
-    INSERT ls_hotkey_action INTO TABLE rt_hotkey_actions.
-
     ls_hotkey_action-ui_component = 'Repo'.
 
     ls_hotkey_action-description   = |Stage changes|.


### PR DESCRIPTION
To me it feels like the settings button does not belong into the menu since it is a "user facing" functionality while the other stuff in the utility menu is more for development on abapGit itself or less commonly used utility functions. Open to opinions though, maybe I am alone in that assumption.

![image](https://user-images.githubusercontent.com/5270359/93749292-f7244800-fbf9-11ea-9d45-6eda8fd105f3.png)

Addresses #3770 with the least amount of effort possible :)