### PR TITLE
Add option to synchronize theme with frontend

### DIFF
--- a/src/ui/zcl_abapgit_gui_page_settings.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_settings.clas.abap
@@ -652,18 +652,21 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETTINGS IMPLEMENTATION.
 
     DATA:
       BEGIN OF ls_sel,
-        default TYPE string,
-        dark    TYPE string,
-        belize  TYPE string,
+        default         TYPE string,
+        dark            TYPE string,
+        belize          TYPE string,
+        synced_with_gui TYPE string,
       END OF ls_sel.
 
-    CASE mo_settings->get_ui_theme( ).
+    CASE mo_settings->get_ui_theme( abap_false ).
       WHEN zcl_abapgit_settings=>c_ui_theme-default.
         ls_sel-default = ' selected'.
       WHEN zcl_abapgit_settings=>c_ui_theme-dark.
         ls_sel-dark = ' selected'.
       WHEN zcl_abapgit_settings=>c_ui_theme-belize.
         ls_sel-belize = ' selected'.
+      WHEN zcl_abapgit_settings=>c_ui_theme-synced_with_gui.
+        ls_sel-synced_with_gui = ' selected'.
     ENDCASE.
 
     CREATE OBJECT ri_html TYPE zcl_abapgit_html.
@@ -671,13 +674,15 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_SETTINGS IMPLEMENTATION.
     ri_html->add( |<h2>UI Theme</h2>| ).
     ri_html->add( |<label for="ui_theme">UI Theme</label>| ).
     ri_html->add( |<br>| ).
-    ri_html->add( |<select name="ui_theme" size="3">| ).
+    ri_html->add( |<select name="ui_theme" size="4">| ).
     ri_html->add( |<option value="{ zcl_abapgit_settings=>c_ui_theme-default }"{
       ls_sel-default }>{ zcl_abapgit_settings=>c_ui_theme-default }</option>| ).
     ri_html->add( |<option value="{ zcl_abapgit_settings=>c_ui_theme-dark }"{
       ls_sel-dark }>{ zcl_abapgit_settings=>c_ui_theme-dark }</option>| ).
     ri_html->add( |<option value="{ zcl_abapgit_settings=>c_ui_theme-belize }"{
       ls_sel-belize }>{ zcl_abapgit_settings=>c_ui_theme-belize }</option>| ).
+    ri_html->add( |<option value="{ zcl_abapgit_settings=>c_ui_theme-synced_with_gui }"{
+      ls_sel-synced_with_gui }>Synced with SAP GUI</option>| ).
     ri_html->add( |</select>| ).
 
     ri_html->add( |<br>| ).


### PR DESCRIPTION
I'll add the two new Quartz themes when the new 7.70 beta version is available. It makes more sense then to have the option to sync the abapGit theme selection with the SAP GUI theme selection. Could also maybe set it as the default then.

Note you need to re-logon to the system after a frontend theme change for get_themename to report the new one (even if you force refresh the cache).